### PR TITLE
build(mac): add stable signed release workflow

### DIFF
--- a/.github/workflows/macos-signed-build.yml
+++ b/.github/workflows/macos-signed-build.yml
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 26
 
@@ -132,15 +132,6 @@ jobs:
       - name: Verify signed DMG
         run: node scripts/verify-macos-release.mjs ${{ matrix.arch }}
 
-      - name: Upload signed artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.artifact-name }}
-          path: |
-            dist/*.dmg
-            dist/signing-report-*.txt
-          if-no-files-found: error
-
       - name: Clean signing material
         if: always()
         run: |
@@ -167,3 +158,13 @@ jobs:
             "$CERT_DER" \
             "$KEYCHAIN_PATH" \
             "$TRUST_MARKER"
+
+      - name: Upload signed artifacts
+        if: success()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: |
+            dist/*.dmg
+            dist/signing-report-*.txt
+          if-no-files-found: error

--- a/.github/workflows/macos-signed-build.yml
+++ b/.github/workflows/macos-signed-build.yml
@@ -7,7 +7,20 @@ permissions:
   contents: read
 
 jobs:
+  require-main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require main branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "Signed builds may only run from main."
+            exit 1
+          fi
+
   build:
+    needs: require-main
     name: macOS ${{ matrix.arch }} signed build
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -25,10 +38,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 26
 
@@ -102,6 +115,7 @@ jobs:
           sudo security add-trusted-cert \
             -d \
             -r trustRoot \
+            -p codeSign \
             -k /Library/Keychains/System.keychain \
             "$CERT_DER"
           touch "$TRUST_MARKER"

--- a/.github/workflows/macos-signed-build.yml
+++ b/.github/workflows/macos-signed-build.yml
@@ -1,0 +1,155 @@
+name: macOS signed build
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: macOS ${{ matrix.arch }} signed build
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            runner: macos-15
+            build-command: pnpm dist:mac:release:arm64
+            artifact-name: rovai-macos-arm64-signed
+          - arch: x64
+            runner: macos-15-intel
+            build-command: pnpm dist:mac:release:x64
+            artifact-name: rovai-macos-x64-signed
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 26
+
+      - name: Install pnpm
+        run: npm install --global pnpm@11.20.0
+
+      - name: Install Rust 1.97.1
+        run: |
+          rustup toolchain install 1.97.1 --profile minimal
+          rustup default 1.97.1
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Import and trust fixed signing identity
+        env:
+          MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          MAC_CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+        run: |
+          set +x
+          set -euo pipefail
+          umask 077
+
+          : "${MAC_CSC_LINK:?MAC_CSC_LINK is required}"
+          : "${MAC_CSC_KEY_PASSWORD:?MAC_CSC_KEY_PASSWORD is required}"
+
+          P12_PATH="$RUNNER_TEMP/rovai-release-signing.p12"
+          CERT_PEM="$RUNNER_TEMP/rovai-release-signing.pem"
+          CERT_DER="$RUNNER_TEMP/rovai-release-signing.cer"
+          KEYCHAIN_PATH="$RUNNER_TEMP/rovai-signing.keychain-db"
+          TRUST_MARKER="$RUNNER_TEMP/rovai-system-trust-added"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+          DEFAULT_KEYCHAIN="$(security default-keychain -d user | tr -d '"')"
+
+          printf '%s' "$MAC_CSC_LINK" | /usr/bin/base64 -D > "$P12_PATH"
+          test -s "$P12_PATH"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" "$DEFAULT_KEYCHAIN"
+
+          security import "$P12_PATH" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$MAC_CSC_KEY_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s \
+            -k "$KEYCHAIN_PASSWORD" \
+            "$KEYCHAIN_PATH"
+
+          openssl pkcs12 \
+            -in "$P12_PATH" \
+            -clcerts \
+            -nokeys \
+            -passin env:MAC_CSC_KEY_PASSWORD \
+            -out "$CERT_PEM"
+          openssl x509 -in "$CERT_PEM" -outform DER -out "$CERT_DER"
+
+          ACTUAL_FINGERPRINT="$(
+            openssl x509 -in "$CERT_PEM" -noout -fingerprint -sha256 \
+              | cut -d= -f2 \
+              | tr -d ':\r\n' \
+              | tr '[:lower:]' '[:upper:]'
+          )"
+          EXPECTED_FINGERPRINT="875C6F486E223AB1889A2AD63860FBE48F7E8C0E4D94832656896BA5DA4EF82E"
+          test "$ACTUAL_FINGERPRINT" = "$EXPECTED_FINGERPRINT"
+
+          sudo security add-trusted-cert \
+            -d \
+            -r trustRoot \
+            -k /Library/Keychains/System.keychain \
+            "$CERT_DER"
+          touch "$TRUST_MARKER"
+
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+            | grep -F 'Rovai Release Signing'
+
+          printf 'CSC_NAME=%s\n' 'Rovai Release Signing' >> "$GITHUB_ENV"
+          printf 'CSC_KEYCHAIN=%s\n' "$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+
+      - name: Build signed DMG
+        run: ${{ matrix.build-command }}
+
+      - name: Verify signed DMG
+        run: node scripts/verify-macos-release.mjs ${{ matrix.arch }}
+
+      - name: Upload signed artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: |
+            dist/*.dmg
+            dist/signing-report-*.txt
+          if-no-files-found: error
+
+      - name: Clean signing material
+        if: always()
+        run: |
+          set +x
+          P12_PATH="$RUNNER_TEMP/rovai-release-signing.p12"
+          CERT_PEM="$RUNNER_TEMP/rovai-release-signing.pem"
+          CERT_DER="$RUNNER_TEMP/rovai-release-signing.cer"
+          KEYCHAIN_PATH="$RUNNER_TEMP/rovai-signing.keychain-db"
+          TRUST_MARKER="$RUNNER_TEMP/rovai-system-trust-added"
+          DEFAULT_KEYCHAIN="$(security default-keychain -d user | tr -d '"')"
+
+          if test -f "$TRUST_MARKER" && test -f "$CERT_DER"; then
+            sudo security remove-trusted-cert -d "$CERT_DER" || true
+            sudo security delete-certificate \
+              -Z 465802DA7386E9676668078E7D44704CBBEADD1E \
+              /Library/Keychains/System.keychain || true
+          fi
+
+          security list-keychains -d user -s "$DEFAULT_KEYCHAIN" || true
+          security delete-keychain "$KEYCHAIN_PATH" || true
+          rm -f \
+            "$P12_PATH" \
+            "$CERT_PEM" \
+            "$CERT_DER" \
+            "$KEYCHAIN_PATH" \
+            "$TRUST_MARKER"

--- a/package.json
+++ b/package.json
@@ -91,8 +91,10 @@
     "smoke:missing-send-recovery": "pnpm core:build:debug && node scripts/smoke-missing-send-recovery.mjs",
     "experiment:p1:copilot-native-turn": "node scripts/experiment-copilot-native-turn-reconciliation.mjs",
     "test:p1:copilot-native-turn-evidence": "node --test scripts/lib/copilot-native-turn-reconciliation-evidence.test.mjs",
-    "package:mac": "pnpm build && CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --mac dir --arm64",
-    "dist:mac": "pnpm build && CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --mac dmg --arm64"
+    "package:mac": "pnpm build && CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --mac dir --arm64 -c.mac.identity=-",
+    "dist:mac": "pnpm build && CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --mac dmg --arm64 -c.mac.identity=-",
+    "dist:mac:release:arm64": "pnpm build && electron-builder --mac dmg --arm64 --publish never -c.mac.identity=\"Rovai Release Signing\" -c.forceCodeSigning=true",
+    "dist:mac:release:x64": "pnpm build && electron-builder --mac dmg --x64 --publish never -c.mac.identity=\"Rovai Release Signing\" -c.forceCodeSigning=true"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "1.1.19",
@@ -144,7 +146,10 @@
     "afterPack": "scripts/after-pack.cjs",
     "mac": {
       "icon": "build/icon.png",
-      "identity": "-",
+      "binaries": [
+        "Contents/Resources/bin/rovai-core",
+        "Contents/Resources/bin/rovai"
+      ],
       "hardenedRuntime": true,
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",

--- a/scripts/verify-macos-release.mjs
+++ b/scripts/verify-macos-release.mjs
@@ -1,0 +1,257 @@
+import { spawnSync } from 'node:child_process'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmdirSync,
+  statSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { basename, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const EXPECTED_APP_ID = 'ai.rovai.desktop'
+const EXPECTED_AUTHORITY = 'Rovai Release Signing'
+const EXPECTED_CERTIFICATE_ROOT = '465802da7386e9676668078e7d44704cbbeadd1e'
+const EXPECTED_ARCHITECTURES = {
+  arm64: 'arm64',
+  x64: 'x86_64'
+}
+
+const arch = process.argv[2]
+if (!(arch in EXPECTED_ARCHITECTURES)) {
+  console.error('Usage: node scripts/verify-macos-release.mjs <arm64|x64>')
+  process.exit(2)
+}
+
+const root = resolve(fileURLToPath(new URL('..', import.meta.url)))
+const distDir = join(root, 'dist')
+const reportPath = join(distDir, `signing-report-${arch}.txt`)
+const packageMetadata = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'))
+const productName = packageMetadata.build.productName
+const appName = `${productName}.app`
+const expectedArchitecture = EXPECTED_ARCHITECTURES[arch]
+const mountPoint = mkdtempSync(join(tmpdir(), `rovai-release-${arch}-`))
+const report = [
+  'Rovai macOS signing verification',
+  `Architecture: ${arch}`,
+  `Expected Mach-O architecture: ${expectedArchitecture}`
+]
+
+let mounted = false
+let failure = null
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: root,
+    encoding: 'utf8'
+  })
+  const output = `${result.stdout ?? ''}${result.stderr ?? ''}`.trim()
+  if (result.error) throw result.error
+  if (result.status !== 0) {
+    throw new Error(`${basename(command)} failed (${result.status}): ${output}`)
+  }
+  return output
+}
+
+function findDmg() {
+  if (!existsSync(distDir)) throw new Error('dist directory does not exist')
+
+  const expectedName = `${productName}-${packageMetadata.version}-${arch}.dmg`
+  const exactPath = join(distDir, expectedName)
+  if (existsSync(exactPath)) return exactPath
+
+  const candidates = readdirSync(distDir)
+    .filter((name) => name.startsWith(`${productName}-`) && name.endsWith(`-${arch}.dmg`))
+    .map((name) => join(distDir, name))
+
+  if (candidates.length !== 1) {
+    throw new Error(`expected exactly one ${arch} DMG in dist, found ${candidates.length}`)
+  }
+  return candidates[0]
+}
+
+function architectureOf(binaryPath) {
+  return run('/usr/bin/lipo', ['-archs', binaryPath]).split(/\s+/).filter(Boolean)
+}
+
+function assertArchitecture(label, binaryPath) {
+  const actual = architectureOf(binaryPath)
+  if (actual.length !== 1 || actual[0] !== expectedArchitecture) {
+    throw new Error(`${label} architecture is ${actual.join(' ')}, expected only ${expectedArchitecture}`)
+  }
+  report.push(`${label} architecture: ${actual[0]}`)
+}
+
+function findPackagedApp() {
+  const preferredDirectories = arch === 'arm64'
+    ? ['mac-arm64', 'mac']
+    : ['mac', 'mac-x64']
+  const candidates = preferredDirectories
+    .map((directory) => join(distDir, directory, appName))
+    .filter((candidate) => existsSync(candidate))
+
+  const matching = candidates.filter((candidate) => {
+    const executable = join(candidate, 'Contents', 'MacOS', productName)
+    try {
+      const actual = architectureOf(executable)
+      return actual.length === 1 && actual[0] === expectedArchitecture
+    } catch {
+      return false
+    }
+  })
+
+  if (matching.length !== 1) {
+    throw new Error(`expected exactly one unpacked ${arch} ${appName} in dist, found ${matching.length}`)
+  }
+  return matching[0]
+}
+
+function signatureDetails(label, targetPath) {
+  const details = run('/usr/bin/codesign', ['-d', '--verbose=4', targetPath])
+  if (/^Signature=adhoc$/m.test(details)) {
+    throw new Error(`${label} uses an ad-hoc signature`)
+  }
+
+  const authorities = [...details.matchAll(/^Authority=(.+)$/gm)].map((match) => match[1].trim())
+  if (!authorities.includes(EXPECTED_AUTHORITY)) {
+    throw new Error(`${label} is missing Authority=${EXPECTED_AUTHORITY}`)
+  }
+
+  const requirementOutput = run('/usr/bin/codesign', ['-d', '-r-', targetPath])
+  const designatedRequirement = requirementOutput
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.startsWith('designated =>'))
+
+  if (!designatedRequirement) throw new Error(`${label} has no designated requirement`)
+  if (/designated\s*=>\s*cdhash\b/i.test(designatedRequirement)) {
+    throw new Error(`${label} uses a CDHash-only designated requirement`)
+  }
+
+  report.push(`${label} authority: ${EXPECTED_AUTHORITY}`)
+  report.push(`${label} designated requirement: ${designatedRequirement}`)
+  return { details, designatedRequirement }
+}
+
+function detachDmg() {
+  if (!mounted) return
+
+  const detached = spawnSync('/usr/bin/hdiutil', ['detach', mountPoint], {
+    encoding: 'utf8'
+  })
+  if (detached.status === 0) {
+    mounted = false
+    return
+  }
+
+  const forced = spawnSync('/usr/bin/hdiutil', ['detach', '-force', mountPoint], {
+    encoding: 'utf8'
+  })
+  if (forced.status !== 0) {
+    throw new Error(`failed to detach DMG mounted at ${mountPoint}`)
+  }
+  mounted = false
+}
+
+try {
+  const dmgPath = findDmg()
+  const dmgSize = statSync(dmgPath).size
+  if (dmgSize <= 0) throw new Error('DMG is empty')
+
+  const packagedAppPath = findPackagedApp()
+  report.push(`DMG: ${relative(root, dmgPath)}`)
+  report.push(`DMG size: ${dmgSize}`)
+  report.push(`Unpacked app: ${relative(root, packagedAppPath)}`)
+
+  run('/usr/bin/hdiutil', [
+    'attach',
+    '-nobrowse',
+    '-readonly',
+    '-mountpoint',
+    mountPoint,
+    dmgPath
+  ])
+  mounted = true
+
+  const appPath = join(mountPoint, appName)
+  if (!existsSync(appPath)) throw new Error(`${appName} is missing from the mounted DMG`)
+
+  const appExecutable = join(appPath, 'Contents', 'MacOS', productName)
+  const corePath = join(appPath, 'Contents', 'Resources', 'bin', 'rovai-core')
+  const cliPath = join(appPath, 'Contents', 'Resources', 'bin', 'rovai')
+  for (const requiredPath of [appExecutable, corePath, cliPath]) {
+    if (!existsSync(requiredPath)) throw new Error(`required binary is missing: ${requiredPath}`)
+  }
+
+  run('/usr/bin/codesign', ['--verify', '--deep', '--strict', '--verbose=2', appPath])
+  run('/usr/bin/codesign', ['--verify', '--strict', '--verbose=2', corePath])
+  run('/usr/bin/codesign', ['--verify', '--strict', '--verbose=2', cliPath])
+  report.push('App codesign verification: passed')
+  report.push('rovai-core codesign verification: passed')
+  report.push('rovai codesign verification: passed')
+
+  assertArchitecture('App', appExecutable)
+  assertArchitecture('rovai-core', corePath)
+  assertArchitecture('rovai', cliPath)
+
+  const bundleId = run('/usr/bin/plutil', [
+    '-extract',
+    'CFBundleIdentifier',
+    'raw',
+    '-o',
+    '-',
+    join(appPath, 'Contents', 'Info.plist')
+  ])
+  if (bundleId !== EXPECTED_APP_ID) {
+    throw new Error(`Bundle ID is ${bundleId}, expected ${EXPECTED_APP_ID}`)
+  }
+  report.push(`Bundle ID: ${bundleId}`)
+
+  const appSignature = signatureDetails('App', appPath)
+  const normalizedRequirement = appSignature.designatedRequirement.toLowerCase()
+  if (!normalizedRequirement.includes(`identifier "${EXPECTED_APP_ID}"`)) {
+    throw new Error('App designated requirement has the wrong identifier')
+  }
+  if (!normalizedRequirement.includes(`certificate root = h"${EXPECTED_CERTIFICATE_ROOT}"`)) {
+    throw new Error('App designated requirement has the wrong certificate root')
+  }
+
+  signatureDetails('rovai-core', corePath)
+  signatureDetails('rovai', cliPath)
+  report.push('CDHash-only signature found: no')
+  report.push('Result: passed')
+} catch (error) {
+  failure = error instanceof Error ? error : new Error(String(error))
+  report.push(`Result: failed - ${failure.message}`)
+} finally {
+  try {
+    detachDmg()
+  } catch (error) {
+    const detachError = error instanceof Error ? error : new Error(String(error))
+    if (!failure) failure = detachError
+    report.push(`DMG detach: failed - ${detachError.message}`)
+  }
+
+  if (!mounted) {
+    try {
+      rmdirSync(mountPoint)
+    } catch {
+      // The verification result already records any meaningful mount failure.
+    }
+  }
+
+  mkdirSync(distDir, { recursive: true })
+  writeFileSync(reportPath, `${report.join('\n')}\n`, { mode: 0o644 })
+}
+
+if (failure) {
+  console.error(`macOS ${arch} signing verification failed: ${failure.message}`)
+  process.exit(1)
+}
+
+console.log(`macOS ${arch} signing verification passed`)
+console.log(`Report: ${reportPath}`)

--- a/scripts/verify-macos-release.mjs
+++ b/scripts/verify-macos-release.mjs
@@ -137,6 +137,14 @@ function signatureDetails(label, targetPath) {
   return { details, designatedRequirement }
 }
 
+function assertCertificateRoot(label, designatedRequirement) {
+  const normalized = designatedRequirement.toLowerCase()
+  const expected = `certificate root = h"${EXPECTED_CERTIFICATE_ROOT}"`
+  if (!normalized.includes(expected)) {
+    throw new Error(`${label} designated requirement has the wrong certificate root`)
+  }
+}
+
 function detachDmg() {
   if (!mounted) return
 
@@ -216,12 +224,13 @@ try {
   if (!normalizedRequirement.includes(`identifier "${EXPECTED_APP_ID}"`)) {
     throw new Error('App designated requirement has the wrong identifier')
   }
-  if (!normalizedRequirement.includes(`certificate root = h"${EXPECTED_CERTIFICATE_ROOT}"`)) {
-    throw new Error('App designated requirement has the wrong certificate root')
-  }
+  assertCertificateRoot('App', appSignature.designatedRequirement)
 
-  signatureDetails('rovai-core', corePath)
-  signatureDetails('rovai', cliPath)
+  const coreSignature = signatureDetails('rovai-core', corePath)
+  assertCertificateRoot('rovai-core', coreSignature.designatedRequirement)
+
+  const cliSignature = signatureDetails('rovai', cliPath)
+  assertCertificateRoot('rovai', cliSignature.designatedRequirement)
   report.push('CDHash-only signature found: no')
   report.push('Result: passed')
 } catch (error) {


### PR DESCRIPTION
## Summary

- replace release ad-hoc signing with the fixed `Rovai Release Signing` identity
- add separate macOS arm64 and x64 signed DMG build commands
- explicitly sign and verify `rovai-core` and `rovai`
- add a manually triggered GitHub Actions signed-build matrix
- fail closed if the certificate, architecture, Bundle ID, signature, or designated requirement is incorrect

## Local validation

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- arm64 DMG build completed successfully
- App, `rovai-core`, and `rovai` verified as arm64
- `codesign --verify --deep --strict` passed
- signing authority verified as `Rovai Release Signing`
- Bundle ID verified as `ai.rovai.desktop`
- designated requirement verified as certificate-based rather than CDHash-only

## Security

- GitHub Secrets are only used during the certificate import step
- decoded P12 and temporary keychain are deleted with `if: always()`
- certificate SHA-256 fingerprint is pinned
- workflow permissions are limited to `contents: read`
- workflow is `workflow_dispatch` only
- unsigned or ad-hoc release builds fail closed

## Distribution limitations

This uses a fixed self-signed Code Signing identity, not Apple Developer ID.

It is intended to preserve a stable macOS code identity across Rovai releases. It does not provide Apple notarization or automatic Gatekeeper trust.

## Not included

- no GitHub Release creation
- no automatic updater
- no Windows build
- no Linux build
- no Universal macOS build
