### PR TITLE
Redesign desktop workspace with Graphite Command

### DIFF
--- a/apps/desktop/src/renderer/src/graphite-command-foundation.css
+++ b/apps/desktop/src/renderer/src/graphite-command-foundation.css
@@ -1,0 +1,206 @@
+/*
+ * Graphite Command visual layer
+ *
+ * This stylesheet is intentionally imported after styles.css. It changes only
+ * presentation: React component boundaries, IPC calls, keyboard behavior and
+ * persisted Rovai data contracts stay in the existing renderer code.
+ */
+
+:root {
+  color-scheme: light;
+  --rail-width: 272px;
+
+  --canvas: #ececea;
+  --surface: #fbfbf9;
+  --surface-raised: #ffffff;
+  --surface-subtle: #f4f5f2;
+  --surface-muted: #eceeea;
+  --surface-selected: #e2f2ee;
+  --surface-hover: #e8eae6;
+  --surface-sunken: #e5e7e3;
+  --conversation-surface: #fbfbf9;
+  --inspector-surface: #f7f7f4;
+  --conversation-inspector-line: #d7dad5;
+  --home-surface: #fbfbf9;
+  --topbar: #f7f7f4;
+  --input: #f0f1ee;
+
+  --ink: #151920;
+  --muted: #606873;
+  --faint: #7d8690;
+  --line: #e1e3df;
+  --line-strong: #cfd3ce;
+  --control-line: #cfd3ce;
+
+  --brand: #147d6f;
+  --brand-hover: #0d665b;
+  --brand-contrast: #f4fffc;
+  --brand-soft: #e2f2ee;
+  --brand-ink: #0d695e;
+  --mention-ink: #0d695e;
+  --mention-ink-hover: #09584f;
+  --mention-feedback: rgb(20 125 111 / 9%);
+  --mention-popover-portrait-scrim: rgb(21 25 32 / 10%);
+  --mention-popover-label-line: rgb(255 255 255 / 42%);
+  --mention-popover-label-surface: rgb(21 25 32 / 38%);
+  --mention-popover-accent: var(--brand);
+
+  --aurora: #6ed8c3;
+  --aurora-soft: #ddf5ef;
+  --violet: #75698f;
+  --violet-soft: #eeeaf4;
+  --ember: #b66d24;
+  --ember-soft: #fff0df;
+
+  --rail: #171a20;
+  --rail-ink: #aeb6c4;
+  --rail-line: #2a2f38;
+  --rail-logo: #6ed8c3;
+
+  --success: #187157;
+  --success-soft: #e8f5ef;
+  --success-contrast: #ffffff;
+  --attention: #965607;
+  --attention-soft: #fff3df;
+  --attention-contrast: #ffffff;
+  --danger: #a9343c;
+  --danger-soft: #fdebed;
+  --danger-contrast: #ffffff;
+  --info: #28698f;
+  --info-soft: #e9f3fb;
+  --info-contrast: #ffffff;
+  --neutral: #59616c;
+  --neutral-soft: #eceeea;
+  --focus: #147d6f;
+  --focus-soft: rgb(20 125 111 / 16%);
+  --overlay: rgb(16 19 24 / 54%);
+
+  --shadow-float: 0 18px 44px rgb(27 34 51 / 14%);
+  --shadow-menu: 0 14px 34px rgb(27 34 51 / 16%);
+  --shadow-dialog: 0 24px 64px rgb(16 19 24 / 24%);
+  --shadow-card: none;
+
+  --approval-line: #d8b980;
+  --evidence-canvas: #f0f1ee;
+  --evidence-surface: #fbfbf9;
+  --evidence-ink: #1b2028;
+  --evidence-muted: #606873;
+  --evidence-line: #d8dbd6;
+  --diff-add: #246849;
+  --diff-add-soft: #e5f1e9;
+  --diff-remove: #8f3538;
+  --diff-remove-soft: #f8e7e7;
+
+  --graphite-sidebar-title: #f7f8fa;
+  --graphite-sidebar-ink: #aeb6c4;
+  --graphite-sidebar-muted: #929dab;
+  --graphite-sidebar-faint: #7d8796;
+  --graphite-sidebar-hover: #21262e;
+  --graphite-sidebar-active: #272e38;
+  --graphite-accent: #6ed8c3;
+  --graphite-accent-ink: #102c28;
+  --graphite-charcoal-button: #1b2227;
+  --graphite-charcoal-button-hover: #147d6f;
+  --graphite-field: #f0f1ee;
+  --graphite-topbar-line: #d7dad5;
+  --graphite-radius-xs: 4px;
+  --graphite-radius-sm: 6px;
+  --graphite-radius-md: 8px;
+  --graphite-radius-lg: 10px;
+}
+
+html,
+body,
+#root {
+  background: var(--canvas);
+}
+
+body {
+  font-size: 13px;
+  letter-spacing: -0.005em;
+}
+
+button,
+input,
+textarea,
+select {
+  letter-spacing: inherit;
+}
+
+:where(button, input, textarea, select, summary, [role="tab"], [role="button"]):focus-visible {
+  outline-color: color-mix(in srgb, var(--focus) 78%, white);
+}
+
+::selection {
+  color: var(--ink);
+  background: var(--brand-soft);
+}
+
+/* App shell ---------------------------------------------------------------- */
+
+.app-shell {
+  grid-template-columns: var(--rail-width) minmax(0, 1fr);
+  grid-template-rows: 56px minmax(0, 1fr);
+  background: var(--canvas);
+}
+
+.topbar {
+  min-height: 56px;
+  gap: 12px;
+  padding: 0 24px;
+  border-bottom-color: var(--graphite-topbar-line);
+  background: var(--topbar);
+}
+
+.window-drag-strip {
+  height: 56px;
+}
+
+.window-drag-strip-members,
+.window-drag-strip-memory {
+  background: color-mix(in srgb, var(--topbar) 96%, transparent);
+  border-bottom: 1px solid var(--graphite-topbar-line);
+}
+
+.context-breadcrumb {
+  gap: 8px;
+}
+
+.context-project,
+.context-sep {
+  color: var(--faint);
+  font-size: 11px;
+}
+
+.topbar h1 {
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 690;
+  letter-spacing: -0.01em;
+}
+
+.context-day-badge,
+.run-badge,
+.approval-badge,
+.state-chip,
+.status-badge,
+.activity-status,
+.approval-status {
+  border-radius: 999px;
+}
+
+.topbar-inspector-toggle {
+  border-radius: var(--graphite-radius-sm);
+}
+
+.topbar-inspector-toggle:hover {
+  background: var(--surface-hover);
+}
+
+.content {
+  background: var(--surface);
+}
+
+.content.task-content {
+  background: var(--conversation-surface);
+}

--- a/apps/desktop/src/renderer/src/graphite-command-overlays.css
+++ b/apps/desktop/src/renderer/src/graphite-command-overlays.css
@@ -1,0 +1,260 @@
+/* Notifications, dialogs and transient UI -------------------------------- */
+
+.dialog-overlay,
+.attachment-lightbox-overlay,
+.memory-drawer-overlay {
+  backdrop-filter: blur(3px);
+}
+
+.dialog-content,
+.new-camp-dialog,
+.notification-center,
+.notification-drawer,
+.memory-proposal-drawer {
+  border-color: var(--line-strong);
+  border-radius: var(--graphite-radius-lg);
+  color: var(--ink);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-dialog);
+}
+
+.dialog-heading,
+.new-camp-dialog-header,
+.notification-center-header,
+.memory-proposal-drawer > header {
+  border-bottom-color: var(--line);
+}
+
+.dialog-heading h2,
+.new-camp-dialog-header h2,
+.notification-center-header h2,
+.memory-proposal-drawer h2 {
+  letter-spacing: -0.03em;
+}
+
+.dialog-close,
+.notification-center-close {
+  border-radius: var(--graphite-radius-sm);
+  background: var(--surface-subtle);
+}
+
+.new-camp-dialog-header {
+  border-top: 3px solid var(--ink);
+}
+
+.new-camp-section-heading > span {
+  border-radius: var(--graphite-radius-xs);
+  color: var(--graphite-accent-ink);
+  background: var(--graphite-accent);
+}
+
+.new-camp-picker-trigger,
+.new-camp-project-option,
+.new-camp-member-option,
+.workspace-capability-note,
+.notification-card,
+.notification-item {
+  border-radius: var(--graphite-radius-sm);
+}
+
+.new-camp-picker-trigger {
+  border-color: transparent;
+  border-bottom-color: var(--line-strong);
+  border-radius: 4px 4px 0 0;
+  background: var(--graphite-field);
+}
+
+.new-camp-picker-trigger[aria-expanded="true"] {
+  border-color: transparent;
+  border-bottom-color: var(--brand);
+  box-shadow: inset 0 -2px 0 var(--brand);
+}
+
+.new-camp-picker-menu {
+  border-radius: var(--graphite-radius-md);
+}
+
+.new-camp-project-option.selected {
+  color: var(--brand-ink);
+  background: var(--brand-soft);
+}
+
+.notification-drawer {
+  border-radius: var(--graphite-radius-lg) 0 0 var(--graphite-radius-lg);
+}
+
+.notification-drawer-header,
+.notification-drawer-actions,
+.notification-filter {
+  border-color: var(--line);
+}
+
+.notification-filter button {
+  border-radius: var(--graphite-radius-xs);
+}
+
+.notification-filter button[aria-pressed="true"] {
+  color: var(--brand-ink);
+  background: var(--brand-soft);
+}
+
+.notification-row {
+  border-bottom-color: var(--line);
+}
+
+.notification-row:hover,
+.notification-row.unread {
+  background: var(--surface-subtle);
+}
+
+.notification-unread-mark {
+  background: var(--brand);
+}
+
+.notification-heads-up {
+  border-color: var(--line-strong);
+  border-radius: var(--graphite-radius-md);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-float);
+}
+
+.app-toast,
+.toast {
+  border-color: var(--line-strong);
+  border-radius: var(--graphite-radius-md);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-float);
+}
+
+.error-banner,
+.memory-proposal-notice,
+.runtime-recovery-dock {
+  border-radius: var(--graphite-radius-sm);
+}
+
+.startup-gate,
+.empty-state {
+  background:
+    linear-gradient(180deg, rgb(110 216 195 / 7%), transparent 180px),
+    var(--surface);
+}
+
+.startup-gate-mark,
+.empty-state > span {
+  color: var(--brand);
+}
+
+/* Responsive --------------------------------------------------------------- */
+
+@media (max-width: 1180px) {
+  :root {
+    --rail-width: 242px;
+  }
+
+  .settings-workbench {
+    padding-right: 30px;
+    padding-left: 30px;
+  }
+
+  .memory-library {
+    width: min(calc(100% - 40px), 1080px);
+  }
+}
+
+@media (max-width: 960px) {
+  .settings-panel .section-block {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 16px;
+  }
+
+  .settings-panel .section-block > .section-heading,
+  .settings-panel .section-block > :not(.section-heading) {
+    grid-column: 1;
+  }
+
+  .member-detail-scroll {
+    padding-right: 24px;
+    padding-left: 24px;
+  }
+
+  .memory-catalog-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 760px) {
+  :root {
+    --rail-width: 214px;
+  }
+
+  .app-shell {
+    grid-template-columns: var(--rail-width) minmax(0, 1fr);
+  }
+
+  .topbar {
+    padding-right: 14px;
+    padding-left: 14px;
+  }
+
+  .new-conversation-stage {
+    width: min(calc(100% - 36px), 720px);
+    padding-top: 64px;
+  }
+
+  .timeline-track {
+    width: min(calc(100% - 28px), 760px);
+  }
+
+  .composer {
+    padding-right: 14px;
+    padding-left: 14px;
+  }
+
+  .settings-workbench {
+    padding: 28px 18px 54px;
+  }
+
+  .settings-page-heading,
+  .memory-library-header,
+  .member-detail-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .memory-library {
+    width: calc(100% - 28px);
+  }
+
+  .memory-summary-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .memory-summary-strip > div + div {
+    border-left: 0;
+    border-top: 1px solid var(--line);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+@media (forced-colors: active) {
+  .rail-button.active,
+  .camp-nav-row.selected,
+  .member-sidebar-row.selected,
+  .startup-location-option:has(input:checked),
+  .appearance-option:has(input:checked),
+  .general-default-member-row:has(input:checked),
+  .memory-catalog-item.selected {
+    outline: 2px solid Highlight;
+    outline-offset: -2px;
+  }
+}

--- a/apps/desktop/src/renderer/src/graphite-command-settings.css
+++ b/apps/desktop/src/renderer/src/graphite-command-settings.css
@@ -1,0 +1,261 @@
+/* Settings ----------------------------------------------------------------- */
+
+.content.settings-content {
+  position: relative;
+  padding: 56px 0 0;
+  overflow: hidden;
+  background: var(--surface);
+}
+
+.content.settings-content::before {
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  right: 0;
+  left: 0;
+  display: flex;
+  height: 56px;
+  align-items: center;
+  padding: 0 24px;
+  border-bottom: 1px solid var(--graphite-topbar-line);
+  color: var(--faint);
+  background: var(--topbar);
+  content: "设置";
+  font-size: 11px;
+  -webkit-app-region: drag;
+}
+
+.settings-workbench {
+  height: 100%;
+  overflow: auto;
+  padding: 36px clamp(30px, 4.5vw, 72px) 72px;
+  background: var(--surface);
+  scrollbar-width: thin;
+}
+
+.settings-panel {
+  width: min(1040px, 100%);
+  max-width: none;
+  margin: 0 auto;
+}
+
+.settings-page-heading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 28px;
+  padding: 0 0 25px;
+  border-bottom: 2px solid var(--ink);
+}
+
+.settings-page-heading-copy {
+  min-width: 0;
+}
+
+.settings-page-eyebrow {
+  margin: 0 0 8px;
+}
+
+.settings-page-heading h1 {
+  margin: 0;
+  color: var(--ink);
+  font-size: clamp(27px, 3vw, 34px);
+  font-weight: 760;
+  line-height: 1.1;
+  letter-spacing: -0.045em;
+}
+
+.settings-page-heading-copy > p:last-child {
+  max-width: 700px;
+  margin: 9px 0 0;
+  color: var(--muted);
+  font-size: 11.5px;
+  line-height: 1.65;
+}
+
+.settings-page-heading-aside {
+  flex: 0 0 auto;
+}
+
+.settings-panel .section-block {
+  display: grid;
+  grid-template-columns: 190px minmax(0, 1fr);
+  gap: clamp(30px, 4vw, 52px);
+  margin: 0;
+  padding: 30px 0;
+  border: 0;
+  border-bottom: 1px solid var(--line);
+  border-radius: 0;
+  background: transparent;
+}
+
+.settings-panel .section-block:last-child {
+  border-bottom: 0;
+}
+
+.settings-panel .section-block > .section-heading {
+  display: grid;
+  grid-column: 1;
+  align-content: start;
+  gap: 5px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.settings-panel .section-block > .section-heading > div {
+  display: grid;
+  gap: 5px;
+}
+
+.settings-panel .section-block > .section-heading h2 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+}
+
+.settings-panel .section-block > .section-heading p,
+.settings-panel .section-block > .section-heading small {
+  color: var(--muted);
+  font-size: 10.5px;
+  line-height: 1.55;
+}
+
+.settings-panel .section-block > :not(.section-heading) {
+  grid-column: 2;
+  min-width: 0;
+}
+
+.general-settings-section,
+.appearance-settings,
+.notification-settings .section-block,
+.skill-settings .section-block,
+.mcp-settings .section-block,
+.diagnostics-center .section-block {
+  box-shadow: none;
+}
+
+.general-setting-row,
+.notification-switch,
+.general-subsection-heading,
+.settings-row {
+  min-height: 50px;
+}
+
+.general-setting-row + .general-setting-row,
+.notification-switch + .notification-switch {
+  border-top-color: var(--line);
+}
+
+.startup-location-options,
+.appearance-options,
+.general-default-member-list {
+  gap: 8px;
+}
+
+.startup-location-option,
+.appearance-option,
+.general-default-member-row,
+.skill-source-option,
+.mcp-import-option {
+  border-color: transparent;
+  border-left: 2px solid var(--line-strong);
+  border-radius: 0 var(--graphite-radius-sm) var(--graphite-radius-sm) 0;
+  background: var(--surface-subtle);
+}
+
+.startup-location-option:hover,
+.appearance-option:hover,
+.general-default-member-row:hover,
+.skill-source-option:hover,
+.mcp-import-option:hover {
+  border-left-color: color-mix(in srgb, var(--brand) 48%, var(--line-strong));
+  background: var(--surface-muted);
+}
+
+.startup-location-option:has(input:checked),
+.appearance-option:has(input:checked),
+.general-default-member-row:has(input:checked),
+.skill-source-option:has(input:checked),
+.mcp-import-option:has(input:checked) {
+  border-color: transparent;
+  border-left-color: var(--brand);
+  background: var(--brand-soft);
+}
+
+.general-default-member-list,
+.skill-list,
+.mcp-server-list,
+.runtime-installation-list,
+.diagnostics-result-list {
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--graphite-radius-md);
+  background: var(--surface-raised);
+}
+
+.general-default-member-row,
+.skill-row,
+.mcp-server-row,
+.runtime-installation-row,
+.diagnostics-result-row {
+  border-radius: 0;
+}
+
+.general-inline-status,
+.general-recovery-note,
+.skill-import-help,
+.mcp-file-banner,
+.mcp-permission-banner,
+.notification-inline-note,
+.diagnostics-privacy-note {
+  border-radius: var(--graphite-radius-sm);
+}
+
+.skill-card,
+.skill-source-card,
+.mcp-member-card,
+.mcp-server-card,
+.diagnostics-summary,
+.appearance-option {
+  box-shadow: none;
+}
+
+.skill-card,
+.mcp-member-card,
+.mcp-server-card {
+  border-radius: var(--graphite-radius-sm);
+}
+
+.skill-card:hover,
+.mcp-member-card:hover,
+.mcp-server-card:hover {
+  border-color: color-mix(in srgb, var(--brand) 28%, var(--line));
+}
+
+.mcp-json-editor textarea,
+.mcp-import-json textarea,
+pre,
+code {
+  font-variant-ligatures: none;
+}
+
+.mcp-json-editor textarea,
+.mcp-import-json textarea {
+  border-radius: 4px 4px 0 0;
+  background: var(--evidence-canvas);
+}
+
+.diagnostics-summary,
+.diagnostic-summary {
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--graphite-radius-md);
+  background: var(--surface-raised);
+}
+
+.diagnostic-stat + .diagnostic-stat {
+  border-left-color: var(--line);
+}

--- a/apps/desktop/src/renderer/src/graphite-command-sidebar.css
+++ b/apps/desktop/src/renderer/src/graphite-command-sidebar.css
@@ -1,0 +1,284 @@
+/* Graphite sidebar --------------------------------------------------------- */
+
+.unified-sidebar {
+  padding: 0 13px 14px;
+  color: var(--graphite-sidebar-ink);
+  border-right-color: var(--rail-line);
+  background: var(--rail);
+}
+
+.unified-sidebar-drag {
+  flex-basis: 28px;
+}
+
+.unified-brand {
+  min-height: 50px;
+  padding: 0 7px 14px;
+}
+
+.rail-logo {
+  min-height: 34px;
+  gap: 10px;
+  color: var(--graphite-accent);
+}
+
+.rail-logo > svg {
+  width: 30px;
+  height: 30px;
+  padding: 4px;
+  border-radius: 7px;
+  color: var(--graphite-accent-ink);
+  background: var(--graphite-accent);
+}
+
+.rail-logo strong {
+  color: var(--graphite-sidebar-title);
+  font-size: 15px;
+  font-weight: 720;
+}
+
+.rail-logo small,
+.rail-logo span span {
+  color: var(--graphite-sidebar-faint);
+}
+
+.notification-trigger {
+  color: var(--graphite-sidebar-muted);
+  border-radius: var(--graphite-radius-sm);
+}
+
+.notification-trigger:hover {
+  color: var(--graphite-sidebar-title);
+  background: var(--graphite-sidebar-hover);
+}
+
+.notification-trigger-badge {
+  color: var(--graphite-accent-ink);
+  border-color: var(--rail);
+  background: var(--graphite-accent);
+}
+
+.unified-primary-nav {
+  gap: 3px;
+  margin-bottom: 14px;
+}
+
+.rail-button {
+  position: relative;
+  min-height: 39px;
+  gap: 9px;
+  padding: 0 10px;
+  overflow: hidden;
+  border-radius: var(--graphite-radius-sm);
+  color: var(--graphite-sidebar-ink);
+}
+
+.rail-label {
+  font-size: 12px;
+  font-weight: 620;
+}
+
+.rail-glyph {
+  width: 22px;
+  flex-basis: 22px;
+  color: var(--graphite-sidebar-muted);
+}
+
+.rail-button:hover:not(:disabled) {
+  color: var(--graphite-sidebar-title);
+  background: var(--graphite-sidebar-hover);
+}
+
+.rail-button.active {
+  color: var(--graphite-sidebar-title);
+  background: var(--graphite-sidebar-active);
+}
+
+.rail-button.active::before {
+  position: absolute;
+  top: 7px;
+  bottom: 7px;
+  left: 0;
+  width: 3px;
+  border-radius: 0 3px 3px 0;
+  background: var(--graphite-accent);
+  content: "";
+}
+
+.rail-button.active .rail-glyph {
+  color: var(--graphite-accent);
+}
+
+.rail-button.active .rail-label {
+  font-weight: 660;
+}
+
+.rail-badge-dot {
+  background: var(--graphite-accent);
+  box-shadow: 0 0 0 3px rgb(110 216 195 / 12%);
+}
+
+.navigation-scroll {
+  scrollbar-color: #3b424d transparent;
+}
+
+.navigation-section-title {
+  color: var(--graphite-sidebar-faint);
+}
+
+.navigation-section-title > span {
+  color: inherit;
+  font: 700 9px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.section-create-button,
+.group-create-button,
+.sidebar-menu-trigger {
+  color: var(--graphite-sidebar-muted);
+  border-radius: var(--graphite-radius-xs);
+}
+
+.section-create-button:hover,
+.group-create-button:hover,
+.sidebar-menu-trigger:hover,
+.sidebar-menu-trigger[data-state="open"] {
+  color: var(--graphite-sidebar-title);
+  background: var(--graphite-sidebar-hover);
+}
+
+.project-heading-row,
+.camp-nav-row {
+  border-radius: var(--graphite-radius-sm);
+}
+
+.project-heading-row:hover,
+.camp-nav-row:hover {
+  background: var(--graphite-sidebar-hover);
+}
+
+.project-select-row,
+.camp-nav-open {
+  color: #c2c9d3;
+}
+
+.project-select-row:hover,
+.project-select-row[aria-current="true"],
+.camp-nav-row.selected .camp-nav-open {
+  color: var(--graphite-sidebar-title);
+}
+
+.project-folder-glyph {
+  color: var(--graphite-sidebar-muted);
+}
+
+.project-select-row[aria-current="true"] .project-folder-glyph,
+.project-heading-row[data-expanded="true"] .project-folder-glyph {
+  color: var(--graphite-accent);
+}
+
+.project-folder-glyph .folder-fill {
+  fill: rgb(110 216 195 / 10%);
+}
+
+.camp-nav-row.selected {
+  background: var(--graphite-sidebar-active);
+}
+
+.camp-nav-row.selected::before {
+  top: 6px;
+  bottom: 6px;
+  width: 3px;
+  background: var(--graphite-accent);
+}
+
+.conversation-jump {
+  border-color: var(--rail-line);
+  border-radius: var(--graphite-radius-sm);
+  color: var(--graphite-sidebar-muted);
+  background: var(--graphite-sidebar-hover);
+}
+
+.conversation-jump:hover {
+  border-color: #46505d;
+  color: var(--graphite-sidebar-title);
+}
+
+.conversation-jump kbd {
+  color: var(--graphite-sidebar-muted);
+  background: var(--graphite-sidebar-active);
+}
+
+.camp-draft-badge,
+.sidebar-empty,
+.show-more-camps,
+.collapse-camps,
+.camp-nav-open small {
+  color: var(--graphite-sidebar-faint);
+}
+
+.show-more-camps:hover,
+.collapse-camps:hover {
+  color: var(--graphite-sidebar-title);
+  background: var(--graphite-sidebar-hover);
+}
+
+.pinned-navigation,
+.unified-sidebar-footer,
+.settings-sidebar-heading {
+  border-color: var(--rail-line);
+}
+
+.settings-sidebar-back {
+  border-radius: var(--graphite-radius-sm);
+  color: var(--graphite-sidebar-ink);
+}
+
+.settings-sidebar-back > span {
+  color: var(--graphite-sidebar-faint);
+}
+
+.settings-sidebar-back:hover {
+  color: var(--graphite-sidebar-title);
+  background: var(--graphite-sidebar-hover);
+}
+
+.settings-sidebar-title small,
+.settings-sidebar-title span {
+  color: var(--graphite-sidebar-faint);
+}
+
+.settings-sidebar-title strong {
+  color: var(--graphite-sidebar-title);
+  font-size: 20px;
+  letter-spacing: -0.035em;
+}
+
+.unified-sidebar-footer {
+  color: var(--graphite-sidebar-muted);
+}
+
+.unified-sidebar-footer .rail-button {
+  min-height: 36px;
+}
+
+/* Portaled menus stay light even when opened from the dark rail. */
+.sidebar-action-menu,
+.command-palette,
+.mention-menu {
+  border-color: var(--line-strong);
+  border-radius: var(--graphite-radius-md);
+  color: var(--ink);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-menu);
+}
+
+.sidebar-action-menu-item[data-highlighted],
+.command-palette-item:hover,
+.command-palette-item.active,
+.mention-menu button:hover,
+.mention-menu button.active {
+  color: var(--brand-ink);
+  background: var(--brand-soft);
+}

--- a/apps/desktop/src/renderer/src/graphite-command-workspaces.css
+++ b/apps/desktop/src/renderer/src/graphite-command-workspaces.css
@@ -1,0 +1,681 @@
+/* Shared controls ---------------------------------------------------------- */
+
+.primary-button,
+.dialog-content .primary-button,
+.new-camp-dialog .primary-button,
+.memory-library .primary-button,
+.settings-panel .primary-button,
+.member-dialog .primary-button {
+  min-height: 34px;
+  border-color: var(--graphite-charcoal-button);
+  border-radius: var(--graphite-radius-sm);
+  color: #eafffa;
+  background: var(--graphite-charcoal-button);
+  box-shadow: none;
+}
+
+.primary-button:hover:not(:disabled),
+.dialog-content .primary-button:hover:not(:disabled),
+.new-camp-dialog .primary-button:hover:not(:disabled),
+.memory-library .primary-button:hover:not(:disabled),
+.settings-panel .primary-button:hover:not(:disabled),
+.member-dialog .primary-button:hover:not(:disabled) {
+  border-color: var(--graphite-charcoal-button-hover);
+  background: var(--graphite-charcoal-button-hover);
+}
+
+.quiet-button,
+.secondary-button,
+.icon-button,
+.danger-button {
+  border-radius: var(--graphite-radius-sm);
+}
+
+.quiet-button,
+.secondary-button {
+  border-color: var(--line-strong);
+  background: var(--surface-raised);
+}
+
+.quiet-button:hover:not(:disabled),
+.secondary-button:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--brand) 30%, var(--line-strong));
+  background: var(--surface-subtle);
+}
+
+.danger-button {
+  border-color: color-mix(in srgb, var(--danger) 28%, var(--line));
+  color: var(--danger);
+  background: var(--danger-soft);
+}
+
+:where(.settings-panel, .member-detail-scroll, .memory-library, .dialog-content, .new-camp-dialog)
+  :is(input[type="text"], input[type="search"], input[type="url"], input[type="password"], input[type="number"], select, textarea) {
+  border: 0;
+  border-bottom: 1px solid var(--line-strong);
+  border-radius: 4px 4px 0 0;
+  outline: 0;
+  background: var(--graphite-field);
+}
+
+:where(.settings-panel, .member-detail-scroll, .memory-library, .dialog-content, .new-camp-dialog)
+  :is(input[type="text"], input[type="search"], input[type="url"], input[type="password"], input[type="number"], select, textarea):hover {
+  border-bottom-color: color-mix(in srgb, var(--brand) 58%, var(--line-strong));
+}
+
+:where(.settings-panel, .member-detail-scroll, .memory-library, .dialog-content, .new-camp-dialog)
+  :is(input[type="text"], input[type="search"], input[type="url"], input[type="password"], input[type="number"], select, textarea):focus {
+  border-bottom-color: var(--brand);
+  background: var(--surface-raised);
+  box-shadow: inset 0 -2px 0 var(--brand);
+}
+
+input[type="checkbox"],
+input[type="radio"] {
+  accent-color: var(--brand);
+}
+
+.notification-switch input[type="checkbox"],
+.general-setting-row input[role="switch"],
+.skill-row input[role="switch"],
+.mcp-server-row input[role="switch"] {
+  accent-color: var(--brand);
+}
+
+.section-block,
+.context-card,
+.camp-context-controls,
+.approval-card,
+.task-card,
+.execution-drawer,
+.run-pulse,
+.memory-detail,
+.memory-catalog-list,
+.member-section,
+.dialog-content,
+.new-camp-dialog {
+  box-shadow: none;
+}
+
+/* Quick Chat / compose ----------------------------------------------------- */
+
+.content.compose-content {
+  padding: 0;
+  background: var(--home-surface);
+}
+
+.workspace-shell,
+.new-conversation-workspace,
+.quick-chat-workspace {
+  background: var(--home-surface);
+}
+
+.new-conversation-main {
+  background:
+    linear-gradient(180deg, rgb(110 216 195 / 7%), transparent 180px),
+    var(--home-surface);
+}
+
+.new-conversation-stage {
+  width: min(860px, calc(100% - 64px));
+  padding: 80px 0 72px;
+}
+
+.quick-chat-mark {
+  filter: saturate(0.82);
+}
+
+.quick-chat-eyebrow,
+.empty-camp-eyebrow,
+.settings-page-eyebrow,
+.eyebrow {
+  color: var(--brand);
+  font: 760 9px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.new-conversation-stage h2 {
+  color: var(--ink);
+  font-size: clamp(30px, 4vw, 44px);
+  font-weight: 760;
+  letter-spacing: -0.05em;
+}
+
+.quick-chat-subline {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.65;
+}
+
+.quick-chat-continue {
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--graphite-radius-md);
+  background: var(--surface-raised);
+}
+
+.quick-chat-continue-title {
+  color: var(--faint);
+  background: var(--surface-subtle);
+  font: 700 9px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.quick-chat-continue-row {
+  border-radius: 0;
+}
+
+.quick-chat-continue-row:hover {
+  background: var(--surface-subtle);
+}
+
+.quick-chat-empty {
+  border-top: 2px solid var(--ink);
+}
+
+/* Camp conversation -------------------------------------------------------- */
+
+.camp-workspace {
+  background: var(--conversation-surface);
+}
+
+.workspace-grid {
+  background: var(--conversation-surface);
+}
+
+.timeline-pane {
+  background: var(--conversation-surface);
+}
+
+.activity-pane {
+  border-left-color: var(--conversation-inspector-line);
+  background: var(--inspector-surface);
+}
+
+.tabs-list,
+.sticky-tabs {
+  border-bottom-color: var(--graphite-topbar-line);
+  background: color-mix(in srgb, var(--inspector-surface) 96%, transparent);
+}
+
+.tabs-list [role="tab"] {
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.015em;
+}
+
+.tabs-list [role="tab"][data-state="active"],
+.tabs-list [role="tab"][aria-selected="true"] {
+  color: var(--brand-ink);
+}
+
+.tabs-list [role="tab"][data-state="active"]::after,
+.tabs-list [role="tab"][aria-selected="true"]::after {
+  height: 2px;
+  background: var(--brand);
+}
+
+.timeline-track {
+  width: min(820px, calc(100% - 54px));
+}
+
+.timeline-day {
+  color: var(--faint);
+  font: 700 9px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.conversation-bubble {
+  gap: 11px;
+}
+
+.conversation-bubble .message-body {
+  min-width: 0;
+}
+
+.bubble-meta {
+  color: var(--faint);
+}
+
+.bubble-meta strong {
+  color: var(--ink);
+  font-size: 11px;
+}
+
+.message-surface {
+  border-radius: var(--graphite-radius-md);
+}
+
+.conversation-bubble.user .message-surface,
+.message-bubble {
+  border-radius: var(--graphite-radius-md);
+  color: var(--ink);
+  background: var(--surface-muted);
+}
+
+.conversation-bubble.agent .message-surface {
+  border-left: 2px solid color-mix(in srgb, var(--agent-accent, var(--brand)) 72%, var(--line));
+  border-radius: 0 var(--graphite-radius-md) var(--graphite-radius-md) 0;
+  background: transparent;
+}
+
+.final-copy {
+  color: var(--ink);
+}
+
+.final-copy :is(pre, code),
+.message-surface :is(pre, code),
+.execution-drawer :is(pre, code),
+.context-card :is(pre, code) {
+  border-radius: var(--graphite-radius-sm);
+}
+
+.message-run-origin,
+.message-copy-button {
+  border-radius: var(--graphite-radius-xs);
+}
+
+.task-timeline-card,
+.task-card {
+  border-radius: var(--graphite-radius-sm);
+  background: var(--surface-subtle);
+}
+
+.task-timeline-card:hover,
+.task-card:hover {
+  border-color: color-mix(in srgb, var(--brand) 28%, var(--line));
+}
+
+.empty-camp-welcome {
+  max-width: 760px;
+  padding: 54px 0 46px;
+}
+
+.empty-camp-description {
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.empty-camp-context {
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--graphite-radius-md);
+  background: var(--surface-subtle);
+}
+
+.starter-prompts {
+  gap: 8px;
+}
+
+.starter-prompts button {
+  border-radius: var(--graphite-radius-sm);
+  background: var(--surface-subtle);
+}
+
+.starter-prompts button:hover {
+  border-color: color-mix(in srgb, var(--brand) 32%, var(--line));
+  background: var(--brand-soft);
+}
+
+.run-pulse {
+  border-bottom-color: var(--line);
+  background: var(--surface-subtle);
+}
+
+.run-pulse button,
+.execution-drawer button,
+.runtime-option {
+  border-radius: var(--graphite-radius-sm);
+}
+
+.execution-drawer {
+  border-color: var(--line-strong);
+  border-radius: var(--graphite-radius-lg) var(--graphite-radius-lg) 0 0;
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-dialog);
+}
+
+.context-card,
+.camp-context-controls {
+  border-radius: var(--graphite-radius-sm);
+}
+
+.context-card {
+  background: var(--evidence-surface);
+}
+
+.camp-context-controls {
+  border-left: 2px solid var(--brand);
+  border-radius: 0 var(--graphite-radius-sm) var(--graphite-radius-sm) 0;
+  background: var(--surface-subtle);
+}
+
+.approval-card,
+.approval-dock {
+  border-radius: var(--graphite-radius-sm);
+}
+
+.approval-dock {
+  border-top: 2px solid var(--attention);
+  background: var(--attention-soft);
+}
+
+.inspector-meta {
+  border-top-color: var(--line);
+  color: var(--faint);
+  background: var(--inspector-surface);
+}
+
+.composer {
+  padding: 0 27px 16px;
+  background: var(--conversation-surface);
+}
+
+.composer-box {
+  width: min(820px, 100%);
+  border: 0;
+  border-bottom: 1px solid var(--line-strong);
+  border-radius: 6px 6px 0 0;
+  background: var(--graphite-field);
+  box-shadow: none;
+}
+
+.composer-box:focus-within {
+  border-color: var(--brand);
+  background: var(--surface-raised);
+  box-shadow: inset 0 -2px 0 var(--brand);
+}
+
+.composer-send,
+.send-button {
+  border-radius: var(--graphite-radius-sm);
+  color: var(--graphite-accent-ink);
+  background: var(--graphite-accent);
+}
+
+.composer-send:hover:not(:disabled),
+.send-button:hover:not(:disabled) {
+  color: var(--brand-contrast);
+  background: var(--brand);
+}
+
+/* Members ------------------------------------------------------------------ */
+
+.content.members-content {
+  background: var(--home-surface);
+}
+
+.member-sidebar-navigation,
+.member-sidebar-list {
+  color: var(--graphite-sidebar-ink);
+}
+
+.member-sidebar-heading,
+.member-sidebar-toolbar {
+  border-color: var(--rail-line);
+}
+
+.member-sidebar-heading strong,
+.member-sidebar-title,
+.member-sidebar-copy strong {
+  color: var(--graphite-sidebar-title);
+}
+
+.member-sidebar-heading small,
+.member-sidebar-copy small,
+.member-sidebar-empty p {
+  color: var(--graphite-sidebar-muted);
+}
+
+.member-sidebar-row {
+  border-radius: var(--graphite-radius-sm);
+}
+
+.member-sidebar-row:hover {
+  background: var(--graphite-sidebar-hover);
+}
+
+.member-sidebar-row.selected {
+  background: var(--graphite-sidebar-active);
+}
+
+.member-sidebar-row.selected .member-sidebar-copy strong {
+  color: var(--graphite-sidebar-title);
+}
+
+.member-runtime-shortcut,
+.member-order-handle {
+  color: var(--graphite-sidebar-muted);
+  border-radius: var(--graphite-radius-sm);
+}
+
+.member-runtime-shortcut:hover,
+.member-order-handle:hover {
+  color: var(--graphite-sidebar-title);
+  background: var(--graphite-sidebar-hover);
+}
+
+.member-detail-scroll {
+  padding-right: clamp(24px, 4vw, 54px);
+  padding-left: clamp(24px, 4vw, 54px);
+  background: var(--home-surface);
+}
+
+.member-detail-header {
+  min-height: 84px;
+  padding: 10px 0 14px;
+  border-bottom: 2px solid var(--ink);
+}
+
+.member-detail-heading h2 {
+  font-size: clamp(24px, 2.6vw, 32px);
+  font-weight: 750;
+  letter-spacing: -0.045em;
+}
+
+.member-detail-statuses > span,
+.member-header-runtime {
+  border-radius: 999px;
+  background: var(--surface-subtle);
+}
+
+.member-tabs {
+  gap: 24px;
+  min-height: 48px;
+}
+
+.member-tabs button {
+  font-size: 11px;
+}
+
+.member-tabs button[aria-selected="true"]::after {
+  background: var(--brand);
+}
+
+.member-section {
+  border-radius: 0;
+  background: transparent;
+}
+
+.member-section + .member-section {
+  border-top: 1px solid var(--line);
+}
+
+.member-identity-overview {
+  gap: clamp(28px, 5vw, 64px);
+}
+
+.member-portrait,
+.member-portrait-button,
+.member-preset-card {
+  border-radius: var(--graphite-radius-md);
+}
+
+.member-portrait-edit {
+  border-radius: 999px;
+}
+
+.runtime-installation-list,
+.member-runtime-list {
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--graphite-radius-md);
+  background: var(--surface-raised);
+}
+
+.runtime-installation-row {
+  padding-right: 14px;
+  padding-left: 14px;
+}
+
+.member-detail-menu > summary,
+.member-detail-menu > div {
+  border-radius: var(--graphite-radius-sm);
+}
+
+/* Memory ------------------------------------------------------------------- */
+
+.content.memory-content {
+  padding: 0;
+  background: var(--home-surface);
+}
+
+.memory-library {
+  width: min(1180px, calc(100% - 64px));
+  margin: 0 auto;
+  padding: 30px 0 64px;
+}
+
+.memory-library-header {
+  min-height: 94px;
+  padding: 8px 0 22px;
+  border-bottom: 2px solid var(--ink);
+}
+
+.memory-library-header h2 {
+  margin: 0;
+  font-size: clamp(28px, 3vw, 36px);
+  font-weight: 760;
+  letter-spacing: -0.05em;
+}
+
+.memory-library-header p {
+  color: var(--muted);
+  font-size: 11.5px;
+  line-height: 1.65;
+}
+
+.memory-summary-strip {
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--graphite-radius-md);
+  background: var(--surface-raised);
+}
+
+.memory-summary-strip > div {
+  background: transparent;
+}
+
+.memory-summary-strip > div + div {
+  border-left: 1px solid var(--line);
+}
+
+.memory-summary-strip strong {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.memory-pending-banner {
+  border-radius: var(--graphite-radius-sm);
+}
+
+.memory-scope-tabs {
+  border-bottom: 1px solid var(--line);
+}
+
+.memory-scope-tabs button,
+.memory-governance-tabs button {
+  border-radius: var(--graphite-radius-xs);
+}
+
+.memory-scope-tabs button.active {
+  color: var(--brand-ink);
+}
+
+.memory-scope-tabs button.active::after {
+  background: var(--brand);
+}
+
+.memory-governance-tabs {
+  padding: 3px;
+  border-radius: var(--graphite-radius-sm);
+  background: var(--surface-subtle);
+}
+
+.memory-governance-tabs button.active {
+  color: var(--brand-ink);
+  background: var(--surface-raised);
+  box-shadow: 0 1px 3px rgb(29 36 53 / 9%);
+}
+
+.memory-search input {
+  min-height: 36px;
+}
+
+.memory-capacity-strip {
+  border-radius: var(--graphite-radius-sm);
+  background: var(--surface-subtle);
+}
+
+.memory-catalog-layout {
+  gap: 14px;
+}
+
+.memory-catalog-list,
+.memory-detail {
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--graphite-radius-md);
+  background: var(--surface-raised);
+}
+
+.memory-catalog-item {
+  border-radius: 0;
+}
+
+.memory-catalog-item:hover {
+  background: var(--surface-subtle);
+}
+
+.memory-catalog-item.selected {
+  border-left-color: var(--brand);
+  background: var(--brand-soft);
+}
+
+.memory-detail > header {
+  border-bottom-color: var(--line);
+}
+
+.memory-detail-section + .memory-detail-section {
+  border-top-color: var(--line);
+}
+
+.memory-authority,
+.memory-catalog-meta > span,
+.memory-catalog-meta > b {
+  border-radius: 999px;
+}
+
+.memory-proposal-drawer {
+  border-left: 1px solid var(--line-strong);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-dialog);
+}
+
+.memory-proposal-item {
+  border-radius: var(--graphite-radius-sm);
+  background: var(--surface-subtle);
+}

--- a/apps/desktop/src/renderer/src/graphite-command.css
+++ b/apps/desktop/src/renderer/src/graphite-command.css
@@ -1,0 +1,6 @@
+/* Graphite Command is split by responsibility to keep renderer overrides reviewable. */
+@import './graphite-command-foundation.css';
+@import './graphite-command-sidebar.css';
+@import './graphite-command-workspaces.css';
+@import './graphite-command-settings.css';
+@import './graphite-command-overlays.css';

--- a/apps/desktop/src/renderer/src/graphite-command.test.ts
+++ b/apps/desktop/src/renderer/src/graphite-command.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const entry = readFileSync(new URL('./main.tsx', import.meta.url), 'utf8')
+const manifest = readFileSync(new URL('./graphite-command.css', import.meta.url), 'utf8')
+const css = [
+  'graphite-command-foundation.css',
+  'graphite-command-sidebar.css',
+  'graphite-command-workspaces.css',
+  'graphite-command-settings.css',
+  'graphite-command-overlays.css'
+].map((file) => readFileSync(new URL(`./${file}`, import.meta.url), 'utf8')).join('\n')
+
+describe('Graphite Command renderer layer', () => {
+  it('loads after the canonical renderer stylesheet', () => {
+    expect(entry.indexOf("import './graphite-command.css'"))
+      .toBeGreaterThan(entry.indexOf("import './styles.css'"))
+    expect(manifest.match(/@import/g)).toHaveLength(5)
+  })
+
+  it('covers every top-level desktop workspace without replacing behavior', () => {
+    for (const selector of [
+      '.unified-sidebar',
+      '.quick-chat-workspace',
+      '.camp-workspace',
+      '.content.members-content',
+      '.memory-library',
+      '.content.settings-content',
+      '.new-camp-dialog',
+      '.notification-drawer'
+    ]) {
+      expect(css, selector).toContain(selector)
+    }
+  })
+
+  it('keeps the shared Graphite palette and reduced-motion contract explicit', () => {
+    expect(css).toContain('--graphite-sidebar-active: #272e38')
+    expect(css).toContain('--graphite-accent: #6ed8c3')
+    expect(css).toContain('@media (prefers-reduced-motion: reduce)')
+  })
+})

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -2,10 +2,10 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { App } from './App'
 import './styles.css'
+import './graphite-command.css'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
   </StrictMode>
 )
-


### PR DESCRIPTION
## What changed

- add a Graphite Command visual foundation with the reference graphite, warm-white and mint palette
- redesign the shared application shell and dark command sidebar
- cover Quick Chat, Camp conversation/inspector/composer, Members, Memory, every Settings section, notifications, drawers, dialogs and startup/empty states
- reduce card radii and shadows, introduce underlined control treatments, stronger section dividers and responsive fallbacks
- keep accessibility behavior explicit with visible focus, reduced-motion and forced-colors handling
- add a renderer test that verifies the visual layer loads after the canonical stylesheet and covers every top-level workspace

## Functional impact

This is a presentation-only layer. Existing React components, IPC requests, keyboard interactions, persisted data contracts, camp execution flows, member management, memory governance, settings behavior and notification behavior are unchanged.

## Validation

- parsed every new CSS module with `tinycss2`: 0 syntax errors
- verified balanced rule blocks in all modules
- verified the entry import order and top-level workspace selector coverage
- verified every GitHub blob SHA against the locally generated file content

Full repository checks are left to GitHub Actions because this environment does not include the repository package manager or GitHub CLI.