### PR TITLE
fix(mac): prevent signed build cleanup hang

### DIFF
--- a/.github/workflows/macos-signed-build.yml
+++ b/.github/workflows/macos-signed-build.yml
@@ -21,6 +21,7 @@ jobs:
 
   build:
     needs: require-main
+    timeout-minutes: 45
     name: macOS ${{ matrix.arch }} signed build
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -39,6 +40,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
@@ -112,7 +115,7 @@ jobs:
           EXPECTED_FINGERPRINT="875C6F486E223AB1889A2AD63860FBE48F7E8C0E4D94832656896BA5DA4EF82E"
           test "$ACTUAL_FINGERPRINT" = "$EXPECTED_FINGERPRINT"
 
-          sudo security add-trusted-cert \
+          sudo -n security add-trusted-cert \
             -d \
             -r trustRoot \
             -p codeSign \
@@ -132,32 +135,40 @@ jobs:
       - name: Verify signed DMG
         run: node scripts/verify-macos-release.mjs ${{ matrix.arch }}
 
-      - name: Clean signing material
+      - name: Clean sensitive signing material
         if: always()
+        shell: bash
         run: |
           set +x
+          set +e
+
           P12_PATH="$RUNNER_TEMP/rovai-release-signing.p12"
           CERT_PEM="$RUNNER_TEMP/rovai-release-signing.pem"
           CERT_DER="$RUNNER_TEMP/rovai-release-signing.cer"
           KEYCHAIN_PATH="$RUNNER_TEMP/rovai-signing.keychain-db"
           TRUST_MARKER="$RUNNER_TEMP/rovai-system-trust-added"
-          DEFAULT_KEYCHAIN="$(security default-keychain -d user | tr -d '"')"
+          DEFAULT_KEYCHAIN="$(
+            security default-keychain -d user 2>/dev/null |
+              tr -d '"'
+          )"
 
-          if test -f "$TRUST_MARKER" && test -f "$CERT_DER"; then
-            sudo security remove-trusted-cert -d "$CERT_DER" || true
-            sudo security delete-certificate \
-              -Z 465802DA7386E9676668078E7D44704CBBEADD1E \
-              /Library/Keychains/System.keychain || true
+          if test -n "$DEFAULT_KEYCHAIN"; then
+            security list-keychains \
+              -d user \
+              -s "$DEFAULT_KEYCHAIN" >/dev/null 2>&1 || true
           fi
 
-          security list-keychains -d user -s "$DEFAULT_KEYCHAIN" || true
-          security delete-keychain "$KEYCHAIN_PATH" || true
+          security delete-keychain \
+            "$KEYCHAIN_PATH" >/dev/null 2>&1 || true
+
           rm -f \
             "$P12_PATH" \
             "$CERT_PEM" \
             "$CERT_DER" \
             "$KEYCHAIN_PATH" \
             "$TRUST_MARKER"
+
+          exit 0
 
       - name: Upload signed artifacts
         if: success()


### PR DESCRIPTION
Superseded by #17, which refreshes the same cleanup fix on top of the current public `main` while preserving the latest Actions hardening and `release-signing` Environment configuration.

Historical evidence remains useful: the previous signed run built and verified both DMGs, then stalled in the System-keychain cleanup commands before artifact upload.