### PR TITLE
Build v0.29 member workbench

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -444,12 +444,12 @@ _Avoid_: AgentRun, form-submit preflight, message-send preflight, synchronous pa
 A legacy durable request created by older versions while a message waited for Runtime Resolution. Ordinary sends no longer create it; upgrade recovery may dispatch its message and queued AgentRun through the current message-first path and then retire it as consumed.
 _Avoid_: current message-send state, Renderer draft, CampMessage, queued AgentRun
 
-**Execution Engine (product term)**:
-The product-facing name for a Member's Product Runtime Selection. The Member settings section is titled `Agent运行时`; its selectable engine field, ordinary status, empty states, Toasts, and user guidance say `执行引擎`. Runtime, Adapter, and AdapterInstallation remain implementation and protocol vocabulary, and specific products such as Codex CLI keep their names.
-_Avoid_: displaying Adapter Installation, Agent Runtime, bare Runtime, or English `Ready` as generic end-user labels
+**Agent Runtime (product term)**:
+The product-facing name `Agent 运行时` for a Member's Product Runtime Selection and for the application settings/catalog surface. The Member editor section is `运行配置`; its selector, ordinary status, empty states, Toasts, and user guidance use `Agent 运行时`. Product Runtime, Runtime, Adapter, and AdapterInstallation remain domain or protocol vocabulary, while specific products such as Codex CLI keep their names.
+_Avoid_: 执行引擎, displaying Adapter Installation, bare Runtime, or English `Ready` as generic end-user labels
 
 **Runtime User Status**:
-The single actionable status shown for one Product Runtime or Member Runtime configuration: `正在检查…`, `可用`, `需要登录`, `未安装`, `版本不支持`, `不可用`, or `暂时无法确认`; no selection is `未配置执行引擎`. It may include a secondary reason or repair link, but never exposes `found_uninspected`, “已找到”, “尚未检查”, or “已检查”. A still-usable cached success remains `可用` while Core refreshes it in the background.
+The single actionable status shown for one Product Runtime or Member Runtime configuration: `正在检查…`, `可用`, `需要登录`, `未安装`, `版本不支持`, `不可用`, or `暂时无法确认`; no selection is `未配置 Agent 运行时`. It may include a secondary reason or repair link, but never exposes `found_uninspected`, “已找到”, “尚未检查”, or “已检查”. A still-usable cached success remains `可用` while Core refreshes it in the background.
 _Avoid_: Runtime Discovery status, Probe Attempt status, Snapshot lifecycle label, stacked primary statuses
 
 **Runtime Readiness Projection**:

--- a/apps/desktop/src/renderer/src/App.test.ts
+++ b/apps/desktop/src/renderer/src/App.test.ts
@@ -754,6 +754,48 @@ describe('task event projections', () => {
     expect(markup).not.toContain('Core')
   })
 
+  it('replaces project navigation with the member roster on the members page', () => {
+    const markup = renderToStaticMarkup(createElement(CampNavigation, {
+      view: 'members',
+      state: 'ready',
+      navigation: {
+        schemaVersion: 2,
+        throughGlobalSequence: 1,
+        quickChat: { totalCount: 0, recentCamps: [] },
+        projects: [{
+          projectKey: 'directory:/repo',
+          name: 'should-not-render',
+          projectPath: '/repo',
+          lastActivityAt: '2026-08-01T00:00:00Z',
+          lastActivityGlobalSequence: 0,
+          totalCount: 0,
+          recentCamps: []
+        }]
+      },
+      agents: [],
+      activeCampId: null,
+      memberSidebar: createElement('section', { 'aria-label': '队员名册' }, '唯一队员名册'),
+      onNewConversation: () => undefined,
+      onMembers: () => undefined,
+      onMemory: () => undefined,
+      pendingMemoryCount: 0,
+      onSettings: () => undefined,
+      onOpenProject: () => undefined,
+      onCamp: () => undefined,
+      onRename: async () => undefined,
+      onDelete: async () => ({ deleted: true, blockers: [] }),
+      onStop: async () => undefined,
+      onError: () => undefined
+    }))
+
+    expect(markup).toContain('唯一队员名册')
+    expect(markup).toContain('跳转到对话')
+    expect(markup).toContain('新对话')
+    expect(markup).toContain('设置')
+    expect(markup).not.toContain('should-not-render')
+    expect(markup).not.toContain('id="projects-heading"')
+  })
+
   it('keeps an unready Default Lead selectable while warning that execution is blocked', () => {
     const profile = agentProfile()
     const unreadyProfile: AgentProfile = {
@@ -1663,14 +1705,20 @@ describe('task event projections', () => {
       installations: [codexInstallation()],
       runtimeAvailability: [],
       runtimeDiscoveryPending: false,
+      selectedAgentId: 'agent-muwa',
+      activeTab: 'identity',
+      runtimeFocusRequest: 0,
+      onSelectedAgentChange: () => undefined,
+      onTabChange: () => undefined,
       onReload: async () => undefined,
       onOpenRuntimeSettings: () => undefined
     }))
 
-    expect(markup).toContain('选择一位队员')
-    expect(markup).toContain('不会替新队员绑定 Agent 运行时')
+    expect(markup).toContain('role="tablist"')
+    expect(markup).toContain('>身份</button>')
+    expect(markup).toContain('>运行配置</button>')
+    expect(markup).not.toContain('member-list')
     expect(markup).not.toContain('@muwa')
-    expect(markup).toContain('var(--identity-')
     expect(markup).not.toContain('身份强调色')
     expect(markup).not.toContain('保存运行配置')
   })
@@ -1767,12 +1815,12 @@ describe('task event projections', () => {
     expect(markup).not.toContain('Claude Code CLI')
     expect(markup).not.toContain('Antigravity App')
     expect(markup).not.toContain('/opt/homebrew/bin/codex')
-    expect(markup).toContain('<h3>运行配置</h3>')
+    expect(markup).toContain('<h3>Agent 运行时</h3>')
     expect(markup).toContain('Agent 运行时')
     expect(markup).toContain('保存运行时')
     expect(markup).not.toContain('放弃更改')
     expect(markup).not.toContain('清除 Agent 运行时')
-    expect(markup).toContain('只选择 Agent 产品')
+    expect(markup).toContain('选择产品并使用当前能力快照')
   })
 
   it('persists a missing Product Runtime choice and links to its checks', () => {
@@ -1797,7 +1845,7 @@ describe('task event projections', () => {
     expect(markup).toContain('未安装的 Agent 运行时也可以保存')
     expect(markup).toContain('未安装')
     expect(markup).toContain('前往 Agent 运行时')
-    expect(markup).toContain('<button class="primary-button">保存运行时</button>')
+    expect(markup).toContain('<button class="primary-button" disabled="">保存运行时</button>')
     expect(markup).not.toContain('放弃更改')
     expect(markup).not.toContain('清除 Agent 运行时')
   })

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -24,7 +24,15 @@ import type {
   ThemePreference,
   WorkspaceInspection
 } from '@contracts'
-import { MembersView, RuntimeInstallationsPanel } from './MemberManagement'
+import {
+  MembersView,
+  RuntimeInstallationsPanel,
+  type MembersViewHandle
+} from './MemberManagement'
+import {
+  MemberSidebar,
+  type MemberWorkspaceTab
+} from './MemberSidebar'
 import {
   CampWorkspace,
   QuickChatWorkspace,
@@ -166,6 +174,9 @@ export function App(): React.JSX.Element {
   const [cancellingTurnIds, setCancellingTurnIds] = useState<Set<string>>(() => new Set())
   const [state, setState] = useState<LoadState>('loading')
   const [view, setView] = useState<View>('compose')
+  const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null)
+  const [memberTab, setMemberTab] = useState<MemberWorkspaceTab>('identity')
+  const [memberRuntimeFocusRequest, setMemberRuntimeFocusRequest] = useState(0)
   const [settingsSection, setSettingsSection] = useState<SettingsSection>('skills')
   const [activeCampId, setActiveCampId] = useState<string | null>(null)
   const [notificationOpen, setNotificationOpen] = useState(false)
@@ -190,12 +201,24 @@ export function App(): React.JSX.Element {
   const newConversationReturnFocus = useRef<HTMLElement | null>(null)
   const liveRuntimeEventSequence = useRef(0)
   const runtimeHealthRefreshTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const membersViewRef = useRef<MembersViewHandle>(null)
   const campCreationPreflight = useMemo(
     () => campCreationPreflightFromAgents(agents),
     [agents]
   )
   activeCampIdRef.current = activeCampId
   viewRef.current = view
+
+  useEffect(() => {
+    if (view !== 'members') return
+    const manageable = agents.filter((agent) => agent.presence !== 'removed' && agent.removedAt === null)
+    if (selectedMemberId && manageable.some((agent) => agent.id === selectedMemberId)) return
+    const next = manageable.find((agent) => agent.presence === 'present')
+      ?? manageable.find((agent) => agent.presence === 'away')
+      ?? null
+    setSelectedMemberId(next?.id ?? null)
+    setMemberTab('identity')
+  }, [agents, selectedMemberId, view])
 
   useEffect(() => {
     try {
@@ -624,10 +647,37 @@ export function App(): React.JSX.Element {
     }
   }
 
+  const requestMemberTransition = useCallback((
+    action: () => void | Promise<void>
+  ): Promise<boolean> => {
+    if (viewRef.current !== 'members') {
+      return Promise.resolve().then(action).then(() => true)
+    }
+    return membersViewRef.current?.requestTransition(action) ?? Promise.resolve(false)
+  }, [])
+
   const chooseView = (nextView: View): void => {
-    if (nextView !== 'settings') lastMainView.current = nextView
-    if (nextView !== 'camp') setNotificationFocus(null)
-    setView(nextView)
+    const commit = (): void => {
+      if (nextView !== 'settings') lastMainView.current = nextView
+      if (nextView !== 'camp') setNotificationFocus(null)
+      setView(nextView)
+    }
+    if (nextView === 'members') commit()
+    else void requestMemberTransition(commit)
+  }
+
+  const chooseMember = (
+    agentId: string,
+    tab: MemberWorkspaceTab,
+    focusRuntime: boolean
+  ): void => {
+    const commit = (): void => {
+      setSelectedMemberId(agentId)
+      setMemberTab(tab)
+      if (focusRuntime) setMemberRuntimeFocusRequest((request) => request + 1)
+    }
+    if (selectedMemberId === agentId) commit()
+    else void requestMemberTransition(commit)
   }
 
   const openMemoryProposals = (): void => {
@@ -649,44 +699,48 @@ export function App(): React.JSX.Element {
   }
 
   const beginNewConversation = (): void => {
-    openNewConversation(null)
+    void requestMemberTransition(() => openNewConversation(null))
   }
 
   const chooseCamp = (camp: NavigationCampItem): void => {
-    lastMainView.current = 'camp'
-    setNotificationFocus(null)
-    void activateCamp(camp.id)
+    void requestMemberTransition(() => {
+      lastMainView.current = 'camp'
+      setNotificationFocus(null)
+      return activateCamp(camp.id)
+    })
   }
 
   const navigateFromNotification = useCallback(async (
     notification: InAppNotificationView
   ): Promise<void> => {
-    const target: NotificationFocusTarget | null = notification.kind === 'runtime_permission_attention'
-      ? notification.attentionState === 'pending'
-        ? {
-          requestId: ++notificationFocusSequence.current,
-          kind: 'approval',
-          campTurnId: null
-        }
-        : null
-      : notification.sourceAvailable && notification.campTurnId
-        ? {
-          requestId: ++notificationFocusSequence.current,
-          kind: 'camp_turn',
-          campTurnId: notification.campTurnId
-        }
-        : null
-    setNotificationFocus(target)
-    if (target?.kind === 'approval') {
-      setCampInspectorTab('approvals')
-      setCampInspectorVisible(true)
-    }
-    await activateCamp(notification.camp.id, {
-      preserveNotificationFocus: target !== null,
-      reconcileDefaultLead: notification.camp.status === 'active',
-      suppressErrors: true
+    await requestMemberTransition(async () => {
+      const target: NotificationFocusTarget | null = notification.kind === 'runtime_permission_attention'
+        ? notification.attentionState === 'pending'
+          ? {
+            requestId: ++notificationFocusSequence.current,
+            kind: 'approval',
+            campTurnId: null
+          }
+          : null
+        : notification.sourceAvailable && notification.campTurnId
+          ? {
+            requestId: ++notificationFocusSequence.current,
+            kind: 'camp_turn',
+            campTurnId: notification.campTurnId
+          }
+          : null
+      setNotificationFocus(target)
+      if (target?.kind === 'approval') {
+        setCampInspectorTab('approvals')
+        setCampInspectorVisible(true)
+      }
+      await activateCamp(notification.camp.id, {
+        preserveNotificationFocus: target !== null,
+        reconcileDefaultLead: notification.camp.status === 'active',
+        suppressErrors: true
+      })
     })
-  }, [activateCamp])
+  }, [activateCamp, requestMemberTransition])
 
   const toggleNavigationPin = async (
     kind: NavigationPin['kind'],
@@ -1044,6 +1098,17 @@ export function App(): React.JSX.Element {
         notificationUnreadCount={notificationUnreadCount}
         notificationButtonRef={notificationButtonRef}
         onNotifications={() => setNotificationOpen(true)}
+        memberSidebar={view === 'members' ? (
+          <MemberSidebar
+            agents={agents}
+            runtimeAvailability={health?.runtimeAvailability ?? []}
+            runtimeDiscoveryPending={health === null || healthLoading}
+            selectedAgentId={selectedMemberId}
+            onSelect={chooseMember}
+            onCreate={(trigger) => membersViewRef.current?.requestCreate(trigger)}
+            onReload={loadMemberData}
+          />
+        ) : null}
         onSettings={() => chooseView('settings')}
         onSettingsSectionChange={setSettingsSection}
         onSettingsBack={closeSettings}
@@ -1069,7 +1134,7 @@ export function App(): React.JSX.Element {
         onOpenInspector={openCampInspector}
       />}
 
-      <main className={`content ${view === 'compose' || view === 'camp' ? 'task-content' : ''} ${showAppHeader ? '' : 'content-without-app-header'} ${view === 'settings' ? 'settings-content' : ''} ${view === 'memory' ? 'memory-content' : ''}`}>
+      <main className={`content ${view === 'compose' || view === 'camp' ? 'task-content' : ''} ${showAppHeader ? '' : 'content-without-app-header'} ${view === 'settings' ? 'settings-content' : ''} ${view === 'memory' ? 'memory-content' : ''} ${view === 'members' ? 'members-content' : ''}`}>
         {memoryProposalNotice && (
           <div className="memory-proposal-notice" role="status">
             <div><strong>伙伴提出了一条记忆建议</strong><span>提案尚未生效，你可以稍后在“记忆”中逐条确认。</span></div>
@@ -1169,10 +1234,19 @@ export function App(): React.JSX.Element {
 
         {view === 'members' && (
           <MembersView
+            ref={membersViewRef}
             agents={agents}
             installations={installations}
             runtimeAvailability={health?.runtimeAvailability ?? []}
             runtimeDiscoveryPending={health === null || healthLoading}
+            selectedAgentId={selectedMemberId}
+            activeTab={memberTab}
+            runtimeFocusRequest={memberRuntimeFocusRequest}
+            onSelectedAgentChange={(agentId, tab) => {
+              setSelectedMemberId(agentId)
+              setMemberTab(tab)
+            }}
+            onTabChange={setMemberTab}
             onReload={loadMemberData}
             onOpenRuntimeSettings={() => {
               setSettingsSection('runtime')

--- a/apps/desktop/src/renderer/src/CampNavigation.tsx
+++ b/apps/desktop/src/renderer/src/CampNavigation.tsx
@@ -5,6 +5,7 @@ import {
   useState,
   type FormEvent,
   type JSX,
+  type ReactNode,
   type RefObject
 } from 'react'
 import * as Dialog from '@radix-ui/react-dialog'
@@ -53,6 +54,7 @@ export function CampNavigation({
   notificationUnreadCount = 0,
   notificationButtonRef,
   onNotifications = () => undefined,
+  memberSidebar = null,
   onSettings,
   onSettingsSectionChange = () => undefined,
   onSettingsBack = () => undefined,
@@ -79,6 +81,7 @@ export function CampNavigation({
   notificationUnreadCount?: number
   notificationButtonRef?: RefObject<HTMLButtonElement | null>
   onNotifications?(): void
+  memberSidebar?: ReactNode
   onSettings(): void
   onSettingsSectionChange?(section: NavigationSettingsSection): void
   onSettingsBack?(): void
@@ -322,7 +325,9 @@ export function CampNavigation({
                   <span>跳转到对话…</span><kbd aria-hidden="true">⌘K</kbd>
                 </button>
 
-      <div className="navigation-scroll">
+      {view === 'members' && memberSidebar
+        ? memberSidebar
+        : <div className="navigation-scroll">
         {(pinnedCamps.length > 0 || pinnedProjects.length > 0) && (
           <section className="pinned-navigation" aria-labelledby="pinned-heading">
             <div className="sidebar-group-title navigation-section-title">
@@ -405,7 +410,7 @@ export function CampNavigation({
             onAction={openAction}
           />
         </section>
-      </div>
+          </div>}
       <div className="unified-sidebar-footer">
         <button
           className="rail-button"

--- a/apps/desktop/src/renderer/src/MemberManagement.tsx
+++ b/apps/desktop/src/renderer/src/MemberManagement.tsx
@@ -1,4 +1,14 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from 'react'
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+  type ReactNode
+} from 'react'
 import * as Dialog from '@radix-ui/react-dialog'
 import type {
   AdapterInstallation,
@@ -8,7 +18,6 @@ import type {
   HealthStatus,
   MemberRemovalPreview,
   ProductRuntimeAvailability,
-  RuntimeReadinessStatus,
   SetAgentProfileAvatarCommand,
   SetAgentProfileMemoryWriteCommand,
   StoredCommandResult,
@@ -35,8 +44,10 @@ import {
   type PendingMemberAvatarSource
 } from './member-avatar-submit'
 import { invalidateManagedAvatarObjectUrl } from './managed-avatar-cache'
-import { identityColorToken } from './theme'
-import { SummaryModelSettings } from './SummaryModelSettings'
+import {
+  SummaryModelSettings,
+  type SummaryModelSettingsHandle
+} from './SummaryModelSettings'
 import {
   MemberRuntimeParameters,
   runtimeDraftForMember,
@@ -46,16 +57,35 @@ import {
 import {
   memberRuntimePresentation,
   runtimeAvailabilityPresentation,
-  runtimeReadinessLabel
 } from './runtime-status'
+import type { MemberWorkspaceTab } from './MemberSidebar'
 
 type MembersViewProps = {
   agents: AgentProfile[]
   installations: AdapterInstallation[]
   runtimeAvailability: ProductRuntimeAvailability[]
   runtimeDiscoveryPending: boolean
+  selectedAgentId: string | null
+  activeTab: MemberWorkspaceTab
+  runtimeFocusRequest: number
+  onSelectedAgentChange(agentId: string, tab: MemberWorkspaceTab): void
+  onTabChange(tab: MemberWorkspaceTab): void
   onReload(): Promise<void>
   onOpenRuntimeSettings(): void
+}
+
+type GuardedTransition = {
+  action(): void | Promise<void>
+  resolve(continued: boolean): void
+  returnFocus: HTMLElement | null
+}
+
+export type MembersViewHandle = {
+  requestTransition(
+    action: () => void | Promise<void>,
+    returnFocus?: HTMLElement | null
+  ): Promise<boolean>
+  requestCreate(trigger: HTMLButtonElement): void
 }
 
 type IdentityDraft = {
@@ -76,8 +106,19 @@ const EMPTY_IDENTITY: IdentityDraft = {
   growthTopic: ''
 }
 
-export function MembersView({ agents, installations, runtimeAvailability, runtimeDiscoveryPending, onReload, onOpenRuntimeSettings }: MembersViewProps): React.JSX.Element {
-  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null)
+export const MembersView = forwardRef<MembersViewHandle, MembersViewProps>(function MembersView({
+  agents,
+  installations,
+  runtimeAvailability,
+  runtimeDiscoveryPending,
+  selectedAgentId,
+  activeTab,
+  runtimeFocusRequest,
+  onSelectedAgentChange,
+  onTabChange,
+  onReload,
+  onOpenRuntimeSettings
+}, ref): React.JSX.Element {
   const [identityDialog, setIdentityDialog] = useState<'create' | 'edit' | null>(null)
   const [avatarDialogOpen, setAvatarDialogOpen] = useState(false)
   const [removal, setRemoval] = useState<{
@@ -88,18 +129,29 @@ export function MembersView({ agents, installations, runtimeAvailability, runtim
   const [busy, setBusy] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
-  const [dragAgentId, setDragAgentId] = useState<string | null>(null)
-  const [dragOverAgentId, setDragOverAgentId] = useState<string | null>(null)
+  const [runtimeDirty, setRuntimeDirty] = useState(false)
+  const [summaryDirty, setSummaryDirty] = useState(false)
+  const [pendingTransition, setPendingTransition] = useState<GuardedTransition | null>(null)
   const identityReturnFocusRef = useRef<HTMLButtonElement | null>(null)
   const avatarReturnFocusRef = useRef<HTMLButtonElement | null>(null)
   const removalReturnFocusRef = useRef<HTMLButtonElement | null>(null)
+  const runtimeFormRef = useRef<MemberRuntimeFormHandle>(null)
+  const summarySettingsRef = useRef<SummaryModelSettingsHandle>(null)
+  const pendingTransitionRef = useRef<GuardedTransition | null>(null)
+  const dirtyRef = useRef(false)
   const selectedAgent = agents.find((agent) => agent.id === selectedAgentId) ?? null
 
   useEffect(() => {
-    if (selectedAgentId && !agents.some((agent) => agent.id === selectedAgentId)) {
-      setSelectedAgentId(null)
-    }
-  }, [agents, selectedAgentId])
+    dirtyRef.current = runtimeDirty || summaryDirty
+  }, [runtimeDirty, summaryDirty])
+
+  useEffect(() => {
+    if (activeTab !== 'runtime' || runtimeFocusRequest < 1) return undefined
+    const frame = requestAnimationFrame(() => {
+      document.querySelector<HTMLSelectElement>('#member-runtime-select')?.focus()
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [activeTab, runtimeFocusRequest, selectedAgentId])
 
   useEffect(() => {
     if (!notice) return undefined
@@ -145,7 +197,7 @@ export function MembersView({ agents, installations, runtimeAvailability, runtim
     const result = await runCommand('identity', method, identity)
     if (!targetAgent) {
       const createdId = result.resultEntity?.entityId ?? stringField(result.payload, 'agentProfileId')
-      if (createdId) setSelectedAgentId(createdId)
+      if (createdId) onSelectedAgentChange(createdId, 'identity')
     }
     closeIdentityDialog()
   }
@@ -253,157 +305,104 @@ export function MembersView({ agents, installations, runtimeAvailability, runtim
     })
     setNotice(`${removal.displayName} 已移除，历史身份与记录继续保留。`)
     setRemoval(null)
-    setSelectedAgentId(null)
   }
 
-  const dropReorder = async (targetAgentId: string): Promise<void> => {
-    const sourceAgentId = dragAgentId
-    setDragAgentId(null)
-    setDragOverAgentId(null)
-    if (!sourceAgentId || sourceAgentId === targetAgentId) return
-    const orderedAgentProfileIds = agents.map((agent) => agent.id)
-    const from = orderedAgentProfileIds.indexOf(sourceAgentId)
-    const to = orderedAgentProfileIds.indexOf(targetAgentId)
-    if (from < 0 || to < 0) return
-    orderedAgentProfileIds.splice(from, 1)
-    orderedAgentProfileIds.splice(to, 0, sourceAgentId)
-    await runCommand('reorder', 'agents.reorder', { orderedAgentProfileIds }).catch(() => undefined)
-  }
+  const discardDrafts = useCallback((): void => {
+    runtimeFormRef.current?.discard()
+    summarySettingsRef.current?.discard()
+    setRuntimeDirty(false)
+    setSummaryDirty(false)
+    dirtyRef.current = false
+  }, [])
 
-  const moveMemberByKeyboard = async (
-    agent: AgentProfile,
-    direction: -1 | 1
-  ): Promise<void> => {
-    const samePresence = agents.filter((candidate) => candidate.presence === agent.presence)
-    const visibleIndex = samePresence.findIndex((candidate) => candidate.id === agent.id)
-    const target = samePresence[visibleIndex + direction]
-    if (!target) return
-    const orderedAgentProfileIds = agents.map((candidate) => candidate.id)
-    const from = orderedAgentProfileIds.indexOf(agent.id)
-    const to = orderedAgentProfileIds.indexOf(target.id)
-    orderedAgentProfileIds.splice(from, 1)
-    orderedAgentProfileIds.splice(to, 0, agent.id)
-    await runCommand('reorder', 'agents.reorder', { orderedAgentProfileIds }).catch(() => undefined)
+  const requestTransition = useCallback((
+    action: () => void | Promise<void>,
+    returnFocus: HTMLElement | null = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null
+  ): Promise<boolean> => {
+    if (!dirtyRef.current) {
+      return Promise.resolve()
+        .then(action)
+        .then(() => true)
+        .catch((nextError) => {
+          setError(errorMessage(nextError))
+          return false
+        })
+    }
+    if (pendingTransitionRef.current) return Promise.resolve(false)
+    return new Promise((resolve) => {
+      const transition = { action, resolve, returnFocus }
+      pendingTransitionRef.current = transition
+      setPendingTransition(transition)
+    })
+  }, [])
+
+  const continueEditing = useCallback((): void => {
+    const transition = pendingTransitionRef.current
+    pendingTransitionRef.current = null
+    setPendingTransition(null)
+    transition?.resolve(false)
+    requestAnimationFrame(() => transition?.returnFocus?.focus())
+  }, [])
+
+  const discardAndContinue = useCallback(async (): Promise<void> => {
+    const transition = pendingTransitionRef.current
+    if (!transition) return
+    pendingTransitionRef.current = null
+    setPendingTransition(null)
+    discardDrafts()
+    try {
+      await transition.action()
+      transition.resolve(true)
+    } catch (nextError) {
+      setError(errorMessage(nextError))
+      transition.resolve(false)
+    }
+  }, [discardDrafts])
+
+  const requestCreate = useCallback((trigger: HTMLButtonElement): void => {
+    void requestTransition(() => {
+      identityReturnFocusRef.current = trigger
+      setIdentityDialog('create')
+    }, trigger)
+  }, [requestTransition])
+
+  useImperativeHandle(ref, () => ({ requestTransition, requestCreate }), [requestCreate, requestTransition])
+
+  const openRuntimeTab = (): void => {
+    onTabChange('runtime')
+    requestAnimationFrame(() => document.querySelector<HTMLSelectElement>('#member-runtime-select')?.focus())
   }
 
   return (
     <>
-      <section className="project-hero member-hero">
-        <div>
-          <h2>队员</h2>
-          <p>队员保存长期身份和默认 Agent 运行时；加入 Camp、Default Lead 与 Camp 权限仍由具体 Camp 管理。</p>
-        </div>
-        <div className="project-actions">
-          <button
-            className="primary-button"
-            onClick={(event) => {
-              identityReturnFocusRef.current = event.currentTarget
-              setIdentityDialog('create')
-            }}
-          >＋ 新增队员</button>
-        </div>
-      </section>
-
-      {error && (
-        <div className="inline-error member-page-error" role="alert">
-          <strong>队员配置未保存</strong><span>{error}</span>
-        </div>
-      )}
-      {notice && (
-        <div className="app-toast" role="status" aria-live="polite">
-          <span>{notice}</span>
-          <button className="icon-button" type="button" aria-label="关闭提示" onClick={() => setNotice(null)}>×</button>
-        </div>
-      )}
-
-      <section className="member-workbench">
-        <aside className="member-list" aria-label="队员列表">
-          <div className="member-list-heading"><strong>{agents.length} 位队员</strong><span>选择后编辑</span></div>
-          {(['present', 'away'] as const).map((presence) => {
-            const group = agents.filter((agent) => agent.presence === presence)
-            if (group.length === 0) return null
-            return (
-              <div className="member-list-group" key={presence}>
-                <div className="member-list-group-heading">
-                  <span>{memberPresenceLabel(presence)}</span><small>{group.length}</small>
-                </div>
-                {group.map((agent) => (
-                  <div
-                    key={agent.id}
-                    className={`member-list-row ${dragOverAgentId === agent.id && dragAgentId !== agent.id ? 'drag-over' : ''}`}
-                    draggable={busy === null}
-                    onDragStart={(event) => {
-                      setDragAgentId(agent.id)
-                      event.dataTransfer.effectAllowed = 'move'
-                    }}
-                    onDragOver={(event) => {
-                      event.preventDefault()
-                      setDragOverAgentId(agent.id)
-                    }}
-                    onDragLeave={() => setDragOverAgentId((current) => current === agent.id ? null : current)}
-                    onDrop={(event) => {
-                      event.preventDefault()
-                      void dropReorder(agent.id)
-                    }}
-                    onDragEnd={() => {
-                      setDragAgentId(null)
-                      setDragOverAgentId(null)
-                    }}
-                  >
-                    <button
-                      className="member-drag-handle"
-                      type="button"
-                      title="拖拽；聚焦后用方向键调整 Member Order"
-                      aria-label={`调整 ${agent.displayName} 的顺序；上、下方向键移动`}
-                      disabled={busy !== null}
-                      onKeyDown={(event) => {
-                        if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return
-                        event.preventDefault()
-                        void moveMemberByKeyboard(agent, event.key === 'ArrowUp' ? -1 : 1)
-                      }}
-                    >⋮⋮</button>
-                    <button
-                      type="button"
-                      className={`member-list-item ${selectedAgent?.id === agent.id ? 'selected' : ''}`}
-                      aria-current={selectedAgent?.id === agent.id ? 'true' : undefined}
-                      onClick={() => setSelectedAgentId(agent.id)}
-                      style={{ '--agent-accent': identityColorToken(agent.id) } as React.CSSProperties}
-                    >
-                      <span className="member-list-accent" aria-hidden="true" />
-                      <MemberAvatar
-                        agentProfileId={agent.id}
-                        avatarRef={agent.avatarRef}
-                        displayName={agent.displayName}
-                        size="list"
-                        decorative
-                        className="member-list-avatar"
-                      />
-                      <span className="member-list-copy">
-                        <strong>{agent.displayName}</strong>
-                        <small>{memberPresenceLabel(agent.presence)}</small>
-                      </span>
-                      <RuntimeReadinessMark status={agent.runtimeReadiness.status} />
-                    </button>
-                  </div>
-                ))}
-              </div>
-            )
-          })}
-          <p className="member-order-note">⋮⋮ 拖拽调整 Member Order —— 只影响展示与新 Camp 初始顺序，不代表能力或权限。</p>
-        </aside>
-
-        <div className="member-detail">
+      <section className="members-view">
+        {error && (
+          <div className="inline-error member-page-error" role="alert">
+            <strong>队员配置未保存</strong><span>{error}</span>
+          </div>
+        )}
+        {notice && (
+          <div className="app-toast" role="status" aria-live="polite">
+            <span>{notice}</span>
+            <button className="icon-button" type="button" aria-label="关闭提示" onClick={() => setNotice(null)}>×</button>
+          </div>
+        )}
+        <div className="member-detail-scroll">
           {!selectedAgent && (
             <div className="member-empty">
               <span aria-hidden="true">◎</span>
-              <h3>选择一位队员</h3>
-              <p>这里不会自动选中队员，也不会替新队员绑定 Agent 运行时。请选择已有队员，或新建一个长期身份。</p>
+              <h3>建立第一位队员</h3>
+              <p>队员保存长期身份与默认 Agent 运行时；创建后仍需由你明确选择和保存运行配置。</p>
             </div>
           )}
           {selectedAgent && (
             <>
-              <MemberIdentitySummary
+              <MemberDetailHeader
                 agent={selectedAgent}
+                runtimeAvailability={runtimeAvailability}
+                runtimeDiscoveryPending={runtimeDiscoveryPending}
                 busy={busy}
                 onEdit={(trigger) => {
                   identityReturnFocusRef.current = trigger
@@ -414,35 +413,43 @@ export function MembersView({ agents, installations, runtimeAvailability, runtim
                   setAvatarDialogOpen(true)
                 }}
                 onPresence={changePresence}
+                onRuntime={openRuntimeTab}
+                onRemove={(trigger) => {
+                  void requestTransition(() => previewRemoval(trigger), trigger)
+                }}
               />
-              <MemberMemorySettings
-                agent={selectedAgent}
-                busy={busy}
-                onChange={saveMemoryWrite}
+              <MemberTabs
+                value={activeTab}
+                onChange={onTabChange}
               />
-              <MemberRuntimeForm
-                key={`${selectedAgent.id}:${selectedAgent.version}`}
-                agent={selectedAgent}
-                installations={installations}
-                runtimeAvailability={runtimeAvailability}
-                runtimeDiscoveryPending={runtimeDiscoveryPending}
-                busy={busy}
-                onSave={saveRuntime}
-                onClear={clearRuntime}
-                onRuntimeEnsure={ensureRuntime}
-                onRuntimeSelected={checkRuntime}
-                onOpenRuntimeSettings={onOpenRuntimeSettings}
-              />
-              <MemberAdvancedSettings
-                key={`advanced:${selectedAgent.id}`}
-                agent={selectedAgent}
-                installations={installations}
-              />
-              <MemberRemovalSection
-                agent={selectedAgent}
-                busy={busy}
-                onRemove={previewRemoval}
-              />
+              <div id="member-identity-panel" role="tabpanel" aria-labelledby="member-identity-tab" hidden={activeTab !== 'identity'}>
+                <MemberIdentitySummary agent={selectedAgent} />
+                <MemberMemorySettings agent={selectedAgent} busy={busy} onChange={saveMemoryWrite} />
+              </div>
+              <div id="member-runtime-panel" role="tabpanel" aria-labelledby="member-runtime-tab" hidden={activeTab !== 'runtime'}>
+                <p className="member-runtime-intro">为这位队员设置后续 Run 使用的 Agent 运行时、模型和该运行时提供的权限选项。保存后仅影响之后创建的 Run。</p>
+                <MemberRuntimeForm
+                  ref={runtimeFormRef}
+                  agent={selectedAgent}
+                  installations={installations}
+                  runtimeAvailability={runtimeAvailability}
+                  runtimeDiscoveryPending={runtimeDiscoveryPending}
+                  busy={busy}
+                  onDirtyChange={setRuntimeDirty}
+                  onSave={saveRuntime}
+                  onClear={clearRuntime}
+                  onRuntimeEnsure={ensureRuntime}
+                  onRuntimeSelected={checkRuntime}
+                  onOpenRuntimeSettings={onOpenRuntimeSettings}
+                />
+                <MemberAdvancedSettings
+                  key={`advanced:${selectedAgent.id}`}
+                  ref={summarySettingsRef}
+                  agent={selectedAgent}
+                  installations={installations}
+                  onDirtyChange={setSummaryDirty}
+                />
+              </div>
             </>
           )}
         </div>
@@ -507,9 +514,27 @@ export function MembersView({ agents, installations, runtimeAvailability, runtim
           </Dialog.Content>
         </Dialog.Portal>
       </Dialog.Root>
+      <Dialog.Root open={pendingTransition !== null} onOpenChange={(open) => !open && continueEditing()}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="dialog-overlay" />
+          <Dialog.Content className="dialog-content member-leave-dialog" aria-describedby="member-leave-description">
+            <div className="dialog-heading">
+              <div><Dialog.Title>运行配置尚未保存</Dialog.Title></div>
+              <Dialog.Close className="dialog-close" aria-label="继续编辑">×</Dialog.Close>
+            </div>
+            <Dialog.Description id="member-leave-description">
+              当前队员的运行配置或 Camp 共享摘要模型包含未保存更改。你可以继续编辑，或放弃更改后执行刚才的操作。
+            </Dialog.Description>
+            <div className="dialog-actions">
+              <button className="quiet-button" type="button" onClick={continueEditing}>继续编辑</button>
+              <button className="danger-button" type="button" onClick={() => void discardAndContinue()}>放弃更改</button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
     </>
   )
-}
+})
 
 export function memberIdentityTargetAgent(
   mode: 'create' | 'edit' | null,
@@ -518,71 +543,217 @@ export function memberIdentityTargetAgent(
   return mode === 'edit' ? selectedAgent : null
 }
 
-function MemberIdentitySummary({ agent, busy, onEdit, onEditAvatar, onPresence }: {
+function MemberDetailHeader({
+  agent,
+  runtimeAvailability,
+  runtimeDiscoveryPending,
+  busy,
+  onEdit,
+  onEditAvatar,
+  onPresence,
+  onRuntime,
+  onRemove
+}: {
   agent: AgentProfile
+  runtimeAvailability: ProductRuntimeAvailability[]
+  runtimeDiscoveryPending: boolean
   busy: string | null
   onEdit(trigger: HTMLButtonElement): void
   onEditAvatar(trigger: HTMLButtonElement): void
   onPresence(presence: 'present' | 'away'): Promise<void>
+  onRuntime(): void
+  onRemove(trigger: HTMLButtonElement): void
 }): React.JSX.Element {
+  const availability = runtimeAvailability.find(
+    (item) => item.runtimeKind === agent.runtimeSelection?.adapterKind
+  ) ?? null
+  const runtime = memberRuntimePresentation(
+    agent,
+    agent.runtimeSelection?.adapterKind ?? null,
+    availability,
+    runtimeDiscoveryPending
+  )
+  return (
+    <header className="member-detail-header">
+      <div className="member-detail-heading">
+        <MemberAvatar
+          agentProfileId={agent.id}
+          avatarRef={agent.avatarRef}
+          displayName={agent.displayName}
+          size="profile"
+          decorative
+          className="member-detail-avatar"
+        />
+        <div>
+          <h2>{agent.displayName}</h2>
+          <p>{agent.teamRole || '团队角色未设置'}</p>
+          <div className="member-detail-statuses">
+            <span className={`presence-${agent.presence}`}>{memberPresenceLabel(agent.presence)}</span>
+            <button
+              className={`member-header-runtime status-${runtime.status}`}
+              type="button"
+              onClick={onRuntime}
+              title={runtime.detail ?? runtime.label}
+            >
+              <i aria-hidden="true" />
+              <span>{agent.runtimeSelection?.adapterKind ? adapterLabel(agent.runtimeSelection.adapterKind) : 'Agent 运行时'}</span>
+              <strong>{runtime.label}</strong>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div className="member-detail-actions">
+        <button className="quiet-button" type="button" disabled={busy !== null} onClick={(event) => onEdit(event.currentTarget)}>编辑身份</button>
+        <details className="member-detail-menu">
+          <summary aria-label={`管理 ${agent.displayName}`} title="更多操作">•••</summary>
+          <div role="menu">
+            <button type="button" role="menuitem" disabled={busy !== null} onClick={(event) => {
+              closeParentDetails(event.currentTarget)
+              onEditAvatar(event.currentTarget)
+            }}>更换角色图片</button>
+            <button type="button" role="menuitem" disabled={busy !== null} onClick={(event) => {
+              closeParentDetails(event.currentTarget)
+              void onPresence(agent.presence === 'present' ? 'away' : 'present').catch(() => undefined)
+            }}>{agent.presence === 'present' ? '暂时离队' : '归队'}</button>
+            <button className="danger-menu-item" type="button" role="menuitem" disabled={busy !== null} onClick={(event) => {
+              closeParentDetails(event.currentTarget)
+              onRemove(event.currentTarget)
+            }}>永久移除队员</button>
+          </div>
+        </details>
+      </div>
+    </header>
+  )
+}
+
+function MemberTabs({ value, onChange }: {
+  value: MemberWorkspaceTab
+  onChange(tab: MemberWorkspaceTab): void
+}): React.JSX.Element {
+  const identityRef = useRef<HTMLButtonElement>(null)
+  const runtimeRef = useRef<HTMLButtonElement>(null)
+  const focusTab = (tab: MemberWorkspaceTab): void => {
+    (tab === 'identity' ? identityRef : runtimeRef).current?.focus()
+  }
+  const onKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>): void => {
+    if (event.key === 'ArrowLeft' || event.key === 'ArrowUp' || event.key === 'Home') {
+      event.preventDefault()
+      focusTab('identity')
+    } else if (event.key === 'ArrowRight' || event.key === 'ArrowDown' || event.key === 'End') {
+      event.preventDefault()
+      focusTab('runtime')
+    } else if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      onChange(event.currentTarget.dataset.memberTab as MemberWorkspaceTab)
+    }
+  }
+  return (
+    <div className="member-tabs" role="tablist" aria-label="队员详情">
+      <button
+        id="member-identity-tab"
+        ref={identityRef}
+        data-member-tab="identity"
+        role="tab"
+        type="button"
+        aria-selected={value === 'identity'}
+        aria-controls="member-identity-panel"
+        tabIndex={value === 'identity' ? 0 : -1}
+        onClick={() => onChange('identity')}
+        onKeyDown={onKeyDown}
+      >身份</button>
+      <button
+        id="member-runtime-tab"
+        ref={runtimeRef}
+        data-member-tab="runtime"
+        role="tab"
+        type="button"
+        aria-selected={value === 'runtime'}
+        aria-controls="member-runtime-panel"
+        tabIndex={value === 'runtime' ? 0 : -1}
+        onClick={() => onChange('runtime')}
+        onKeyDown={onKeyDown}
+      >运行配置</button>
+    </div>
+  )
+}
+
+function MemberIdentitySummary({ agent }: { agent: AgentProfile }): React.JSX.Element {
   return (
     <section className="member-section member-identity-section">
       <div className="member-identity-overview">
+        <div className="member-identity-copy">
+          <ExpandableIdentityField label="专业职责" lines={4} contentKey={agent.professionalResponsibilities}>
+            <p className="member-role-description">{agent.professionalResponsibilities || '未设置'}</p>
+          </ExpandableIdentityField>
+          <ExpandableIdentityField label="性格底色" lines={2} contentKey={agent.personalityTraits.join('\u0000')}>
+            {agent.personalityTraits.length > 0
+              ? <div className="member-trait-list">{agent.personalityTraits.map((trait) => <span key={trait}>{trait}</span>)}</div>
+              : <p className="member-identity-empty">未设置</p>}
+          </ExpandableIdentityField>
+          <ExpandableIdentityField label="工作准则" lines={3} contentKey={agent.workingPrinciples}>
+            <p className="member-role-description">{agent.workingPrinciples || '未设置'}</p>
+          </ExpandableIdentityField>
+          <ExpandableIdentityField label="成长课题" lines={3} contentKey={agent.growthTopic}>
+            <p className="member-role-description">{agent.growthTopic || '未设置'}</p>
+          </ExpandableIdentityField>
+        </div>
         <div className="member-identity-appearance">
           <MemberPortrait
             agentProfileId={agent.id}
             avatarRef={agent.avatarRef}
             displayName={agent.displayName}
           />
-          <button
-            className="quiet-button member-avatar-change"
-            type="button"
-            disabled={busy !== null}
-            onClick={(event) => onEditAvatar(event.currentTarget)}
-          >更换角色图片</button>
         </div>
-        <div className="member-identity-copy">
-          <div className="member-section-heading">
-            <div className="member-profile-heading">
-              <MemberAvatar
-                agentProfileId={agent.id}
-                avatarRef={agent.avatarRef}
-                displayName={agent.displayName}
-                size="profile"
-                decorative
-                className="member-profile-avatar"
-              />
-              <div><h3>{agent.displayName}</h3><span>{agent.teamRole || '团队角色未设置'}</span></div>
-            </div>
-            <button className="quiet-button" onClick={(event) => onEdit(event.currentTarget)}>编辑身份</button>
-          </div>
-          <div className="member-identity-field">
-            <strong>专业职责</strong>
-            <p className="member-role-description">{agent.professionalResponsibilities || '未设置'}</p>
-          </div>
-          <div className="member-identity-field">
-            <strong>性格底色</strong>
-            {agent.personalityTraits.length > 0
-              ? <div className="member-trait-list">{agent.personalityTraits.map((trait) => <span key={trait}>{trait}</span>)}</div>
-              : <p className="member-identity-empty">未设置</p>}
-          </div>
-          <div className="member-identity-field">
-            <strong>工作准则</strong>
-            <p className="member-role-description">{agent.workingPrinciples || '未设置'}</p>
-          </div>
-          <div className="member-identity-field">
-            <strong>成长课题</strong>
-            <p className="member-role-description">{agent.growthTopic || '未设置'}</p>
-          </div>
-        </div>
-      </div>
-      <div className="member-status-actions">
-        <span>在队状态：<strong>{memberPresenceLabel(agent.presence)}</strong></span>
-        {agent.presence === 'present' && <button className="quiet-button" disabled={busy !== null} onClick={() => void onPresence('away').catch(() => undefined)}>暂离</button>}
-        {agent.presence === 'away' && <button className="quiet-button" disabled={busy !== null} onClick={() => void onPresence('present').catch(() => undefined)}>归队</button>}
       </div>
       {agent.presence === 'away' && <div className="member-status-note" role="status">队员仍属于已有 Camp；已有 Run 不会中断，但不会再启动新的 Run。</div>}
     </section>
+  )
+}
+
+function ExpandableIdentityField({ label, lines, contentKey, children }: {
+  label: string
+  lines: number
+  contentKey: string
+  children: ReactNode
+}): React.JSX.Element {
+  const contentRef = useRef<HTMLDivElement>(null)
+  const [expanded, setExpanded] = useState(false)
+  const [overflow, setOverflow] = useState(false)
+  const measure = useCallback((): void => {
+    const element = contentRef.current
+    if (!element || expanded) return
+    setOverflow(element.scrollHeight > element.clientHeight + 1)
+  }, [expanded])
+  useEffect(() => {
+    setExpanded(false)
+    setOverflow(false)
+  }, [contentKey])
+  useEffect(() => {
+    if (expanded) return undefined
+    const frame = requestAnimationFrame(measure)
+    return () => cancelAnimationFrame(frame)
+  }, [contentKey, expanded, measure])
+  useEffect(() => {
+    const element = contentRef.current
+    if (!element || typeof ResizeObserver === 'undefined') return undefined
+    const observer = new ResizeObserver(measure)
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [measure])
+  return (
+    <div className="member-identity-field">
+      <strong>{label}</strong>
+      <div
+        ref={contentRef}
+        className={`member-identity-clamp ${expanded ? 'expanded' : ''}`}
+        style={{ '--identity-clamp-lines': lines } as React.CSSProperties}
+      >{children}</div>
+      {overflow && (
+        <button className="member-identity-expand" type="button" onClick={() => setExpanded((value) => !value)}>
+          {expanded ? `收起${label}` : `展开${label}`}
+        </button>
+      )}
+    </div>
   )
 }
 
@@ -596,7 +767,7 @@ function MemberMemorySettings({ agent, busy, onChange }: {
     <section className="member-section member-memory-settings">
       <div>
         <h3>伙伴记忆</h3>
-        <p>允许伙伴在真实形成长期偏好、约定或经验时写入记忆；成长课题本身不会自动创建记忆。</p>
+        <p>允许这位伙伴在协作中形成长期偏好、约定或经验时写入记忆。</p>
       </div>
       <label className="memory-capability-toggle member-memory-toggle">
         <input
@@ -611,15 +782,32 @@ function MemberMemorySettings({ agent, busy, onChange }: {
   )
 }
 
-export function MemberAdvancedSettings({ installations, agent, defaultOpen = false }: {
+export const MemberAdvancedSettings = forwardRef<SummaryModelSettingsHandle, {
   installations: AdapterInstallation[]
   agent: AgentProfile
   defaultOpen?: boolean
-}): React.JSX.Element {
+  onDirtyChange?(dirty: boolean): void
+}>(function MemberAdvancedSettings({
+  installations,
+  agent,
+  defaultOpen = false,
+  onDirtyChange
+}, ref): React.JSX.Element {
   const [open, setOpen] = useState(defaultOpen)
+  const [openedOnce, setOpenedOnce] = useState(defaultOpen)
+  const settingsRef = useRef<SummaryModelSettingsHandle>(null)
+  useImperativeHandle(ref, () => ({
+    discard(): void {
+      settingsRef.current?.discard()
+    }
+  }), [])
   return (
     <section className="member-section member-advanced-settings">
-      <details open={open} onToggle={(event) => setOpen(event.currentTarget.open)}>
+      <details open={open} onToggle={(event) => {
+        const nextOpen = event.currentTarget.open
+        setOpen(nextOpen)
+        if (nextOpen) setOpenedOnce(true)
+      }}>
         <summary>
           <span>
             <strong>高级设置</strong>
@@ -627,29 +815,20 @@ export function MemberAdvancedSettings({ installations, agent, defaultOpen = fal
           </span>
           <i aria-hidden="true">⌄</i>
         </summary>
-        {open && <SummaryModelSettings installations={installations} agent={agent} />}
+        {openedOnce && (
+          <div hidden={!open}>
+            <SummaryModelSettings
+              ref={settingsRef}
+              installations={installations}
+              agent={agent}
+              onDirtyChange={onDirtyChange}
+            />
+          </div>
+        )}
       </details>
     </section>
   )
-}
-
-function MemberRemovalSection({ agent, busy, onRemove }: {
-  agent: AgentProfile
-  busy: string | null
-  onRemove(trigger: HTMLButtonElement): Promise<void>
-}): React.JSX.Element {
-  return (
-    <section className="member-section member-danger-zone">
-      <div>
-        <h3>移除队员</h3>
-        <p>停止后续参与并从队员管理中隐藏。身份、头像、Agent 运行时和全部历史记录仍会保留。</p>
-      </div>
-      <button className="danger-button" disabled={busy !== null} onClick={(event) => void onRemove(event.currentTarget).catch(() => undefined)}>
-        移除 {agent.displayName}
-      </button>
-    </section>
-  )
-}
+})
 
 const PRODUCT_RUNTIMES: AdapterKind[] = [
   'claude-code-cli',
@@ -663,42 +842,60 @@ const PRODUCT_RUNTIMES: AdapterKind[] = [
   'antigravity-app'
 ]
 
-export function MemberRuntimeForm({ agent, installations, runtimeAvailability, runtimeDiscoveryPending = false, busy, onSave, onClear, onRuntimeEnsure, onRuntimeSelected, onOpenRuntimeSettings }: {
+export type MemberRuntimeFormHandle = {
+  discard(): void
+}
+
+type MemberRuntimeEditorState = {
+  selectedKind: AdapterKind | ''
+  draft: MemberRuntimeDraft | null
+}
+
+export const MemberRuntimeForm = forwardRef<MemberRuntimeFormHandle, {
   agent: AgentProfile
   installations: AdapterInstallation[]
   runtimeAvailability: ProductRuntimeAvailability[]
   runtimeDiscoveryPending?: boolean
   busy: string | null
+  onDirtyChange?(dirty: boolean): void
   onSave(adapterKind: AdapterKind, draft: MemberRuntimeDraft | null): Promise<void>
   onClear(): Promise<void>
   onRuntimeEnsure?(adapterKind: AdapterKind): void
   onRuntimeSelected?(adapterKind: AdapterKind): void
   onOpenRuntimeSettings(): void
-}): React.JSX.Element {
-  const [selectedKind, setSelectedKind] = useState<AdapterKind | ''>(
-    agent.runtimeSelection?.adapterKind ?? ''
+}>(function MemberRuntimeForm({
+  agent,
+  installations,
+  runtimeAvailability,
+  runtimeDiscoveryPending = false,
+  busy,
+  onDirtyChange,
+  onSave,
+  onClear,
+  onRuntimeEnsure,
+  onRuntimeSelected,
+  onOpenRuntimeSettings
+}, ref): React.JSX.Element {
+  const initialStateRef = useRef<MemberRuntimeEditorState | null>(null)
+  if (!initialStateRef.current) initialStateRef.current = runtimeEditorState(agent, installations)
+  const [selectedKind, setSelectedKind] = useState<AdapterKind | ''>(initialStateRef.current.selectedKind)
+  const [draft, setDraft] = useState<MemberRuntimeDraft | null>(initialStateRef.current.draft)
+  const [baselineStateKey, setBaselineStateKey] = useState(
+    () => runtimeEditorStateKey(initialStateRef.current as MemberRuntimeEditorState)
   )
-  const [edited, setEdited] = useState(false)
-  const initialInstallation = selectedKind
-    ? runtimeEditorInstallation(
-        installations,
-        selectedKind,
-        agent.runtimePreference?.installationId
-      )
-    : null
-  const [draft, setDraft] = useState<MemberRuntimeDraft | null>(() => (
-    selectedKind
-      ? runtimeDraftForMember(agent, selectedKind, initialInstallation, true)
-      : null
-  ))
   const [submitError, setSubmitError] = useState<string | null>(null)
+  const [conflict, setConflict] = useState(false)
+  const agentIdRef = useRef(agent.id)
+  const persistedRuntimeKeyRef = useRef(persistedRuntimeKey(agent))
+  const currentStateKey = runtimeEditorStateKey({ selectedKind, draft })
+  const dirty = currentStateKey !== baselineStateKey
   const availability = runtimeAvailability.find((item) => item.runtimeKind === selectedKind) ?? null
   const installation = useMemo(() => (
     selectedKind
       ? runtimeEditorInstallation(
           installations,
           selectedKind,
-          !edited && selectedKind === agent.runtimeSelection?.adapterKind
+          !dirty && selectedKind === agent.runtimeSelection?.adapterKind
             ? agent.runtimePreference?.installationId
             : null
         )
@@ -706,12 +903,11 @@ export function MemberRuntimeForm({ agent, installations, runtimeAvailability, r
   ), [
     agent.runtimePreference?.installationId,
     agent.runtimeSelection?.adapterKind,
-    edited,
+    dirty,
     installations,
     selectedKind
   ])
-  const selectionChanged = selectedKind !== (agent.runtimeSelection?.adapterKind ?? '')
-  const canSave = Boolean(selectedKind) || selectionChanged
+  const canSave = dirty && !conflict
   const runtimeStatus = memberRuntimePresentation(
     agent,
     selectedKind || null,
@@ -722,10 +918,38 @@ export function MemberRuntimeForm({ agent, installations, runtimeAvailability, r
     ?? installation?.snapshot?.reportedVersion
     ?? null
 
+  const resetFromAgent = useCallback((): void => {
+    const next = runtimeEditorState(agent, installations)
+    setSelectedKind(next.selectedKind)
+    setDraft(next.draft)
+    setBaselineStateKey(runtimeEditorStateKey(next))
+    setSubmitError(null)
+    setConflict(false)
+    agentIdRef.current = agent.id
+    persistedRuntimeKeyRef.current = persistedRuntimeKey(agent)
+  }, [agent, installations])
+
+  useImperativeHandle(ref, () => ({ discard: resetFromAgent }), [resetFromAgent])
+
   useEffect(() => {
-    if (edited || !selectedKind) return
-    setDraft(runtimeDraftForMember(agent, selectedKind, installation, true))
-  }, [agent, edited, installation, selectedKind])
+    onDirtyChange?.(dirty)
+  }, [dirty, onDirtyChange])
+
+  useEffect(() => {
+    const nextPersistedKey = persistedRuntimeKey(agent)
+    if (agentIdRef.current !== agent.id) {
+      resetFromAgent()
+      return
+    }
+    if (persistedRuntimeKeyRef.current === nextPersistedKey) return
+    persistedRuntimeKeyRef.current = nextPersistedKey
+    if (dirty) {
+      setConflict(true)
+      setSubmitError('已保存的运行配置在编辑期间发生变化。请重新读取后再编辑，或放弃当前更改。')
+      return
+    }
+    resetFromAgent()
+  }, [agent, dirty, resetFromAgent])
 
   useEffect(() => {
     if (selectedKind) onRuntimeEnsure?.(selectedKind)
@@ -741,23 +965,26 @@ export function MemberRuntimeForm({ agent, installations, runtimeAvailability, r
       } else {
         await onClear()
       }
+      setBaselineStateKey(currentStateKey)
+      setConflict(false)
     } catch (nextError) {
       setSubmitError(errorMessage(nextError))
     }
   }
 
   return (
-    <section className="member-section">
+    <section className="member-section member-runtime-section">
       <div className="member-section-heading">
         <div>
-          <h3>运行配置</h3>
-          <p>只选择 Agent 产品；Rovai 自动发现、验证并维护实际启动入口。</p>
+          <h3>Agent 运行时</h3>
+          <p>选择产品并使用当前能力快照配置模型、参数和该 Agent 运行时的原生权限。</p>
         </div>
       </div>
 
       <form onSubmit={(event) => void submit(event)}>
-        <label className="field-label">Agent 运行时
+        <label className="field-label" htmlFor="member-runtime-select">Agent 运行时
           <select
+            id="member-runtime-select"
             value={selectedKind}
             disabled={busy !== null}
             onChange={(event) => {
@@ -769,8 +996,8 @@ export function MemberRuntimeForm({ agent, installations, runtimeAvailability, r
               setDraft(nextKind
                 ? runtimeDraftForMember(agent, nextKind, nextInstallation, false)
                 : null)
-              setEdited(true)
               setSubmitError(null)
+              setConflict(false)
               if (nextKind) onRuntimeSelected?.(nextKind)
             }}
           >
@@ -815,12 +1042,18 @@ export function MemberRuntimeForm({ agent, installations, runtimeAvailability, r
             disabled={busy !== null}
             onChange={(nextDraft) => {
               setDraft(nextDraft)
-              setEdited(true)
               setSubmitError(null)
             }}
           />
         )}
 
+        {conflict && (
+          <div className="member-runtime-conflict" role="alert">
+            <strong>运行配置已在其他操作中更新</strong>
+            <span>当前草稿没有被覆盖。重新读取会放弃这份草稿，并载入最新保存值。</span>
+            <button className="quiet-button" type="button" onClick={resetFromAgent}>重新读取已保存配置</button>
+          </div>
+        )}
         {submitError && <div className="inline-error">{submitError}</div>}
         <div className="member-form-actions">
           <button className="primary-button" disabled={!canSave || busy !== null}>
@@ -830,6 +1063,34 @@ export function MemberRuntimeForm({ agent, installations, runtimeAvailability, r
       </form>
     </section>
   )
+})
+
+function runtimeEditorState(
+  agent: AgentProfile,
+  installations: AdapterInstallation[]
+): MemberRuntimeEditorState {
+  const selectedKind = agent.runtimeSelection?.adapterKind ?? ''
+  if (!selectedKind) return { selectedKind: '', draft: null }
+  const installation = runtimeEditorInstallation(
+    installations,
+    selectedKind,
+    agent.runtimePreference?.installationId
+  )
+  return {
+    selectedKind,
+    draft: runtimeDraftForMember(agent, selectedKind, installation, true)
+  }
+}
+
+function runtimeEditorStateKey(state: MemberRuntimeEditorState): string {
+  return JSON.stringify(state)
+}
+
+function persistedRuntimeKey(agent: AgentProfile): string {
+  return JSON.stringify({
+    selection: agent.runtimeSelection,
+    preference: agent.runtimePreference
+  })
 }
 
 function MemberIdentityDialog({ open, agent, agents, busy, returnFocusRef, onOpenChange, onSubmit }: {
@@ -1379,10 +1640,6 @@ function CustomRuntimeDialog({ open, busy, onOpenChange, onSubmit }: {
   )
 }
 
-function RuntimeReadinessMark({ status }: { status: RuntimeReadinessStatus }): React.JSX.Element {
-  return <span className={`runtime-readiness-mark readiness-${status}`} aria-label={runtimeReadinessLabel(status)} title={runtimeReadinessLabel(status)}>{status === 'ready' ? '✓' : status === 'runtime_not_configured' ? '○' : '!'}</span>
-}
-
 function RuntimeSnapshotBadge({ installation }: { installation: AdapterInstallation }): React.JSX.Element {
   const snapshot = installation.snapshot
   const ready = installation.enabled && Boolean(snapshot) && !snapshot?.staleAt
@@ -1576,6 +1833,10 @@ function runtimePathPlaceholder(kind: AdapterKind): string {
 
 function memberPresenceLabel(presence: AgentProfile['presence']): string {
   return ({ present: '在队', away: '暂离', removed: '已移除' })[presence]
+}
+
+function closeParentDetails(element: HTMLElement): void {
+  element.closest('details')?.removeAttribute('open')
 }
 
 function runtimeSnapshotSummary(installation: AdapterInstallation): string {

--- a/apps/desktop/src/renderer/src/MemberSidebar.test.ts
+++ b/apps/desktop/src/renderer/src/MemberSidebar.test.ts
@@ -1,0 +1,138 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import type {
+  AdapterKind,
+  AgentProfile,
+  ProductRuntimeAvailability
+} from '@contracts'
+import {
+  MemberSidebar,
+  compactRuntimeState,
+  filterMembers
+} from './MemberSidebar'
+
+describe('v0.29 member sidebar', () => {
+  it('filters only by member name and team role', () => {
+    const agents = [
+      profile('agent-muwa', '沐瓦', '开发者', 'present'),
+      { ...profile('agent-luoke', '洛可', '研究员', 'away'), handle: 'secret-match' }
+    ]
+    expect(filterMembers(agents, '开发')).toEqual([agents[0]])
+    expect(filterMembers(agents, '洛可')).toEqual([agents[1]])
+    expect(filterMembers(agents, 'secret-match')).toEqual([])
+  })
+
+  it('maps Runtime user statuses to four compact projections', () => {
+    expect(compactRuntimeState('available')).toBe('available')
+    expect(compactRuntimeState('unconfigured')).toBe('unconfigured')
+    expect(compactRuntimeState('authentication_required')).toBe('action')
+    expect(compactRuntimeState('checking')).toBe('neutral')
+    expect(compactRuntimeState('unknown')).toBe('neutral')
+  })
+
+  it('shows an accessible Runtime shortcut and enables local filtering at member 21', () => {
+    const agents = Array.from({ length: 21 }, (_, index) => (
+      index === 0
+        ? {
+            ...profile('agent-ready', '沐瓦', '开发者', 'present'),
+            runtimeSelection: { adapterKind: 'codex-cli' as const },
+            runtimeReadiness: { status: 'ready' as const, blockers: [] }
+          }
+        : profile(`agent-${index}`, `队员 ${index}`, index % 2 ? '研究员' : '设计师', 'present')
+    ))
+    const markup = renderToStaticMarkup(createElement(MemberSidebar, {
+      agents,
+      runtimeAvailability: [availability('codex-cli', 'ready')],
+      runtimeDiscoveryPending: false,
+      selectedAgentId: 'agent-ready',
+      onSelect: () => undefined,
+      onCreate: () => undefined,
+      onReload: async () => undefined
+    }))
+
+    expect(markup).toContain('id="member-sidebar-filter"')
+    expect(markup).toContain('placeholder="名称或团队角色"')
+    expect(markup).toContain('沐瓦，Codex CLI，可用；打开运行配置')
+    expect(markup).toContain('runtime-available')
+    expect(markup).toContain('>✓</span>')
+    expect(markup).not.toContain('secret-match')
+  })
+
+  it.each([0, 1, 13, 20, 21, 100])('renders %i active members without virtualization', (count) => {
+    const agents = Array.from({ length: count }, (_, index) => (
+      profile(`agent-${index}`, `队员 ${index}`, '测试角色', index % 3 === 0 ? 'away' : 'present')
+    ))
+    const markup = renderToStaticMarkup(createElement(MemberSidebar, {
+      agents,
+      runtimeAvailability: [],
+      runtimeDiscoveryPending: false,
+      selectedAgentId: agents[0]?.id ?? null,
+      onSelect: () => undefined,
+      onCreate: () => undefined,
+      onReload: async () => undefined
+    }))
+    expect(markup.match(/class="member-sidebar-row/g)?.length ?? 0).toBe(count)
+    expect(markup.includes('id="member-sidebar-filter"')).toBe(count > 20)
+    expect(markup).not.toContain('virtualized')
+    if (count === 0) expect(markup).toContain('还没有队员')
+  })
+})
+
+function profile(
+  id: string,
+  displayName: string,
+  teamRole: string,
+  presence: AgentProfile['presence']
+): AgentProfile {
+  return {
+    id,
+    handle: `${id}-handle`,
+    displayName,
+    avatarRef: null,
+    accent: '#39777a',
+    teamRole,
+    professionalResponsibilities: '',
+    personalityTraits: [],
+    workingPrinciples: '',
+    growthTopic: '',
+    defaultCapabilities: [],
+    presence,
+    runtimeSelection: null,
+    runtimePreference: null,
+    runtimeReadiness: {
+      status: 'runtime_not_configured',
+      blockers: [{ code: 'runtime_not_configured', detail: null }]
+    },
+    memberOrder: 0,
+    version: 1,
+    createdAt: '2026-08-01T00:00:00Z',
+    updatedAt: '2026-08-01T00:00:00Z',
+    removedAt: null
+  }
+}
+
+function availability(
+  runtimeKind: AdapterKind,
+  status: ProductRuntimeAvailability['status']
+): ProductRuntimeAvailability {
+  return {
+    runtimeKind,
+    status,
+    checking: false,
+    discovery: {
+      runtimeKind,
+      discoveryStatus: 'found',
+      executablePath: '/opt/homebrew/bin/runtime',
+      source: 'inherited_path',
+      reportedVersion: 'runtime 1.0.0',
+      executableFingerprint: 'sha256:test',
+      searchGeneration: 1,
+      observedAt: '2026-08-01T00:00:00Z',
+      diagnosticCode: null
+    },
+    installationId: `installation-${runtimeKind}`,
+    reportedVersion: 'runtime 1.0.0',
+    diagnosticCode: null
+  }
+}

--- a/apps/desktop/src/renderer/src/MemberSidebar.tsx
+++ b/apps/desktop/src/renderer/src/MemberSidebar.tsx
@@ -1,0 +1,407 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties
+} from 'react'
+import type {
+  AdapterKind,
+  AgentProfile,
+  ProductRuntimeAvailability,
+  StoredCommandResult
+} from '@contracts'
+import { MemberAvatar } from './MemberAvatar'
+import { localizeExecutionEngineTerms } from './product-copy'
+import {
+  memberRuntimePresentation,
+  type RuntimeUserStatus
+} from './runtime-status'
+import { identityColorToken } from './theme'
+
+export type MemberWorkspaceTab = 'identity' | 'runtime'
+
+export type CompactRuntimeState = 'available' | 'unconfigured' | 'action' | 'neutral'
+
+export function compactRuntimeState(status: RuntimeUserStatus): CompactRuntimeState {
+  if (status === 'available') return 'available'
+  if (status === 'unconfigured') return 'unconfigured'
+  if (status === 'checking' || status === 'unknown') return 'neutral'
+  return 'action'
+}
+
+export function filterMembers(
+  agents: AgentProfile[],
+  query: string
+): AgentProfile[] {
+  const normalized = query.trim().normalize('NFKC').toLocaleLowerCase('zh-CN')
+  const active = agents.filter((agent) => agent.presence !== 'removed' && agent.removedAt === null)
+  if (!normalized) return active
+  return active.filter((agent) => (
+    agent.displayName.normalize('NFKC').toLocaleLowerCase('zh-CN').includes(normalized)
+    || agent.teamRole.normalize('NFKC').toLocaleLowerCase('zh-CN').includes(normalized)
+  ))
+}
+
+export function MemberSidebar({
+  agents,
+  runtimeAvailability,
+  runtimeDiscoveryPending,
+  selectedAgentId,
+  onSelect,
+  onCreate,
+  onReload
+}: {
+  agents: AgentProfile[]
+  runtimeAvailability: ProductRuntimeAvailability[]
+  runtimeDiscoveryPending: boolean
+  selectedAgentId: string | null
+  onSelect(agentId: string, tab: MemberWorkspaceTab, focusRuntime: boolean): void
+  onCreate(trigger: HTMLButtonElement): void
+  onReload(): Promise<void>
+}): React.JSX.Element {
+  const activeAgents = useMemo(
+    () => agents.filter((agent) => agent.presence !== 'removed' && agent.removedAt === null),
+    [agents]
+  )
+  const [query, setQuery] = useState('')
+  const [sorting, setSorting] = useState(false)
+  const [busy, setBusy] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [dragAgentId, setDragAgentId] = useState<string | null>(null)
+  const [dragOverAgentId, setDragOverAgentId] = useState<string | null>(null)
+  const [scrollEdges, setScrollEdges] = useState({ top: false, bottom: false })
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const visibleAgents = useMemo(
+    () => sorting ? activeAgents : filterMembers(activeAgents, query),
+    [activeAgents, query, sorting]
+  )
+  const selectedHidden = Boolean(
+    query.trim()
+    && selectedAgentId
+    && !visibleAgents.some((agent) => agent.id === selectedAgentId)
+  )
+
+  const updateScrollEdges = useCallback((): void => {
+    const element = scrollRef.current
+    if (!element) return
+    setScrollEdges({
+      top: element.scrollTop > 1,
+      bottom: element.scrollTop + element.clientHeight < element.scrollHeight - 1
+    })
+  }, [])
+
+  useEffect(() => {
+    updateScrollEdges()
+    const element = scrollRef.current
+    if (!element || typeof ResizeObserver === 'undefined') return undefined
+    const observer = new ResizeObserver(updateScrollEdges)
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [updateScrollEdges, visibleAgents.length])
+
+  const reorder = async (orderedAgentProfileIds: string[], focusAgentId: string): Promise<void> => {
+    setBusy(focusAgentId)
+    setError(null)
+    try {
+      const result = await window.rovai.request<StoredCommandResult>('agents.reorder', {
+        commandId: crypto.randomUUID(),
+        command: { orderedAgentProfileIds }
+      })
+      assertApplied(result)
+      await onReload()
+      requestAnimationFrame(() => {
+        document.querySelector<HTMLButtonElement>(`[data-member-order-handle="${CSS.escape(focusAgentId)}"]`)?.focus()
+      })
+    } catch (nextError) {
+      setError(errorMessage(nextError))
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const moveMember = (agent: AgentProfile, direction: -1 | 1): void => {
+    const group = activeAgents.filter((candidate) => candidate.presence === agent.presence)
+    const index = group.findIndex((candidate) => candidate.id === agent.id)
+    const target = group[index + direction]
+    if (!target) return
+    const ordered = activeAgents.map((candidate) => candidate.id)
+    const from = ordered.indexOf(agent.id)
+    const to = ordered.indexOf(target.id)
+    ordered.splice(from, 1)
+    ordered.splice(to, 0, agent.id)
+    void reorder(ordered, agent.id)
+  }
+
+  const dropMember = (target: AgentProfile): void => {
+    const sourceId = dragAgentId
+    setDragAgentId(null)
+    setDragOverAgentId(null)
+    if (!sourceId || sourceId === target.id) return
+    const source = activeAgents.find((agent) => agent.id === sourceId)
+    if (!source || source.presence !== target.presence) return
+    const ordered = activeAgents.map((agent) => agent.id)
+    const from = ordered.indexOf(sourceId)
+    const to = ordered.indexOf(target.id)
+    ordered.splice(from, 1)
+    ordered.splice(to, 0, sourceId)
+    void reorder(ordered, sourceId)
+  }
+
+  const toggleSorting = (): void => {
+    setError(null)
+    setSorting((current) => {
+      const next = !current
+      if (next) setQuery('')
+      return next
+    })
+  }
+
+  return (
+    <section className="member-sidebar" aria-label="队员名册">
+      <div className="member-sidebar-heading">
+        <div><strong>队员</strong><span>{activeAgents.length}</span></div>
+        <div className="member-sidebar-actions">
+          {activeAgents.length > 0 && (
+            <button
+              type="button"
+              aria-label={sorting ? '完成调整队员顺序' : '调整队员顺序'}
+              title={sorting ? '完成调整顺序' : '调整顺序'}
+              aria-pressed={sorting}
+              onClick={toggleSorting}
+            >{sorting ? '完成' : '⇅'}</button>
+          )}
+          {activeAgents.length > 0 && (
+            <button
+              type="button"
+              aria-label="新增队员"
+              title="新增队员"
+              onClick={(event) => onCreate(event.currentTarget)}
+            >＋</button>
+          )}
+        </div>
+      </div>
+
+      {activeAgents.length > 20 && !sorting && (
+        <div className="member-sidebar-filter">
+          <label htmlFor="member-sidebar-filter">筛选队员</label>
+          <div>
+            <input
+              id="member-sidebar-filter"
+              type="search"
+              value={query}
+              placeholder="名称或团队角色"
+              onChange={(event) => setQuery(event.target.value)}
+            />
+            {query && <button type="button" aria-label="清除队员筛选" onClick={() => setQuery('')}>×</button>}
+          </div>
+        </div>
+      )}
+
+      {sorting && <p className="member-sidebar-mode-note">拖拽，或聚焦把手后按上、下方向键调整 Member Order。</p>}
+      {selectedHidden && (
+        <p className="member-sidebar-selection-note">当前队员未出现在筛选结果中。<button type="button" onClick={() => setQuery('')}>清除筛选</button></p>
+      )}
+      {error && <div className="member-sidebar-error" role="alert">{error}</div>}
+
+      <div className={`member-sidebar-scroll ${scrollEdges.top ? 'has-top-overflow' : ''} ${scrollEdges.bottom ? 'has-bottom-overflow' : ''}`}>
+        <div ref={scrollRef} className="member-sidebar-scroll-body" onScroll={updateScrollEdges}>
+          {(['present', 'away'] as const).map((presence) => {
+            const group = visibleAgents.filter((agent) => agent.presence === presence)
+            if (group.length === 0) return null
+            const total = activeAgents.filter((agent) => agent.presence === presence).length
+            return (
+              <section className="member-sidebar-group" key={presence} aria-labelledby={`member-group-${presence}`}>
+                <div className="member-sidebar-group-heading" id={`member-group-${presence}`}>
+                  <span>{presence === 'present' ? '在队' : '暂离'}</span><small>{query.trim() ? `${group.length}/${total}` : total}</small>
+                </div>
+                {group.map((agent) => (
+                  <MemberSidebarRow
+                    key={agent.id}
+                    agent={agent}
+                    selected={selectedAgentId === agent.id}
+                    sorting={sorting}
+                    busy={busy !== null}
+                    dragOver={dragOverAgentId === agent.id && dragAgentId !== agent.id}
+                    availability={runtimeAvailability.find((item) => item.runtimeKind === agent.runtimeSelection?.adapterKind) ?? null}
+                    runtimeDiscoveryPending={runtimeDiscoveryPending}
+                    onSelect={onSelect}
+                    onMove={moveMember}
+                    onDragStart={() => setDragAgentId(agent.id)}
+                    onDragOver={() => setDragOverAgentId(agent.id)}
+                    onDragLeave={() => setDragOverAgentId((current) => current === agent.id ? null : current)}
+                    onDrop={() => dropMember(agent)}
+                    onDragEnd={() => {
+                      setDragAgentId(null)
+                      setDragOverAgentId(null)
+                    }}
+                  />
+                ))}
+              </section>
+            )
+          })}
+          {activeAgents.length === 0 && (
+            <div className="member-sidebar-empty">
+              <span aria-hidden="true">◎</span>
+              <strong>还没有队员</strong>
+              <p>创建一个长期身份后，可为其配置 Agent 运行时。</p>
+              <button className="primary-button" type="button" onClick={(event) => onCreate(event.currentTarget)}>新增队员</button>
+            </div>
+          )}
+          {activeAgents.length > 0 && visibleAgents.length === 0 && (
+            <div className="member-sidebar-empty compact">
+              <strong>没有匹配的队员</strong>
+              <button className="quiet-button" type="button" onClick={() => setQuery('')}>清除筛选</button>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function MemberSidebarRow({
+  agent,
+  selected,
+  sorting,
+  busy,
+  dragOver,
+  availability,
+  runtimeDiscoveryPending,
+  onSelect,
+  onMove,
+  onDragStart,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  onDragEnd
+}: {
+  agent: AgentProfile
+  selected: boolean
+  sorting: boolean
+  busy: boolean
+  dragOver: boolean
+  availability: ProductRuntimeAvailability | null
+  runtimeDiscoveryPending: boolean
+  onSelect(agentId: string, tab: MemberWorkspaceTab, focusRuntime: boolean): void
+  onMove(agent: AgentProfile, direction: -1 | 1): void
+  onDragStart(): void
+  onDragOver(): void
+  onDragLeave(): void
+  onDrop(): void
+  onDragEnd(): void
+}): React.JSX.Element {
+  const runtime = memberRuntimePresentation(
+    agent,
+    agent.runtimeSelection?.adapterKind ?? null,
+    availability,
+    runtimeDiscoveryPending
+  )
+  const compact = compactRuntimeState(runtime.status)
+  const product = agent.runtimeSelection?.adapterKind
+    ? adapterLabel(agent.runtimeSelection.adapterKind)
+    : 'Agent 运行时'
+  const runtimeLabel = `${agent.displayName}，${product}，${runtime.label}；打开运行配置`
+  return (
+    <div
+      className={`member-sidebar-row ${selected ? 'selected' : ''} ${dragOver ? 'drag-over' : ''}`}
+      draggable={sorting && !busy}
+      onDragStart={(event) => {
+        if (!sorting) return
+        event.dataTransfer.effectAllowed = 'move'
+        onDragStart()
+      }}
+      onDragOver={(event) => {
+        if (!sorting) return
+        event.preventDefault()
+        onDragOver()
+      }}
+      onDragLeave={onDragLeave}
+      onDrop={(event) => {
+        if (!sorting) return
+        event.preventDefault()
+        onDrop()
+      }}
+      onDragEnd={onDragEnd}
+      style={{ '--agent-accent': identityColorToken(agent.id) } as CSSProperties}
+    >
+      <button
+        className="member-sidebar-select"
+        type="button"
+        aria-current={selected ? 'true' : undefined}
+        title={`${agent.displayName} · ${agent.teamRole || '团队角色未设置'}`}
+        onClick={() => onSelect(agent.id, 'identity', false)}
+      >
+        <span className="member-sidebar-accent" aria-hidden="true" />
+        <MemberAvatar
+          agentProfileId={agent.id}
+          avatarRef={agent.avatarRef}
+          displayName={agent.displayName}
+          size="list"
+          decorative
+        />
+        <span className="member-sidebar-copy">
+          <strong>{agent.displayName}</strong>
+          <small>{agent.teamRole || '团队角色未设置'}</small>
+        </span>
+      </button>
+      {sorting
+        ? (
+            <button
+              className="member-order-handle"
+              type="button"
+              data-member-order-handle={agent.id}
+              aria-label={`调整 ${agent.displayName} 的顺序；上、下方向键移动`}
+              title="拖拽；聚焦后按上、下方向键移动"
+              disabled={busy}
+              onKeyDown={(event) => {
+                if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return
+                event.preventDefault()
+                onMove(agent, event.key === 'ArrowUp' ? -1 : 1)
+              }}
+            >⋮⋮</button>
+          )
+        : (
+            <button
+              className={`member-runtime-shortcut runtime-${compact}`}
+              type="button"
+              aria-label={runtimeLabel}
+              title={`${product} · ${runtime.label}${runtime.detail ? ` · ${runtime.detail}` : ''}`}
+              data-tooltip={`${product} · ${runtime.label}${runtime.detail ? ` · ${runtime.detail}` : ''}`}
+              onClick={() => onSelect(agent.id, 'runtime', true)}
+            >
+              <span aria-hidden="true">{compact === 'available' ? '✓' : compact === 'unconfigured' ? '○' : compact === 'action' ? '!' : '…'}</span>
+            </button>
+          )}
+    </div>
+  )
+}
+
+function adapterLabel(kind: AdapterKind): string {
+  return ({
+    'codex-cli': 'Codex CLI',
+    'opencode-cli': 'OpenCode',
+    'copilot-cli': 'GitHub Copilot',
+    'claude-code-cli': 'Claude Code',
+    'kiro-cli': 'Kiro',
+    'qoder-cli': 'Qoder',
+    'codebuddy-cli': 'CodeBuddy',
+    'qwen-code': 'Qwen Code',
+    'antigravity-app': 'Antigravity'
+  })[kind]
+}
+
+function assertApplied(result: StoredCommandResult): void {
+  if (result.status !== 'rejected') return
+  const detail = typeof result.payload.message === 'string'
+    ? result.payload.message
+    : typeof result.payload.detail === 'string'
+      ? result.payload.detail
+      : null
+  throw new Error(detail ?? `Core 拒绝了排序：${result.code}`)
+}
+
+function errorMessage(error: unknown): string {
+  return localizeExecutionEngineTerms(error instanceof Error ? error.message : String(error))
+}

--- a/apps/desktop/src/renderer/src/SummaryModelSettings.tsx
+++ b/apps/desktop/src/renderer/src/SummaryModelSettings.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useMemo, useState, type FormEvent } from 'react'
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent
+} from 'react'
 import type {
   AdapterInstallation,
   AgentProfile,
@@ -26,14 +34,24 @@ export async function saveSummaryModelConfig(
   )
 }
 
-export function SummaryModelSettings({ installations, agent }: {
+export type SummaryModelSettingsHandle = {
+  discard(): void
+}
+
+export const SummaryModelSettings = forwardRef<SummaryModelSettingsHandle, {
   installations: AdapterInstallation[]
   agent: AgentProfile
-}): React.JSX.Element {
+  onDirtyChange?(dirty: boolean): void
+}>(function SummaryModelSettings({ installations, agent, onDirtyChange }, ref): React.JSX.Element {
   const [config, setConfig] = useState<ContextSummaryModelConfig | null>(null)
   const [modelId, setModelId] = useState(UNSELECTED_MODEL)
+  const [baselineModelId, setBaselineModelId] = useState(UNSELECTED_MODEL)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [sourceConflict, setSourceConflict] = useState(false)
+  const [reloadSignal, setReloadSignal] = useState(0)
+  const dirtyRef = useRef(false)
+  const loadedRuntimeInstallationIdRef = useRef<string | null | undefined>(undefined)
   const runtimeInstallationId = agent.runtimePreference?.installationId ?? null
   const installation = installations.find(
     (candidate) => candidate.id === runtimeInstallationId
@@ -47,24 +65,54 @@ export function SummaryModelSettings({ installations, agent }: {
     && installation.snapshot
     && !installation.snapshot.staleAt
   )
+  const dirty = config !== null && modelId !== baselineModelId
+  dirtyRef.current = dirty
+
+  useImperativeHandle(ref, () => ({
+    discard(): void {
+      dirtyRef.current = false
+      setModelId(baselineModelId)
+      setError(null)
+      setSourceConflict(false)
+      setReloadSignal((signal) => signal + 1)
+    }
+  }), [baselineModelId])
 
   useEffect(() => {
+    onDirtyChange?.(dirty)
+  }, [dirty, onDirtyChange])
+
+  useEffect(() => {
+    if (
+      loadedRuntimeInstallationIdRef.current !== undefined
+      && loadedRuntimeInstallationIdRef.current !== runtimeInstallationId
+      && dirtyRef.current
+    ) {
+      setSourceConflict(true)
+      setError('当前队员的 Agent 运行时已变化。摘要模型草稿仍被保留；请放弃草稿并重新读取后再保存。')
+      return undefined
+    }
     let cancelled = false
     setError(null)
+    setSourceConflict(false)
     void loadSummaryModelConfig()
       .then((nextConfig) => {
         if (cancelled) return
-        applyConfig(nextConfig, runtimeInstallationId, setConfig, setModelId)
+        const nextModelId = modelIdForConfig(nextConfig, runtimeInstallationId)
+        loadedRuntimeInstallationIdRef.current = runtimeInstallationId
+        setConfig(nextConfig)
+        setModelId(nextModelId)
+        setBaselineModelId(nextModelId)
       })
       .catch((nextError) => {
         if (!cancelled) setError(errorMessage(nextError))
       })
     return () => { cancelled = true }
-  }, [runtimeInstallationId])
+  }, [reloadSignal, runtimeInstallationId])
 
   const save = async (event: FormEvent): Promise<void> => {
     event.preventDefault()
-    if (!config) return
+    if (!config || sourceConflict) return
     if (modelId === UNSELECTED_MODEL || modelId === OTHER_MEMBER_SELECTION) return
     setBusy(true)
     setError(null)
@@ -85,7 +133,10 @@ export function SummaryModelSettings({ installations, agent }: {
           }
       const preference: ContextSummaryModelPreference = { installationId: installation.id, model }
       const nextConfig = await saveSummaryModelConfig(config, preference)
-      applyConfig(nextConfig, runtimeInstallationId, setConfig, setModelId)
+      const nextModelId = modelIdForConfig(nextConfig, runtimeInstallationId)
+      setConfig(nextConfig)
+      setModelId(nextModelId)
+      setBaselineModelId(nextModelId)
     } catch (nextError) {
       setError(errorMessage(nextError))
     } finally {
@@ -105,7 +156,7 @@ export function SummaryModelSettings({ installations, agent }: {
         <form className="summary-model-settings-form" onSubmit={(event) => void save(event)}>
           <label className="field-label">
             模型
-            <select value={modelId} disabled={busy} onChange={(event) => setModelId(event.target.value)}>
+            <select value={modelId} disabled={busy || sourceConflict} onChange={(event) => setModelId(event.target.value)}>
               <option value={UNSELECTED_MODEL} disabled>选择模型</option>
               {selectedOtherMemberRuntime && (
                 <option value={OTHER_MEMBER_SELECTION}>当前配置来自其他队员；请选择后替换</option>
@@ -116,7 +167,7 @@ export function SummaryModelSettings({ installations, agent }: {
           </label>
           <div className="dialog-actions">
             {config.updatedAt && <span>最近更新 {formatTime(config.updatedAt)}</span>}
-            <button className="primary-button" disabled={busy || !runtimeReady || modelId === UNSELECTED_MODEL || selectedOtherMemberRuntime}>
+            <button className="primary-button" disabled={busy || sourceConflict || !runtimeReady || modelId === UNSELECTED_MODEL || selectedOtherMemberRuntime}>
               {busy ? '正在保存…' : '保存摘要模型'}
             </button>
           </div>
@@ -125,28 +176,21 @@ export function SummaryModelSettings({ installations, agent }: {
       {error && <div className="inline-error" role="alert">{error}</div>}
     </div>
   )
-}
+})
 
-function applyConfig(
+function modelIdForConfig(
   config: ContextSummaryModelConfig,
-  runtimeInstallationId: string | null,
-  setConfig: (config: ContextSummaryModelConfig) => void,
-  setModelId: (modelId: string) => void
-): void {
-  setConfig(config)
+  runtimeInstallationId: string | null
+): string {
   if (!config.preference) {
-    setModelId(UNSELECTED_MODEL)
-    return
+    return UNSELECTED_MODEL
   }
   if (config.preference.installationId !== runtimeInstallationId) {
-    setModelId(OTHER_MEMBER_SELECTION)
-    return
+    return OTHER_MEMBER_SELECTION
   }
-  setModelId(
-    config.preference?.model.mode === 'explicit'
-      ? config.preference.model.modelId
-      : RUNTIME_DEFAULT
-  )
+  return config.preference.model.mode === 'explicit'
+    ? config.preference.model.modelId
+    : RUNTIME_DEFAULT
 }
 
 function formatTime(value: string): string {

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -89,6 +89,7 @@
   --lightbox-shadow: 0 28px 80px rgb(0 0 0 / 42%);
   --member-avatar-size: 32px;
   --member-avatar-accent: var(--identity-1);
+  --identity-clamp-lines: 3;
 
 }
 
@@ -2457,6 +2458,335 @@ label.new-camp-mode-card { cursor: pointer; }
 .member-runtime-empty { display: flex; gap: 12px; align-items: center; justify-content: space-between; margin-top: 12px; text-align: left; }
 .member-runtime-empty span { line-height: 1.5; }
 .member-runtime-empty button { flex: 0 0 auto; }
+
+/* v0.29 Member workbench */
+.member-sidebar {
+  display: flex;
+  min-height: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+  margin: 0 -2px;
+  border-top: 1px solid var(--line);
+}
+.member-sidebar-heading {
+  display: flex;
+  min-height: 42px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 7px 4px 6px 8px;
+}
+.member-sidebar-heading > div:first-child { display: flex; min-width: 0; align-items: baseline; gap: 7px; }
+.member-sidebar-heading strong { font-size: 12px; }
+.member-sidebar-heading span { color: var(--faint); font: 600 10px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace; }
+.member-sidebar-actions { display: flex; flex: 0 0 auto; gap: 2px; }
+.member-sidebar-actions button,
+.member-sidebar-filter button {
+  display: grid;
+  min-width: 28px;
+  height: 28px;
+  place-items: center;
+  padding: 0 5px;
+  border: 0;
+  border-radius: 6px;
+  color: var(--muted);
+  background: transparent;
+  cursor: pointer;
+  font-size: 12px;
+}
+.member-sidebar-actions button:hover,
+.member-sidebar-filter button:hover { color: var(--ink); background: var(--surface-muted); }
+.member-sidebar-actions button[aria-pressed="true"] { color: var(--brand-ink); background: var(--brand-soft); }
+.member-sidebar-filter { flex: 0 0 auto; padding: 0 5px 7px; }
+.member-sidebar-filter > label { display: block; margin: 0 4px 4px; color: var(--faint); font-size: 9px; font-weight: 750; letter-spacing: .05em; }
+.member-sidebar-filter > div { position: relative; }
+.member-sidebar-filter input {
+  width: 100%;
+  height: 32px;
+  padding: 5px 31px 5px 9px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  outline: 0;
+  color: var(--ink);
+  background: var(--surface);
+  font-size: 11px;
+}
+.member-sidebar-filter input:focus { border-color: var(--focus); box-shadow: 0 0 0 2px var(--focus-soft); }
+.member-sidebar-filter button { position: absolute; top: 2px; right: 2px; }
+.member-sidebar-mode-note,
+.member-sidebar-selection-note,
+.member-sidebar-error {
+  flex: 0 0 auto;
+  margin: 0 5px 7px;
+  padding: 7px 8px;
+  border-radius: 6px;
+  color: var(--muted);
+  background: var(--surface-muted);
+  font-size: 9.5px;
+  line-height: 1.45;
+}
+.member-sidebar-selection-note button { margin-left: 4px; padding: 0; border: 0; color: var(--brand-ink); background: transparent; cursor: pointer; font-weight: 700; }
+.member-sidebar-error { border-left: 3px solid var(--danger); color: var(--danger); background: var(--danger-soft); }
+.member-sidebar-scroll { position: relative; min-height: 0; flex: 1 1 auto; }
+.member-sidebar-scroll::before,
+.member-sidebar-scroll::after {
+  position: absolute;
+  z-index: 4;
+  right: 4px;
+  left: 4px;
+  height: 14px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 120ms ease;
+  content: "";
+}
+.member-sidebar-scroll::before { top: 0; background: linear-gradient(var(--rail), transparent); }
+.member-sidebar-scroll::after { bottom: 0; background: linear-gradient(transparent, var(--rail)); }
+.member-sidebar-scroll.has-top-overflow::before,
+.member-sidebar-scroll.has-bottom-overflow::after { opacity: 1; }
+.member-sidebar-scroll-body {
+  height: 100%;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 0 4px 12px;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+}
+.member-sidebar-group + .member-sidebar-group { margin-top: 7px; }
+.member-sidebar-group-heading {
+  position: sticky;
+  z-index: 3;
+  top: 0;
+  display: flex;
+  min-height: 27px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 7px;
+  color: var(--faint);
+  background: color-mix(in srgb, var(--rail) 94%, transparent);
+  backdrop-filter: blur(5px);
+  font-size: 9.5px;
+  font-weight: 750;
+  letter-spacing: .05em;
+}
+.member-sidebar-group-heading small { font: 600 9px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace; }
+.member-sidebar-row {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  min-height: 50px;
+  align-items: stretch;
+  border-radius: 7px;
+}
+.member-sidebar-row:hover { background: var(--surface-muted); }
+.member-sidebar-row.selected { background: var(--brand-soft); }
+.member-sidebar-row.drag-over { box-shadow: inset 0 2px 0 var(--brand); }
+.member-sidebar-select {
+  display: grid;
+  min-width: 0;
+  flex: 1 1 auto;
+  grid-template-columns: 3px 32px minmax(0, 1fr);
+  gap: 8px;
+  align-items: center;
+  padding: 6px 4px;
+  border: 0;
+  border-radius: 7px 0 0 7px;
+  color: var(--ink);
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+}
+.member-sidebar-accent { align-self: stretch; border-radius: 3px; background: var(--agent-accent); }
+.member-sidebar-copy { display: grid; min-width: 0; gap: 3px; }
+.member-sidebar-copy strong,
+.member-sidebar-copy small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.member-sidebar-copy strong { font-size: 11.5px; }
+.member-sidebar-row.selected .member-sidebar-copy strong { color: var(--brand-ink); }
+.member-sidebar-copy small { color: var(--muted); font-size: 9.5px; }
+.member-runtime-shortcut,
+.member-order-handle {
+  display: grid;
+  width: 30px;
+  min-width: 30px;
+  min-height: 30px;
+  align-self: center;
+  place-items: center;
+  margin-right: 3px;
+  padding: 0;
+  border: 0;
+  border-radius: 7px;
+  color: var(--neutral);
+  background: transparent;
+  cursor: pointer;
+}
+.member-runtime-shortcut:hover,
+.member-order-handle:hover { background: color-mix(in srgb, currentColor 10%, transparent); }
+.member-runtime-shortcut > span {
+  display: grid;
+  width: 20px;
+  height: 20px;
+  place-items: center;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  font: 800 10px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+.member-runtime-shortcut::after {
+  position: absolute;
+  z-index: 12;
+  right: 3px;
+  top: calc(100% + 2px);
+  display: none;
+  width: 218px;
+  padding: 6px 8px;
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  color: var(--ink);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-menu);
+  content: attr(data-tooltip);
+  font: 10px/1.45 -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+  letter-spacing: 0;
+  text-align: left;
+}
+.member-runtime-shortcut:hover::after,
+.member-runtime-shortcut:focus-visible::after { display: block; }
+.member-runtime-shortcut.runtime-available { color: var(--success); }
+.member-runtime-shortcut.runtime-action { color: var(--attention); }
+.member-runtime-shortcut.runtime-neutral { color: var(--info); }
+.member-order-handle { color: var(--muted); cursor: grab; font-size: 10px; letter-spacing: -1px; }
+.member-sidebar-empty { display: grid; min-height: 210px; place-content: center; justify-items: center; padding: 18px 12px; text-align: center; }
+.member-sidebar-empty > span { color: var(--brand); font-size: 26px; }
+.member-sidebar-empty strong { margin-top: 8px; font-size: 12px; }
+.member-sidebar-empty p { margin: 5px 0 12px; color: var(--muted); font-size: 10px; line-height: 1.5; }
+.member-sidebar-empty.compact { min-height: 140px; }
+
+.content.members-content {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
+  padding: 0;
+}
+.content.members-content > * { width: 100%; max-width: none; margin: 0; }
+.members-view { position: relative; display: flex; min-height: 0; flex: 1 1 auto; flex-direction: column; background: var(--surface); }
+.members-view > .member-page-error { flex: 0 0 auto; margin: 10px 24px 0; }
+.member-detail-scroll {
+  min-height: 0;
+  flex: 1 1 auto;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 22px 32px 52px;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+}
+.member-detail-header {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--line);
+}
+.member-detail-heading { display: flex; min-width: 0; align-items: center; gap: 13px; }
+.member-detail-avatar { --member-avatar-size: 50px; }
+.member-detail-heading > div { min-width: 0; }
+.member-detail-heading h2 { margin: 0; overflow: hidden; font-size: 20px; letter-spacing: -.02em; text-overflow: ellipsis; white-space: nowrap; }
+.member-detail-heading p { margin: 3px 0 0; overflow: hidden; color: var(--muted); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
+.member-detail-statuses { display: flex; min-width: 0; flex-wrap: wrap; gap: 6px; align-items: center; margin-top: 7px; }
+.member-detail-statuses > span { padding: 2px 6px; border-radius: 5px; color: var(--muted); background: var(--surface-muted); font-size: 9.5px; font-weight: 700; }
+.member-header-runtime {
+  display: inline-flex;
+  min-width: 0;
+  min-height: 28px;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 7px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--muted);
+  background: var(--surface-subtle);
+  cursor: pointer;
+  font-size: 9.5px;
+}
+.member-header-runtime i { width: 6px; height: 6px; flex: 0 0 auto; border-radius: 50%; background: currentColor; }
+.member-header-runtime span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.member-header-runtime strong { flex: 0 0 auto; }
+.member-header-runtime.status-available { color: var(--success); }
+.member-header-runtime.status-authentication_required,
+.member-header-runtime.status-version_unsupported,
+.member-header-runtime.status-unavailable { color: var(--attention); }
+.member-header-runtime.status-checking,
+.member-header-runtime.status-unknown { color: var(--info); }
+.member-detail-actions { display: flex; flex: 0 0 auto; align-items: center; gap: 6px; }
+.member-detail-menu { position: relative; }
+.member-detail-menu > summary {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  color: var(--muted);
+  background: var(--surface);
+  cursor: pointer;
+  font-size: 11px;
+  letter-spacing: -.08em;
+  list-style: none;
+}
+.member-detail-menu > summary::-webkit-details-marker { display: none; }
+.member-detail-menu > div {
+  position: absolute;
+  z-index: 20;
+  top: 36px;
+  right: 0;
+  display: grid;
+  width: 156px;
+  padding: 4px;
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-menu);
+}
+.member-detail-menu button { min-height: 32px; padding: 6px 8px; border: 0; border-radius: 5px; background: transparent; cursor: pointer; font-size: 11px; text-align: left; }
+.member-detail-menu button:hover { background: var(--surface-muted); }
+.member-detail-menu .danger-menu-item { color: var(--danger); }
+.member-tabs { display: flex; gap: 20px; min-height: 48px; align-items: end; border-bottom: 1px solid var(--line); }
+.member-tabs button {
+  position: relative;
+  min-height: 42px;
+  padding: 8px 2px;
+  border: 0;
+  color: var(--muted);
+  background: transparent;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 700;
+}
+.member-tabs button[aria-selected="true"] { color: var(--brand-ink); }
+.member-tabs button[aria-selected="true"]::after { position: absolute; right: 0; bottom: -1px; left: 0; height: 2px; border-radius: 2px; background: var(--brand); content: ""; }
+.member-detail-scroll [role="tabpanel"] { min-width: 0; }
+.member-identity-section { padding-top: 20px; }
+.member-identity-overview { grid-template-columns: minmax(0, 1fr) 288px; gap: 28px; }
+.member-identity-copy { min-height: 360px; }
+.member-identity-appearance { justify-items: end; }
+.member-identity-appearance .member-portrait { width: 288px; max-width: 100%; height: 360px; aspect-ratio: 4 / 5; }
+.member-identity-field:first-child { margin-top: 0; }
+.member-identity-clamp { position: relative; overflow: hidden; line-height: 1.6; }
+.member-identity-clamp:not(.expanded) { max-height: calc(var(--identity-clamp-lines) * 1.6em); }
+.member-identity-clamp.expanded { overflow: visible; }
+.member-identity-clamp .member-role-description { margin-top: 5px; }
+.member-identity-expand { min-height: 28px; margin: 4px 0 0; padding: 3px 0; border: 0; color: var(--brand-ink); background: transparent; cursor: pointer; font-size: 10px; font-weight: 700; }
+.member-runtime-intro { max-width: 760px; margin: 18px 0 0; color: var(--muted); font-size: 11.5px; line-height: 1.6; }
+.member-runtime-section { padding-top: 14px; }
+.member-runtime-conflict { display: grid; gap: 5px; margin-top: 12px; padding: 10px 12px; border-left: 3px solid var(--attention); color: var(--attention); background: var(--attention-soft); }
+.member-runtime-conflict strong { font-size: 12px; }
+.member-runtime-conflict span { font-size: 10.5px; line-height: 1.5; }
+.member-runtime-conflict button { width: fit-content; margin-top: 3px; }
+.member-leave-dialog { width: min(500px, calc(100vw - 48px)); }
 .runtime-installation-list { display: grid; border-top: 1px solid var(--line); }
 .runtime-installation-row { display: grid; grid-template-columns: minmax(260px, 1.4fr) minmax(220px, 0.8fr) auto; gap: 16px; align-items: center; padding: 13px 2px; border-bottom: 1px solid var(--line); }
 .runtime-installation-row.disabled { opacity: 0.72; }
@@ -2648,6 +2978,13 @@ label.new-camp-mode-card { cursor: pointer; }
   .runtime-installation-row { grid-template-columns: minmax(0, 1fr); gap: 10px; }
   .runtime-installation-row dl, .runtime-row-actions { grid-column: 1; grid-row: auto; }
   .runtime-row-actions { justify-content: flex-start; }
+  .member-detail-scroll { padding-right: 16px; padding-left: 16px; }
+  .member-detail-header { align-items: flex-start; flex-direction: column; gap: 12px; }
+  .member-detail-actions { align-self: stretch; justify-content: flex-end; }
+  .member-identity-overview { grid-template-columns: minmax(0, 1fr); }
+  .member-identity-copy { min-height: 0; }
+  .member-identity-appearance { justify-items: start; }
+  .runtime-parameter-form { grid-template-columns: minmax(0, 1fr); }
 }
 
 @media (max-width: 760px) {
@@ -2684,6 +3021,7 @@ label.new-camp-mode-card { cursor: pointer; }
 
 @media (max-width: 760px) {
   .member-dialog { width: calc(100vw - 24px); }
+  .member-identity-overview { grid-template-columns: minmax(0, 1fr); }
   .member-editor-layout { grid-template-columns: minmax(0, 1fr); }
   .member-avatar-editor { padding-right: 0; padding-bottom: 18px; border-right: 0; border-bottom: 1px solid var(--line); }
   .member-form-grid { grid-template-columns: minmax(0, 1fr); }
@@ -2699,11 +3037,16 @@ label.new-camp-mode-card { cursor: pointer; }
 @media (forced-colors: active) {
   .member-avatar,
   .member-portrait,
-  .member-preset-card {
+  .member-preset-card,
+  .member-runtime-shortcut > span,
+  .member-header-runtime,
+  .member-tabs button[aria-selected="true"] {
     border-color: CanvasText;
   }
   .member-preset-card.selected {
     outline: 2px solid Highlight;
     outline-offset: -2px;
   }
+  .member-sidebar-row.selected,
+  .member-tabs button[aria-selected="true"] { outline: 2px solid Highlight; outline-offset: -2px; }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 ---
 document_type: documentation-index
 authority: documentation-routing
-current_version: v0.28
+current_version: v0.29
 last_updated: 2026-08-01
 ---
 
@@ -14,7 +14,7 @@ last_updated: 2026-08-01
 | 任务 | 必读资料 |
 |---|---|
 | 判断长期架构约束或修改领域、持久化、安全、Runtime 边界 | [ADR 索引](adr/README.md)及相关有效 ADR |
-| 判断当前版本目标、范围、进度或验收口径 | [当前版本 v0.28](versions/v0.28/README.md)及[实施计划](versions/v0.28/implementation-plan.md) |
+| 判断当前版本目标、范围、进度或验收口径 | [当前版本 v0.29](versions/v0.29/README.md)及[实施计划](versions/v0.29/implementation-plan.md) |
 | 查询已接入与候选 Agent Runtime 的实测兼容性 | [Runtime 兼容性清单](runtime-compatibility.md) |
 | 理解历史设计与演进原因 | [版本索引](versions/README.md)及对应历史版本；历史内容不能作为当前约束 |
 | 修改 Renderer UI/UX | [UI 规范索引](ui/README.md)；修改当前 Arctic Dawn Renderer 时继续读取[Arctic Dawn V3 设计规范](ui/arctic-dawn.md) |

--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -3,8 +3,8 @@ document_type: ui-style-index
 authority: renderer-ui
 status: accepted
 design_direction: arctic-dawn-v3
-target_version: v0.28
-implementation_status: current_version_complete
+target_version: v0.29
+implementation_status: complete
 last_updated: 2026-08-01
 ---
 
@@ -12,8 +12,8 @@ last_updated: 2026-08-01
 
 本文是 Renderer UI/UX 工作的稳定入口。当前唯一视觉与交互详规是
 [Arctic Dawn V3](arctic-dawn.md)；版本范围、实施门禁和验收见
-[v0.28](../versions/v0.28/README.md)及其
-[实施计划](../versions/v0.28/implementation-plan.md)。
+[v0.29](../versions/v0.29/README.md)及其
+[实施计划](../versions/v0.29/implementation-plan.md)。
 
 Arctic Dawn 设计文档已经冻结；用户已于 2026-07-30 明确授权生产实现。首轮范围及
 随后确认的导航、设置覆盖与空 Camp 欢迎状态均已通过本地自动化与打包 App 验收；
@@ -31,12 +31,16 @@ v0.28 在同一 Arctic Dawn App Shell 中增加持久应用内通知入口、右
 [v0.28 生产设计](../versions/v0.28/production-design.md)；设计已经确认并冻结，用户已授权
 实施，生产代码与打包 App 验收已经完成；精确证据仍以版本实施计划为准。
 
+v0.29 队员工作台信息架构已经形成共同理解、冻结并完成生产实施。版本级变更以
+[v0.29 生产设计](../versions/v0.29/production-design.md)为准；本文未被替代的部分继续遵守
+Arctic Dawn V3。实施与验收状态见[v0.29 实施计划](../versions/v0.29/implementation-plan.md)。
+
 ## 权威边界
 
 1. 有效 ADR、`CONTEXT.md`、Core 合同和安全边界决定领域语义与可执行行为。
 2. [Arctic Dawn V3](arctic-dawn.md)决定 Renderer 信息架构、视觉 Token、组件层级、
    产品文案、交互和适配。
-3. [v0.28](../versions/v0.28/README.md)决定当前版本范围；实施状态只能从代码、测试和
+3. [v0.29](../versions/v0.29/README.md)决定当前版本范围；实施状态只能从代码、测试和
    版本验收证据判断。
 4. 原型与 HTML 样例只帮助评审视觉层级，不是生产合同、数据真源或可直接复制的代码。
 

--- a/docs/versions/README.md
+++ b/docs/versions/README.md
@@ -1,7 +1,7 @@
 ---
 document_type: versions-index
 authority: version-lifecycle
-current_version: v0.28
+current_version: v0.29
 last_updated: 2026-08-01
 ---
 
@@ -48,4 +48,5 @@ last_updated: 2026-08-01
 | v0.25 | `historical` | 持久 Camp Composer Draft 与稳定公共附件路径 | [v0.25/README.md](v0.25/README.md) |
 | v0.26 | `historical` | 队员级模型、Runtime 原生权限与后台可用性检查 | [v0.26/README.md](v0.26/README.md) |
 | v0.27 | `historical` | 伙伴身份六字段、内置队员身份与外观更新 | [v0.27/README.md](v0.27/README.md) |
-| v0.28 | `current` | 已完成的持久应用内通知中心与注意事项呈现 | [v0.28/README.md](v0.28/README.md) |
+| v0.28 | `historical` | 已完成的持久应用内通知中心与注意事项呈现 | [v0.28/README.md](v0.28/README.md) |
+| v0.29 | `current` | 已完成的队员工作台信息架构、上下文名册与运行配置入口 | [v0.29/README.md](v0.29/README.md) |

--- a/docs/versions/v0.24/implementation-plan.md
+++ b/docs/versions/v0.24/implementation-plan.md
@@ -1,7 +1,7 @@
 ---
 document_type: implementation-plan
 version: v0.24
-lifecycle: current
+lifecycle: historical
 authority: implementation-plan-and-acceptance
 design_status: frozen
 implementation_status: complete

--- a/docs/versions/v0.28/README.md
+++ b/docs/versions/v0.28/README.md
@@ -1,7 +1,7 @@
 ---
 document_type: version-overview
 version: v0.28
-lifecycle: current
+lifecycle: historical
 authority: version-scope-and-status
 design_status: frozen
 implementation_status: complete

--- a/docs/versions/v0.29/README.md
+++ b/docs/versions/v0.29/README.md
@@ -1,0 +1,64 @@
+---
+document_type: version-overview
+version: v0.29
+lifecycle: current
+authority: version-scope-and-status
+design_status: frozen
+implementation_status: complete
+last_updated: 2026-08-01
+---
+
+# Rovai-ai v0.29 队员工作台信息架构
+
+> 状态：生产设计与验收矩阵已冻结；Renderer 实施与隔离桌面验收已完成
+>
+> 前置版本：[v0.28 In-App Notifications](../v0.28/README.md)
+>
+> 生产设计：[production-design.md](production-design.md)
+>
+> 实施门禁：[implementation-plan.md](implementation-plan.md)
+
+## 版本意图
+
+重新组织队员页的名册、身份与运行配置入口，使大量队员仍可高效浏览，同时保留
+Agent Runtime 原生字段、六字段身份、独立保存边界与 Arctic Dawn 的可访问性合同。
+
+## 已确认范围
+
+- 进入“队员”一级页后，统一侧栏中部切换为队员名册，不再同时显示“置顶 / 项目”。
+- 页面主内容不再保留第二份独立名册；右侧空间用于当前队员详情。
+- 品牌、全局一级入口、“跳转到对话…”和底部设置保持固定。
+- 离开队员页后，侧栏中部恢复对应页面的普通导航投影。
+- 当前队员详情使用互斥的“身份 / 运行配置”两个顶层 Tab，不再把两个工作区纵向堆叠。
+- 未保存的运行配置草稿只属于当前队员；同一队员切换 Tab 时保留，切换队员或离开
+  队员页前必须显式继续编辑或放弃更改。
+- Member Order 继续可编辑；侧栏名册通过专门排序模式提供拖拽和等价键盘移动，不把
+  排序把手与运行状态快捷入口长期挤在同一行。
+- 普通产品界面统一使用“Agent 运行时”，队员详情区域使用“运行配置”；不再使用
+  “执行引擎”作为同一概念的别名。
+- 名册 Runtime 快捷入口使用四类紧凑投影：可用、未配置、需要处理和中性检查/未知；
+  不把生产状态强行压缩成 A3 的三个符号。
+- 本版本是 Renderer 信息架构改造，不新增 Migration，也不改变 SQLite、Core、IPC/
+  Contracts 或 Runtime Adapter 合同。
+- 名册以 100 位未移除队员为 v0.29 验收上限；超过 20 位时提供本地名称/团队角色筛选，
+  不引入分页、虚拟列表或 Core 搜索。
+
+## 当前边界
+
+- A3 HTML 是必须实际打开并交互核对的设计输入，不是生产字段、组件或静态数据真源。
+- 未被本版本明确替代的 Renderer 规则继续遵守
+  [Arctic Dawn V3](../../ui/arctic-dawn.md)。
+- Runtime、模型与原生权限继续遵守 [ADR-0082](../../adr/0082-member-owned-runtime-parameters.md)。
+- 六字段身份与独立保存边界继续遵守 [ADR-0085](../../adr/0085-run-frozen-six-field-member-identity-context.md)。
+- Camp 共享摘要模型入口继续遵守 [ADR-0060](../../adr/0060-opaque-member-routing-identity.md)，
+  不因 A3 未展示而删除。
+- v0.29 实施保持 Renderer-only；没有修改 Migration、SQLite、Core、IPC/Contracts 或
+  Runtime Adapter 语义。
+
+## 设计状态
+
+侧栏与页面内名册的所有权、详情双 Tab、单队员运行配置草稿边界、Member Order 模式、
+Runtime 状态投影、Renderer-only 范围与 100 位规模边界已经确认。关键异常路径、既有能力
+继承和完整验收矩阵已经收敛并冻结在[生产设计](production-design.md)。用户于
+2026-08-01 明确确认文档已经形成共同理解并授权实施。Renderer 生产改造、组件测试、
+桌面构建和隔离 UI 验收已经完成；具体验证证据见[实施计划](implementation-plan.md)。

--- a/docs/versions/v0.29/implementation-plan.md
+++ b/docs/versions/v0.29/implementation-plan.md
@@ -1,0 +1,44 @@
+---
+document_type: implementation-plan
+version: v0.29
+authority: implementation-status
+status: complete
+implementation_authorized: true
+last_updated: 2026-08-01
+---
+
+# v0.29 实施门禁
+
+> 生产合同：[production-design.md](production-design.md)
+
+用户已明确授权进入生产代码实施。实施必须保持 Renderer-only 边界，并以冻结的生产设计
+与本文件检查点作为验收依据。
+
+## 设计门禁
+
+- [x] 完成高影响决策访谈并覆盖关键异常场景。
+- [x] 用户明确确认文档已经形成共同理解。
+- [x] 冻结生产设计并确定验收矩阵。
+- [x] 用户另行明确授权进入代码实施（2026-08-01）。
+
+## 实施检查点
+
+- [x] 队员页统一侧栏切换为唯一名册投影，保留全局入口、通知与设置。
+- [x] 名册具备 Presence 分组、四类 Runtime 状态、快捷入口、21+ 本地筛选和专门排序模式。
+- [x] 详情收敛为“身份 / 运行配置”双 Tab，并保留身份、头像、Presence、记忆与移除能力。
+- [x] 单队员 Runtime/摘要模型草稿具备同队员保留、跨队员与离页确认、并发冲突保护。
+- [x] 九种 Product Runtime 继续复用生产表单，Camp 共享摘要模型保持独立保存边界。
+- [x] 组件测试、TypeScript 检查和真实页面交互/响应式/无障碍验收通过。
+- [x] 实施 diff 不包含 Migration、Core、IPC/Contracts 或 Adapter 语义变化。
+
+A3 HTML 只作为已核对的设计输入，不替代 Core、ADR、生产组件或现有测试合同。
+
+## 验证证据
+
+- `pnpm typecheck`
+- `pnpm test`：27 个测试文件、158 项测试通过。
+- `pnpm build:desktop`
+- `pnpm package:mac`
+- `pnpm accept:member-lifecycle-ui`：隔离 `userData` 的打包 App 验收通过，覆盖上下文名册、
+  双 Tab、键盘排序往返、Runtime 原子保存/清除、dirty 草稿继续/放弃、永久移除、
+  `1440×920`、`1040×700`、200% 等效内容宽度、reduced-motion、forced-colors 与无横向溢出。

--- a/docs/versions/v0.29/production-design.md
+++ b/docs/versions/v0.29/production-design.md
@@ -1,0 +1,340 @@
+---
+document_type: production-design
+version: v0.29
+authority: version-design
+status: frozen
+last_updated: 2026-08-01
+---
+
+# v0.29 队员工作台生产设计
+
+## 权威与原型边界
+
+本设计在现有 [Arctic Dawn V3](../../ui/arctic-dawn.md)、有效 ADR、Core 合同与生产代码
+基础上收敛。`rovai-members-a3/index.html` 已在浏览器中实际打开并交互核对；其布局与
+交互是本轮设计输入，但假队员、静态 Runtime 字段、演示状态和单文件实现不是生产合同。
+
+只有本文明确标记为“已确认”的项目才替代既有 UI 规范。仍在讨论或本文未涉及的部分
+继续遵守现行权威文档，不能从原型静默推断。
+
+## 已确认：队员页上下文侧栏
+
+进入“队员”一级页后，统一侧栏采用上下文投影：
+
+1. 品牌行固定；
+2. “新对话 / 队员 / 记忆”全局入口固定；
+3. “跳转到对话…”固定；
+4. 侧栏中部由普通页面的“置顶 / 项目”切换为队员名册；
+5. 底部“设置”固定。
+
+队员页主内容不再渲染独立名册栏，只显示当前选中队员的详情。侧栏与主内容之间只有
+一份名册选择状态，不允许用隐藏的第二份列表维持旧 Workbench。
+
+切换到 Quick Chat、Camp 或记忆等其他一级页面后，侧栏中部恢复普通导航投影。停留在
+队员页期间，项目和 Camp 列表不与队员名册并列显示；用户通过“跳转到对话…”，“新对话”
+或既有历史导航离开队员页。
+
+这项决定替代 Arctic Dawn V3 中“普通侧栏在队员页继续显示置顶/项目”以及“队员主体
+包含 272/250px 页面内名册”的对应规则。它不改变 Camp、Project、Member、Member Order
+或 Presence 的领域含义。
+
+## 已确认：身份与运行配置双 Tab
+
+当前队员详情使用且只使用两个顶层 Tab：“身份”和“运行配置”。两个工作区互斥显示，
+不再沿用当前生产页把身份、运行配置依次纵向堆叠的结构，也不增加第三个概括性“设置”
+Tab。
+
+Tab 只改变信息架构，不合并持久化命令：六字段身份继续由 Member Identity Update 独立
+保存，角色图片、Member Runtime Configuration、Memory Write Capability 与 Presence
+继续遵守各自的 mutation 和失败边界。切换 Tab 本身不得提交、回滚或伪造任一领域状态。
+
+运行配置仍必须复用 Runtime 专用生产组件及当前 Adapter Capability Snapshot；A3 中的
+静态“权限方案”字段不进入生产实现。
+
+## 已确认：单队员运行配置草稿
+
+Renderer 同一时间只持有当前选中队员的一份 Member Runtime Configuration 草稿，不为
+多位队员缓存隐藏草稿。
+
+- 当前队员在“身份 / 运行配置”之间切换时保留草稿且不提示；Tab 切换不重新从已保存
+  Profile 或能力快照覆盖用户编辑。
+- 草稿为 dirty 时，选择另一位队员、激活另一位队员的运行配置快捷入口或离开队员页，
+  必须阻止目标切换并显示明确确认，操作为“继续编辑 / 放弃更改”。
+- “继续编辑”关闭确认并保留当前队员、Tab、草稿和焦点；“放弃更改”清除当前草稿后
+  执行原来请求的唯一目标切换，不保留可恢复的隐藏副本。
+- 保存成功后清除 dirty 状态并使用最新服务端 Profile 继续显示。保存失败、CAS 冲突或
+  能力快照校验失败继续保留草稿和当前队员，不静默修复或改写字段。
+
+这项离开保护只管理 Renderer 草稿，不增加 Core 草稿实体、自动保存、跨重启恢复或
+多队员批量提交，也不在页面内增加含义含混的“取消”按钮。
+
+## 已确认：Member Order 专门模式
+
+v0.29 保留 Member Order 的完整编辑能力。普通名册行的末端用于 Runtime 状态和快捷
+入口；名册标题提供“调整顺序”，进入后切换为专门排序模式：
+
+- 行末 Runtime 快捷入口暂时退出，显示拖拽把手和等价的键盘上移/下移操作；
+- 每次移动继续提交权威 `agents.reorder`，不引入仅在 Renderer 保存的排序草稿或额外
+  “保存顺序”命令；
+- “在队 / 暂离”仍由 Member Presence 决定，排序不能改变分组；
+- 排序只改变 Member Order，不能改变 Presence、Runtime Readiness、Capability、权限、
+  当前有效 Default Lead 或执行优先级；
+- 提交失败恢复服务端顺序、播报错误并保留原操作焦点；退出排序模式恢复 Runtime 状态
+  入口和普通选择行为。
+
+这项设计保留 Member Order 对展示、新 Camp 初始队员顺序和未来 Lead 修复的现有领域
+作用，同时避免在窄侧栏中长期并列两个竞争性的行末操作。
+
+## 已确认：Agent 运行时产品术语
+
+普通产品界面统一使用“Agent 运行时”；当前队员详情中的配置工作区和 Tab 使用
+“运行配置”。“执行引擎”退出当前产品词汇，不再作为 selector、状态、空状态、Toast
+或帮助文案的别名。
+
+领域代码和协议仍可使用 Product Runtime、Runtime、Adapter 与 AdapterInstallation；
+Codex CLI、Claude Code 等具体产品保留自身名称。此决定已同步修正根
+[`CONTEXT.md`](../../../CONTEXT.md)中的产品术语和未配置状态，不改变任何持久化值、IPC
+字段、AdapterKind 或 Runtime 合同。
+
+## 已确认：四类名册 Runtime 状态投影
+
+侧栏行末的 Runtime 标记是 `Runtime User Status` 的紧凑入口，不是新的持久状态或
+Readiness 真源。生产实现使用四类视觉投影：
+
+| 投影 | 含义 |
+|---|---|
+| `✓` | 当前有可用的 Agent 运行时证据；仍可用的缓存正在后台刷新时继续显示可用 |
+| `○` | 队员没有选择 Agent 运行时 |
+| `!` | 已有选择，但需要用户登录、安装、处理版本、修正配置或执行其他明确修复 |
+| 中性检查/未知标记 | 正在检查且没有可用缓存，或当前暂时没有可靠结论 |
+
+第四类标记必须在 reduced-motion 下仍可辨认，不能只靠旋转动画。每个标记同时是运行
+配置快捷入口，并通过可访问名称和可见 Tooltip 提供具体队员名、Agent 运行时产品与完整
+状态文字；不能让 `✓ / ○ / !` 或颜色成为唯一信息。详情 Header 和运行配置 Tab 继续显示
+完整 `Runtime User Status`、次级原因与可用修复入口。
+
+这项投影不允许把“正在检查”误报为“需要处理”，也不允许因后台刷新把仍可用的缓存
+降级为未知。
+
+## 已确认：Renderer-only 版本边界
+
+v0.29 只重建 Renderer 的侧栏投影、队员详情信息架构、草稿离开保护、状态映射、焦点
+和响应式呈现。现有 App 状态已经提供 AgentProfile、AdapterInstallation、Product Runtime
+Availability 与所需队员命令；本版本不得新增或改变：
+
+- SQLite schema、Migration 或持久化值；
+- Core 领域对象、状态机、命令语义或 Read Side 权威；
+- Electron IPC 方法、共享 Contracts 或 Adapter Runtime 协议；
+- Member Identity、Runtime Configuration、Presence、Memory Capability、Member Order、
+  Camp Summary Model 或 Permanent Removal 的 mutation 边界。
+
+若生产实施发现现有合同不足，必须停止对应实施、记录具体缺口并重新进入设计确认；不得
+为了完成页面顺手扩张 Core 或数据模型。
+
+### 必须保留的既有能力
+
+A3 未展示下列能力不构成删除授权：
+
+- v0.28 品牌行通知入口与未读徽标；
+- 新增队员、身份编辑、复合头像选择与圆形裁切；
+- Presence 的暂离/归队；
+- 伙伴记忆 Capability 的即时独立保存；
+- 永久移除的预检、明确二次确认和历史保留语义；
+- ADR-0060 规定的应用级 Camp 共享摘要模型入口。该入口继续位于当前队员 Runtime
+  附近，在“运行配置”Tab 的默认折叠高级区域中按需读取；它仍是所有 Camp 共享配置，
+  不是当前队员的 Runtime Preference，也不与“保存运行时”合并提交。
+
+## 已确认：名册规模边界
+
+v0.29 以 100 位未移除队员作为明确验收规模。在此范围内名册使用普通 DOM 列表和独立
+滚动，不分页、不虚拟化，也不增加 Core 查询接口。超过 100 位时应保持基本可访问，
+但性能和高效排序不属于本版本承诺。
+
+- 未移除队员不超过 20 位时保持 A3 的紧凑名册，不占用空间显示无必要搜索框；第 21 位
+  起在名册标题下显示本地筛选。
+- 筛选只匹配 Member Name 与 Team Role，不匹配内部 ID、handle、Runtime 字段、Memory、
+  Presence 或身份长文本。
+- 筛选是临时 Renderer 状态，不持久化、不改变分组计数、Member Order、选择、Lead 或
+  任何 Core 对象；无结果使用明确空状态并允许一键清除。
+- 进入 Member Order 模式前清除筛选并显示完整名册，避免在隐藏行之间执行难以理解的
+  排序；排序模式不提供筛选。
+- 验收至少覆盖 13 位 A3 基准、21 位筛选边界与 100 位键盘/滚动/选择压力样例。
+
+## 生产收敛：App Shell 与名册
+
+队员页继续使用 270px Arctic Dawn 统一侧栏和 50px AppHeader。A3 在小于 920px 时把
+侧栏收窄为 230px 的演示规则不进入生产；现行最小窗口与 200% Zoom 合同仍以固定 270px
+侧栏为准。
+
+品牌行继续显示 `Rovai AI`、v0.28 通知入口和未读徽标。队员名册区的 Header 显示标题、
+未移除队员总数、“新增队员”和“调整顺序”；Icon-only 操作必须有可访问名称和 Tooltip。
+新增成功后选择新队员并打开“身份”，不自动选择或保存 Agent 运行时。
+
+名册滚动区独立于右侧详情，使用细滚动条、`overscroll-behavior: contain`、只在确有隐藏
+内容时出现的顶部/底部渐隐提示，以及不会遮挡 Focus Ring 的“在队 / 暂离”Sticky 分组
+标题。`removed` 不进入名册；Presence 和 Runtime 状态继续是两个独立维度。
+
+普通行依次显示受控圆形 icon、Member Name、Team Role 和行末 Runtime 快捷入口。身份色
+只点缀 icon/选择，不承担 Presence 或 Runtime 状态。名称和角色允许省略号截断，但完整值
+可访问；不能显示 handle、Installation ID、路径或 fingerprint。
+
+首次进入且存在队员时，选择 Member Order 中第一位 `present` 队员；没有 `present` 时
+选择第一位 `away` 队员。没有任何未移除队员时显示解释性空状态和唯一主操作“新增队员”。
+选择和 Tab 是当前 App 会话内的 Renderer 状态，不写入 Core，也不要求跨 App 重启恢复。
+
+## 生产收敛：入口、Tab 与焦点
+
+- 点击名册行主体选择该队员并打开“身份”；点击行末 Runtime 标记选择该队员并打开
+  “运行配置”。详情 Header 的 Runtime 状态入口对当前队员执行同一动作。
+- 由 Runtime 快捷入口进入时，更新完成后聚焦第一个真实可编辑控件“Agent 运行时”；若
+  离开保护先出现，只有用户确认放弃后才执行选择与焦点移动。
+- 同一队员的行主体、Runtime 快捷入口与 Tab 切换不触发离开确认；它们只切换当前
+  panel，并保留该队员 dirty 草稿。
+- Tab 使用 `tablist / tab / tabpanel`、手动激活、方向键和 Home/End；非当前 panel 退出
+  Tab 顺序和无障碍树，但其草稿由上层 Renderer 状态保留。
+- 行选择后键盘焦点保留在触发行，避免详情重绘把用户传送到页面顶部；只有明确 Runtime
+  快捷入口按上述合同主动移动焦点。Dialog、菜单和确认框关闭后返回原触发控件。
+- 筛选不自动改变当前选择。若当前队员不匹配筛选，详情继续显示该队员，筛选区明确提示
+  当前选择未出现在结果中；清除筛选即可恢复其行。
+
+## 生产收敛：详情 Header 与队员操作
+
+详情 Header 位于两个 Tab 之外，持续显示 50px 圆形 icon、Member Name、Team Role、
+Presence 状态和完整 Runtime User Status。Runtime 状态是可激活入口；Presence 只显示
+当前事实，不能因视觉相似而成为含义不明的切换按钮。
+
+Header 直接保留“编辑身份”。`•••` 必须实现为有可访问名称的真实菜单，不得保留原型
+死按钮；菜单承载“更换角色图片”“暂时离队 / 归队”和“永久移除队员”。Presence 变化
+继续即时独立保存且不弹 successor Dialog；永久移除继续执行预检和名称确认，并使用
+danger 呈现。当前存在 dirty 配置草稿时，永久移除先经过同一放弃确认。
+
+身份 Dialog、头像 Dialog、Presence、Memory Capability、Runtime、摘要模型和移除分别
+显示自己的 busy/error/success，不使用全页面锁，也不存在跨区域“一键全部保存”。
+
+## 生产收敛：“身份”Tab
+
+身份首屏使用 A3 的左侧身份摘要 + 右侧 `4:5` portrait。常规默认高度均为 360px；
+portrait 使用现有 `MemberPortrait` 和受控 `avatarRef`，保持 360px，不因文字展开继续拉伸，
+也不裁剪主体或加载任意路径/URL。
+
+摘要按下列顺序显示：
+
+1. 专业职责：默认最多 4 行；
+2. 性格底色：默认最多 2 行标签；
+3. 工作准则：默认最多 3 行；
+4. 成长课题：默认最多 3 行。
+
+只有真实视觉溢出的字段显示“展开”；操作名称包含字段名。展开只作用于当前字段并变为
+“收起”，允许身份摘要超过 360px，其他字段与 portrait 不随之展开。窗口、字体或内容
+变化后重新判断溢出；空值显示“未设置”，不出现无效展开操作。
+
+身份区之后使用单一分隔行显示“伙伴记忆”、当前开关状态和固定说明：
+
+> 允许这位伙伴在协作中形成长期偏好、约定或经验时写入记忆。
+
+Switch 继续即时独立保存 Memory Write Capability；失败恢复服务端值并保留当前 Tab 和
+焦点。它不与身份或 Runtime 保存合并，也不改变既有 Memory。
+
+## 生产收敛：“运行配置”Tab
+
+Tab 顶部固定说明：
+
+> 为这位队员设置后续 Run 使用的 Agent 运行时、模型和该运行时提供的权限选项。保存后
+> 仅影响之后创建的 Run。
+
+随后显示一个完整状态摘要和生产 `MemberRuntimeParameters` 表单。状态摘要使用具体
+Product Runtime、完整 Runtime User Status、版本/次级原因及必要修复入口；名册四类图标
+不能替代这里的精确信息。
+
+- Agent 运行时 selector 始终列出 Product Runtime Catalog；空动作显示“不选择 Agent
+  运行时”，保存后的空状态显示“未配置 Agent 运行时”。
+- 模型策略、模型、模型参数和原生权限严格来自 ADR-0082、Core Adapter policy 与当前
+  Adapter Capability Snapshot。Codex `sandbox_mode` 与 `approval_policy` 等独立字段
+  不能被合并；九种 Runtime 继续使用各自生产组件。
+- 能力快照不可用时允许只保存 Product Runtime Selection，说明需要检查完成后回来保存
+  参数；不伪造模型或权限。失效持久值继续显式显示并阻止无效保存，不能静默回默认。
+- 页面打开使用最近缓存并只触发后台 ensure/refresh；切换 Runtime 不同步执行完整检查，
+  保存也不显示“正在检查并保存”。仍可用缓存刷新期间继续为可用。
+- 表单只提供“保存运行时”；请求期间显示“正在保存…”。不显示“取消”，也不增加独立
+  清除按钮；选择“不选择 Agent 运行时”后保存即调用现有清除命令。
+- 保存成功显示 Toast、刷新权威 Profile 并清除 dirty；失败保留草稿、Tab 和焦点。
+
+运行表单之后保留默认折叠的“高级设置 · Camp 共享摘要模型”。展开后才读取应用级摘要
+模型配置，继续使用自身“保存摘要模型”和 CAS；它不与 Member Runtime Configuration
+共用按钮或草稿。摘要模型存在未保存选择时，同样参加离开保护，避免因切换队员或页面
+静默丢失；不为多位队员缓存不同的隐藏摘要草稿。
+
+## 生产收敛：并发、独立修改与离开保护
+
+AgentProfile 的身份、头像、Memory Capability、Presence、Runtime 和 Member Order 都会
+推进同一 Profile version。Renderer 不再用 `${agent.id}:${agent.version}` 无条件重挂载
+Runtime 表单。
+
+dirty Runtime 草稿记录其起始持久 Runtime Selection/Preference 基线：
+
+- 当前 App 已知由身份、头像、Memory、Presence 或 Member Order 成功导致的版本推进，
+  在持久 Runtime 基线未变时可以把草稿安全带到新 Profile version；
+- 权威刷新若显示持久 Runtime Selection/Preference 已改变，Renderer 不得自动 rebase、
+  覆盖或用更新后的 version 提交旧草稿，而是显示明确冲突，要求用户重新读取或放弃；
+- 当前队员被其他操作移除或不再可管理时，禁止保存草稿，保留冲突说明并允许离开；
+- Runtime 能力快照变化可以更新状态与选项有效性，但不得重置用户输入；最终保存仍由
+  Core 在当前 snapshot 上原子校验。
+
+离开保护覆盖所有可能最终离开队员页的入口：新对话、记忆、设置、Camp 快速跳转、
+通知深链、Runtime 修复入口及选择其他队员。单纯打开通知中心、身份/头像 Dialog 或同一
+队员的另一 Tab 不算离开，草稿继续保留。确认框一次只执行原请求目标，不允许确认后又
+落到过期的第二个导航目标。
+
+## 页面状态、响应式与无障碍
+
+- Loading 保留 App Shell 和稳定几何，名册使用骨架但不虚构人数或状态；读取失败保留
+  全局导航和重试。Partial Runtime 数据使用中性检查/未知投影，不阻塞身份区。
+- 排序、Presence、Memory、Runtime、摘要模型和移除的局部失败各自保留选择、草稿和焦点；
+  Toast 只用于成功的非阻塞反馈，错误不能只靠短暂 Toast。
+- 几何验收继续使用 `1440×920` 与 `1040×700`。A3 已在浏览器中实际验证
+  `1040×700` 为 270px 侧栏 + 770px 主区且无整页横向溢出；这只是设计输入，生产 App
+  仍须重新验收。
+- 详情区独立纵向滚动。常规与 1040px 基准保持双列身份摘要；在 200% Zoom 或有效内容
+  宽度不足时，身份摘要/portrait 和 Runtime 字段按阅读顺序转为单列，侧栏仍为 270px，
+  不产生整页横向滚动或遮挡保存、菜单、Tab 和 Focus Ring。
+- 所有点击目标至少 `28×28px`；状态不只靠颜色；Icon-only 控件有可访问名称；Tooltip
+  可由 Hover 与 Focus 打开。Sticky、Overflow 和渐隐层不能裁切 `focus-visible`。
+- 第四种中性 Runtime 状态在 `prefers-reduced-motion` 下使用静态形状/文字替代持续旋转；
+  `forced-colors` 下仍有边界和符号。页面支持 Tab、Shift+Tab、方向键、Home/End、Escape
+  与 Dialog/Menu Focus Return，不要求指针或拖拽。
+
+## 验收矩阵
+
+生产验收至少覆盖：
+
+- 0、1、13、20、21 和 100 位未移除队员；在队/暂离空分组、长名称/角色、筛选无结果；
+- 普通名册、筛选、排序模式、拖拽、键盘上移/下移、服务端排序失败和焦点恢复；
+- 四类紧凑 Runtime 投影及全部完整 Runtime User Status，含可用缓存后台刷新；
+- 行主体、行末快捷入口、Header Runtime 入口、两个 Tab 的精确选择与焦点路径；
+- 专业职责/性格底色/工作准则/成长课题无溢出、临界溢出、逐字段展开和 200% Zoom；
+- 伙伴记忆成功/失败、Presence、身份、头像、移除，以及它们与 dirty Runtime 草稿的
+  独立 version 推进；
+- 九种 Product Runtime 的生产字段、无 snapshot、失效模型/权限、未安装/需登录、保存
+  成功、异步失败、CAS 冲突与清除选择；
+- dirty 草稿在同队员 Tab 间保留，切换队员和所有离开入口的继续编辑/放弃路径，以及
+  持久 Runtime 被外部改变后的冲突路径；
+- Camp 共享摘要模型的折叠按需读取、独立保存、来源队员变化和 dirty 离开保护；
+- `1440×920`、`1040×700`、200% Zoom、reduced-motion、forced-colors、键盘和读屏；
+- v0.28 通知入口、快速跳转、新对话、设置返回和其他普通侧栏投影无回归；
+- 实施 diff 不包含 Migration、Core、IPC/Contracts 或 Adapter 语义变化。
+
+## 明确非目标
+
+- 不增加第三个队员详情 Tab、移动端布局、虚拟列表、分页或 Core 队员搜索。
+- 不持久化当前队员、当前 Tab、筛选、排序模式或未保存草稿，也不提供跨重启恢复。
+- 不新增全 Profile 自动保存、“保存全部”、多队员批量 Runtime 配置或隐藏多草稿缓存。
+- 不改变 Summary 生成、Member Identity、Runtime Permission、Memory、Presence、Removal、
+  Member Order、Camp、Project、Notification 或 AgentRun 的领域语义。
+- 不复制 A3 的静态 Runtime 列表、合并权限字段、假队员、演示 Toast 或 230px 侧栏断点。
+- 不重做 Arctic Dawn Token、Night 主题、身份素材系统、Dialog 裁切器或设置页。
+
+## 设计门禁状态
+
+高影响决策、现有合同继承、关键异常路径和验收矩阵已经写入。用户于 2026-08-01 明确
+确认本文已经形成共同理解，设计现已冻结；随后已明确授权并完成生产实施。实施与验收
+证据见[实施计划](implementation-plan.md)。

--- a/scripts/accept-member-lifecycle-ui.mjs
+++ b/scripts/accept-member-lifecycle-ui.mjs
@@ -133,7 +133,83 @@ try {
     `Settings still exposes a standalone Context destination: ${JSON.stringify(settingsDestinations)}`)
 
   await openMembers(running.cdp)
+  const memberWorkbenchStructure = await evaluate(running.cdp, `({
+    sidebarWidth: document.querySelector('.unified-sidebar')?.getBoundingClientRect().width,
+    hasRoster: Boolean(document.querySelector('.member-sidebar')),
+    hasProjectNavigation: Boolean(document.querySelector('.navigation-projects')),
+    duplicateRoster: Boolean(document.querySelector('.member-list, .member-workbench')),
+    tabs: [...document.querySelectorAll('.member-tabs [role="tab"]')]
+      .map((tab) => tab.textContent?.trim()),
+    initialMember: document.querySelector('.member-detail-heading h2')?.textContent
+  })`)
+  assert(
+    memberWorkbenchStructure.sidebarWidth === 270
+      && memberWorkbenchStructure.hasRoster
+      && !memberWorkbenchStructure.hasProjectNavigation
+      && !memberWorkbenchStructure.duplicateRoster
+      && JSON.stringify(memberWorkbenchStructure.tabs) === JSON.stringify(['身份', '运行配置'])
+      && memberWorkbenchStructure.initialMember === '小狐狸',
+    `v0.29 member workbench structure is unexpected: ${JSON.stringify(memberWorkbenchStructure)}`
+  )
+  const initialMemberOrder = (await request(running.cdp, 'agents.list'))
+    .map((profile) => profile.id)
+  await mouseClick(running.cdp, '.member-sidebar-actions button[aria-label="调整队员顺序"]')
+  await waitForSelector(running.cdp, '[data-member-order-handle="agent-luoke"]')
+  assert(
+    !await evaluate(running.cdp, `Boolean(document.querySelector('.member-runtime-shortcut'))`),
+    'Runtime shortcuts remained visible in Member Order mode'
+  )
+  await focusElement(running.cdp, '[data-member-order-handle="agent-luoke"]')
+  await pressKey(running.cdp, 'ArrowDown')
+  await waitForAgentOrder(running.cdp, [
+    initialMemberOrder[1],
+    initialMemberOrder[0],
+    ...initialMemberOrder.slice(2)
+  ])
+  await waitForExpression(running.cdp,
+    `document.querySelector('[data-member-order-handle="agent-luoke"]')?.disabled === false`)
+  await focusElement(running.cdp, '[data-member-order-handle="agent-luoke"]')
+  await pressKey(running.cdp, 'ArrowUp')
+  await waitForAgentOrder(running.cdp, initialMemberOrder)
+  await waitForExpression(running.cdp,
+    `document.querySelector('[data-member-order-handle="agent-luoke"]')?.disabled === false`)
+  await mouseClick(running.cdp, '.member-sidebar-actions button[aria-label="完成调整队员顺序"]')
+  await waitForSelector(running.cdp, '.member-runtime-shortcut')
+  await setViewport(running.cdp, 720, 460)
+  await running.cdp.send('Emulation.setEmulatedMedia', {
+    media: 'screen',
+    features: [{ name: 'prefers-reduced-motion', value: 'reduce' }]
+  })
+  await assertNoHorizontalOverflow(running.cdp, 'Member identity at effective 200% Zoom')
+  const compactAccessibilityState = await evaluate(running.cdp, `(() => {
+    const copy = document.querySelector('.member-identity-copy')?.getBoundingClientRect()
+    const portrait = document.querySelector('.member-identity-appearance')?.getBoundingClientRect()
+    const shortcut = document.querySelector('.member-runtime-shortcut')
+    return {
+      reducedMotion: matchMedia('(prefers-reduced-motion: reduce)').matches,
+      stacked: Boolean(copy && portrait && portrait.top >= copy.bottom - 1),
+      shortcutAnimation: shortcut ? getComputedStyle(shortcut).animationName : null
+    }
+  })()`)
+  assert(
+    compactAccessibilityState.reducedMotion
+      && compactAccessibilityState.stacked
+      && compactAccessibilityState.shortcutAnimation === 'none',
+    `Compact/reduced-motion member layout is unexpected: ${JSON.stringify(compactAccessibilityState)}`
+  )
+  await running.cdp.send('Emulation.setEmulatedMedia', {
+    media: 'screen',
+    features: [{ name: 'forced-colors', value: 'active' }]
+  })
+  assert(
+    await evaluate(running.cdp, `matchMedia('(forced-colors: active)').matches`),
+    'Forced Colors emulation did not activate for the member workbench'
+  )
+  await assertNoHorizontalOverflow(running.cdp, 'Member identity in Forced Colors')
+  await running.cdp.send('Emulation.setEmulatedMedia', { media: 'screen', features: [] })
+  await setViewport(running.cdp, 1440, 920)
   await selectMember(running.cdp, '小狐狸')
+  await openMemberRuntimeTab(running.cdp)
   const foldedSummaryState = await evaluate(running.cdp, `({
     open: document.querySelector('.member-advanced-settings details')?.open,
     mounted: Boolean(document.querySelector('.summary-model-settings'))
@@ -179,21 +255,20 @@ try {
   await capture(running.cdp, captures.summaryModelSimplified)
   await assertExecutionEngineProductCopy(running.cdp)
   await setTheme(running.cdp, 'day')
-  await mouseClick(running.cdp, '.member-status-actions button', '暂离')
+  await openMemberMenuAction(running.cdp, '暂时离队')
   await waitForProfile(running.cdp, 'agent-luoke', (profile) => profile.presence === 'away')
   await waitForText(running.cdp, '.app-toast', '已暂离')
-  await focusElement(running.cdp, '.member-status-actions button', '归队')
-  await pressKey(running.cdp, 'Enter')
+  await openMemberMenuAction(running.cdp, '归队')
   await waitForProfile(running.cdp, 'agent-luoke', (profile) => profile.presence === 'present')
   await waitForText(running.cdp, '.app-toast', '已归队')
 
-  await focusElement(running.cdp, '.member-section-heading button', '编辑身份')
+  await focusElement(running.cdp, '.member-detail-actions > .quiet-button', '编辑身份')
   await pressKey(running.cdp, 'Enter')
   await waitForSelector(running.cdp, '.member-dialog')
   await waitForExpression(running.cdp, `document.activeElement?.closest('.member-dialog') !== null`)
   const hiddenHandleState = await evaluate(running.cdp, `({
     dialogExposesHandle: document.querySelector('.member-dialog')?.textContent?.includes('@handle'),
-    rosterExposesHandle: [...document.querySelectorAll('.member-list-copy small')]
+    rosterExposesHandle: [...document.querySelectorAll('.member-sidebar-copy small')]
       .some((node) => node.textContent?.includes('@'))
   })`)
   assert(
@@ -297,6 +372,7 @@ try {
 
   await openMembers(running.cdp)
   await selectMember(running.cdp, '咕咕')
+  await openMemberRuntimeTab(running.cdp)
   const runtimeBeforeDraft = await request(running.cdp, 'agents.get', {
     agentProfileId: 'agent-mianzhi'
   })
@@ -315,7 +391,7 @@ try {
     '.member-section',
     'Agent 运行时',
     'qoder-cli',
-    '运行配置'
+    'Agent 运行时'
   )
   await waitForText(running.cdp, '.member-runtime-parameters', '当前还没有可编辑的能力快照')
   await waitForExpression(running.cdp, `document.querySelector('.member-runtime-parameters')?.open === true`)
@@ -324,7 +400,7 @@ try {
     '.member-section',
     'Agent 运行时',
     'codex-cli',
-    '运行配置'
+    'Agent 运行时'
   )
   await waitForExpression(running.cdp, `document.querySelector('.member-runtime-parameters')?.open === true`)
   const switchedRuntimeDefaults = await runtimeParameterValues(running.cdp)
@@ -366,6 +442,17 @@ try {
     '审批策略',
     'never'
   )
+  await mouseClick(running.cdp, '.member-sidebar-select', '小狐狸', true)
+  await waitForSelector(running.cdp, '.member-leave-dialog')
+  await focusElement(running.cdp, '.member-leave-dialog button', '继续编辑')
+  await pressKey(running.cdp, 'Enter')
+  await waitForExpression(running.cdp,
+    `!document.querySelector('.member-leave-dialog')
+      && document.querySelector('.member-detail-heading h2')?.textContent === '咕咕'`)
+  assert(
+    (await runtimeParameterValues(running.cdp)).modelMode === 'explicit',
+    'Continuing a dirty Runtime edit lost the current member draft'
+  )
   captures.memberRuntimeParameters = join(
     outputDir,
     'member-runtime-parameters-day-1040x700.png'
@@ -391,18 +478,38 @@ try {
   await waitForExpression(running.cdp, `(() => {
     const section = [...document.querySelectorAll('.member-section')]
       .find((candidate) =>
-        candidate.querySelector('.member-section-heading h3')?.textContent?.trim() === '运行配置')
+        candidate.querySelector('.member-section-heading h3')?.textContent?.trim() === 'Agent 运行时')
     const save = [...(section?.querySelectorAll('.member-form-actions button') ?? [])]
       .find((button) => button.textContent?.trim() === '保存运行时')
     return section?.querySelector('.field-label select')?.disabled === false
-      && save?.disabled === false
+      && save?.disabled === true
   })()`)
+  await selectFieldValue(
+    running.cdp,
+    '.member-runtime-parameters',
+    '审批策略',
+    'on-request'
+  )
+  await mouseClick(running.cdp, '.member-sidebar-select', '小狐狸', true)
+  await waitForSelector(running.cdp, '.member-leave-dialog')
+  await focusElement(running.cdp, '.member-leave-dialog button', '放弃更改')
+  await pressKey(running.cdp, 'Enter')
+  await waitForExpression(running.cdp,
+    `!document.querySelector('.member-leave-dialog')
+      && document.querySelector('.member-detail-heading h2')?.textContent === '小狐狸'`)
+  await selectMember(running.cdp, '咕咕')
+  await openMemberRuntimeTab(running.cdp)
+  await waitForText(running.cdp, '.member-runtime-parameters', '审批策略')
+  assert(
+    (await runtimeParameterValues(running.cdp)).approvalPolicy === 'never',
+    'Discarding a dirty Runtime edit changed the persisted configuration'
+  )
   await selectFieldValue(
     running.cdp,
     '.member-section',
     'Agent 运行时',
     '',
-    '运行配置'
+    'Agent 运行时'
   )
   await mouseClick(running.cdp, '.member-form-actions button', '保存运行时')
   await waitForText(running.cdp, '.app-toast', 'Agent 运行时已清除。')
@@ -468,7 +575,7 @@ try {
       && qiluBeforeRemoval.runtimePreference !== null,
     'Removal retention fixture did not configure a Runtime for 小兔'
   )
-  await mouseClick(running.cdp, '.member-danger-zone button', '移除 小兔')
+  await openMemberMenuAction(running.cdp, '永久移除队员')
   await waitForSelector(running.cdp, '.dialog-content')
   await waitForExpression(running.cdp,
     `document.activeElement === document.querySelector('.dialog-content input')`)
@@ -478,7 +585,7 @@ try {
       .find((button) => button.textContent?.trim() === '永久移除' && !button.disabled))`)
   await mouseClick(running.cdp, '.dialog-content button', '永久移除')
   await waitForExpression(running.cdp, `!document.querySelector('.dialog-content')`, 30_000)
-  await waitForExpression(running.cdp, `![...document.querySelectorAll('.member-list-copy strong')]
+  await waitForExpression(running.cdp, `![...document.querySelectorAll('.member-sidebar-copy strong')]
     .some((node) => node.textContent === '小兔')`)
   const qiluAfterRemoval = await historicalProfile(
     join(freshDataDir, 'rovai.sqlite'),
@@ -605,7 +712,7 @@ try {
     outputDir
   ))
   await selectMember(running.cdp, '小兔')
-  await waitForText(running.cdp, '.member-status-actions', '暂离')
+  await waitForText(running.cdp, '.member-detail-statuses', '暂离')
   await closeApp(running)
   running = null
 
@@ -629,6 +736,9 @@ try {
       v14MemberRuntimeResetOnSchemaV41: true,
       mentionComposerUsesMemberName: true,
       contextSettingsDestinationRemoved: true,
+      contextualMemberSidebarAndTabs: true,
+      memberOrderDedicatedModeKeyboardRoundTrip: true,
+      effective200PercentZoomReducedMotionAndForcedColors: true,
       summaryModelAdvancedSettingsFoldedAndSimplified: true,
       memberHandlesHiddenAndDuplicateNameBlocked: true,
       campWhiteSurfacesStrongDividerAndPreservedRailMessageColors: true,
@@ -639,6 +749,7 @@ try {
       radixEscapeAndFocusReturn: true,
       runtimeClearDoesNotChangePresence: true,
       memberRuntimeParametersExpandedSingleSaveAndAtomicClear: true,
+      dirtyRuntimeGuardContinueAndDiscard: true,
       removalRetainsIdentityAvatarRuntimeAndHistory: true,
       removedHiddenFromActiveRoster: true,
       noSuccessorLeadNullComposerToastAndDraft: true,
@@ -661,7 +772,7 @@ async function captureThemeMatrix(cdp, prefix, selectedName, directory) {
       await setViewport(cdp, width, height)
       await setTheme(cdp, theme)
       await waitForExpression(cdp,
-        `document.querySelector('.member-profile-heading h3')?.textContent === ${JSON.stringify(selectedName)}`)
+        `document.querySelector('.member-detail-heading h2')?.textContent === ${JSON.stringify(selectedName)}`)
       await waitForExpression(cdp,
         `[...document.querySelectorAll('.member-avatar img, .member-portrait img')]
           .every((image) => image.complete && image.naturalWidth > 0)`)
@@ -806,6 +917,16 @@ async function waitForProfile(cdp, agentProfileId, predicate, timeoutMs = 30_000
   throw new Error(`AgentProfile ${agentProfileId} did not reach the expected state`)
 }
 
+async function waitForAgentOrder(cdp, expectedIds, timeoutMs = 30_000) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    const ids = (await request(cdp, 'agents.list')).map((profile) => profile.id)
+    if (JSON.stringify(ids) === JSON.stringify(expectedIds)) return
+    await wait(100)
+  }
+  throw new Error(`Member Order did not become ${JSON.stringify(expectedIds)}`)
+}
+
 async function openNewConversation(cdp) {
   await waitForExpression(cdp,
     `Boolean(document.querySelector('.unified-sidebar button[aria-label="新对话"]:not(:disabled)'))`,
@@ -823,11 +944,19 @@ async function openMembers(cdp) {
     await waitForSelector(cdp, '.unified-primary-nav', 30_000)
   }
   await mouseClick(cdp, '.unified-sidebar button[aria-label="队员"]')
-  await waitForSelector(cdp, '.member-workbench', 30_000)
+  await waitForSelector(cdp, '.members-view', 30_000)
 }
 
 async function openCamp(cdp, title) {
   await waitForSelector(cdp, '.unified-sidebar', 30_000)
+  if (await evaluate(cdp, `Boolean(document.querySelector('.members-view'))`)) {
+    await mouseClick(cdp, '.conversation-jump')
+    await waitForSelector(cdp, '.command-palette')
+    await focusElement(cdp, '.command-palette-item', title, true)
+    await pressKey(cdp, 'Enter')
+    await waitForSelector(cdp, '.camp-workspace', 30_000)
+    return
+  }
   await waitForExpression(cdp, `(() => {
     const title = ${JSON.stringify(title)}
     return [...document.querySelectorAll('.camp-nav-open')]
@@ -838,9 +967,22 @@ async function openCamp(cdp, title) {
 }
 
 async function selectMember(cdp, displayName) {
-  await mouseClick(cdp, '.member-list-item', displayName, true)
+  await mouseClick(cdp, '.member-sidebar-select', displayName, true)
   await waitForExpression(cdp,
-    `document.querySelector('.member-profile-heading h3')?.textContent === ${JSON.stringify(displayName)}`)
+    `document.querySelector('.member-detail-heading h2')?.textContent === ${JSON.stringify(displayName)}`)
+}
+
+async function openMemberRuntimeTab(cdp) {
+  await mouseClick(cdp, '#member-runtime-tab', '运行配置')
+  await waitForExpression(cdp,
+    `document.querySelector('#member-runtime-panel')?.hidden === false`)
+}
+
+async function openMemberMenuAction(cdp, label) {
+  await mouseClick(cdp, '.member-detail-menu > summary')
+  await waitForExpression(cdp,
+    `document.querySelector('.member-detail-menu')?.open === true`)
+  await mouseClick(cdp, '.member-detail-menu button', label)
 }
 
 async function focusAndInsertText(cdp, selector, text) {
@@ -1046,13 +1188,31 @@ async function setViewport(cdp, width, height) {
 async function assertNoHorizontalOverflow(cdp, context) {
   const state = await evaluate(cdp, `({
     documentOverflow: document.documentElement.scrollWidth > window.innerWidth,
-    surfaces: [...document.querySelectorAll('.content, .member-workbench, .member-detail, .camp-workspace')]
+    surfaces: [...document.querySelectorAll('.content, .members-view, .member-detail-scroll, .member-sidebar-scroll-body, .camp-workspace')]
       .filter((node) => node.scrollWidth > node.clientWidth + 1)
       .map((node) => ({
         className: node.className,
         scrollWidth: node.scrollWidth,
         clientWidth: node.clientWidth
-      }))
+      })),
+    overflowingMemberChildren: (() => {
+      const container = document.querySelector('.member-detail-scroll')
+      if (!container) return []
+      const right = container.getBoundingClientRect().right
+      return [...container.querySelectorAll('*')]
+        .filter((node) => {
+          const rect = node.getBoundingClientRect()
+          return rect.width > 0 && rect.right > right + 1
+        })
+        .slice(0, 12)
+        .map((node) => ({
+          tag: node.tagName,
+          className: node.className,
+          width: Math.round(node.getBoundingClientRect().width),
+          right: Math.round(node.getBoundingClientRect().right),
+          text: node.textContent?.trim().slice(0, 60)
+        }))
+    })()
   })`)
   assert(
     !state.documentOverflow && state.surfaces.length === 0,


### PR DESCRIPTION
## What changed

- replace the duplicated members roster with a contextual unified-sidebar roster
- introduce Identity and Runtime Configuration workspaces with persistent member context
- protect dirty Runtime and summary-model drafts across navigation and external source changes
- add member filtering, dedicated reorder mode, keyboard support, responsive layouts, and accessibility states
- add v0.29 design, implementation, and acceptance documentation

## Why

The members workspace previously split roster ownership across navigation and page content and stacked identity and Runtime editing in one surface. v0.29 gives the roster one contextual owner while keeping production Runtime fields and existing domain boundaries intact.

## Impact

Members can browse up to the documented 100-member acceptance boundary, switch between identity and Runtime configuration without losing drafts, and receive explicit conflict or leave handling. This is a Renderer-only change; Core, migrations, IPC/contracts, and Runtime Adapter semantics are unchanged.

## Validation

- `pnpm typecheck`
- `pnpm test` — 27 files, 158 tests
- `pnpm build:desktop`
- `pnpm package:mac`
- `pnpm accept:member-lifecycle-ui`
- `git diff --check`
