### PR TITLE
docs: add contribution and security guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,155 @@
+# Contributing to Rovai AI
+
+Thanks for taking the time to contribute to Rovai AI.
+
+Issues and Pull Requests can be written in English or Chinese. Small fixes can go straight to a
+Pull Request. For a large architecture, Runtime, protocol, persistence, or product change, please
+open an Issue first so we can agree on the boundary before implementation.
+
+## Architecture at a glance
+
+```text
+Rovai Desktop
+    ↓
+Rovai Core
+    ↓
+Runtime Adapter Layer
+    ↓
+Agent Runtime
+    ↓
+User workspace and Runtime-native capabilities
+```
+
+| Layer | Responsibility |
+|---|---|
+| **Rovai Desktop** | The Electron interface for Camps, members, Tasks, execution, approvals, and memory. |
+| **Rovai Core** | The authoritative domain and persistence layer. It owns Camp, Member, Task, Run, approval, evidence, recovery, and memory state. |
+| **Runtime Adapter Layer** | Connects Rovai to each Runtime's native protocol, CLI, or ACP interface, and maps context, Sessions, permissions, MCP, Skills, and execution evidence. |
+| **Agent Runtime** | Provides model reasoning, native tools, permissions, Sessions, and Runtime-specific capabilities. |
+| **User environment** | The user's workspace, Git repository, Runtime configuration, credentials, model provider, and native tools remain user-controlled. |
+
+This is only a quick overview. Current architecture rules live in
+[`docs/architecture/`](docs/architecture/), and field-level behavior lives in
+[`docs/contracts/`](docs/contracts/).
+
+## Documentation map
+
+Start with [`docs/README.md`](docs/README.md). It explains which documents are current authority
+and which are historical evidence.
+
+| Path | What it contains |
+|---|---|
+| [`CONTEXT.md`](CONTEXT.md) | Domain glossary and stable product terminology |
+| [`PRODUCT.md`](PRODUCT.md) | Product purpose, users, and positioning |
+| [`DESIGN.md`](DESIGN.md) | Visual system and UI design principles |
+| [`docs/architecture/`](docs/architecture/) | Long-lived component responsibilities and ownership boundaries |
+| [`docs/contracts/`](docs/contracts/) | Versioned fields, states, errors, wire shapes, and testable behavior |
+| [`docs/decisions/`](docs/decisions/) | Why important decisions were made |
+| [`docs/versions/`](docs/versions/) | Current version scope, implementation plan, and historical versions |
+| [`docs/development/`](docs/development/) | Local development, testing, packaging, and Runtime integration guides |
+| [`docs/ui/`](docs/ui/) | Renderer and interaction contracts |
+| [`docs/research/`](docs/research/) | Runtime research and evidence; not a support promise |
+| [`docs/prototypes/`](docs/prototypes/) | Review artifacts; not production authority |
+| [`docs/postmortems/`](docs/postmortems/) | Blameless incident history |
+| [`qualification/`](qualification/) | Public demo cases, acceptance evidence, and diagnostics |
+
+Do not create numbered ADR files. When a change modifies a durable boundary, update the current
+Architecture, Contract, Context, UI, or Development document in the same Pull Request.
+
+## Development
+
+Install dependencies and start the isolated development app:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm dev
+```
+
+Use `pnpm dev` instead of running `electron-vite dev` directly. The full setup and isolation rules
+are in [`docs/development/README.md`](docs/development/README.md).
+
+## Tests
+
+### Common TypeScript and repository checks
+
+```bash
+pnpm typecheck
+pnpm test
+```
+
+### Documentation
+
+```bash
+pnpm docs:test
+pnpm docs:check
+DOCS_BASE_REF=<PR base SHA> pnpm docs:check:ci
+```
+
+### Skills
+
+```bash
+pnpm skills:test
+pnpm skills:check
+```
+
+### Rust
+
+For a quick staged-file check:
+
+```bash
+pnpm test:rust:staged
+```
+
+For a Pull Request that changes Rust:
+
+```bash
+cargo fmt --all --check
+cargo check --workspace --all-targets
+pnpm test:rust:pr
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Before submitting, also run:
+
+```bash
+git diff --check
+```
+
+If a relevant check cannot run in your environment, say so clearly in the Pull Request instead of
+reporting it as passed.
+
+## Adding a new Runtime or ACP Adapter
+
+Use the
+[Agent Runtime Integration and Admission Checklist](docs/development/runtime-integration-checklist.md)
+as the single starting point.
+
+At minimum, a new Runtime needs evidence for:
+
+1. executable identity, version, fingerprint, and target platform;
+2. discovery, availability checks, Probe, and real AgentRun launch;
+3. protocol initialization and stable Session identity;
+4. Tool output, approval allow/deny, cancellation, and process cleanup;
+5. warm continuation and cold resume or history restore;
+6. MCP and Skill behavior when those capabilities are claimed;
+7. real smoke tests on every platform marked as qualified.
+
+A successful `--version`, ACP `initialize`, or ordinary chat response is not enough to mark a
+Runtime as supported. Keep unverified capabilities disabled and document the remaining boundary.
+
+## Pull Requests
+
+Please keep Pull Requests focused and include:
+
+- what changed and why;
+- the tests you ran;
+- screenshots for visible UI changes;
+- exact Runtime and platform evidence for compatibility changes;
+- related documentation updates;
+- known limitations or follow-up work.
+
+Do not commit credentials, private transcripts, personal absolute paths, machine-specific
+configuration, or generated build directories.
+
+Rovai AI is distributed under the [MIT License](LICENSE). By contributing, you confirm that you
+have the right to submit the work under that license.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,62 @@
+# Security Policy
+
+Thanks for helping keep Rovai AI and its users safe.
+
+## Report a vulnerability privately
+
+Please do **not** open a public Issue or Pull Request with vulnerability details.
+
+Use GitHub's private vulnerability reporting form:
+
+```text
+https://github.com/murray17/rovai-ai/security/advisories/new
+```
+
+If the form is unavailable, open a public Issue titled `Security contact request` without technical
+details, logs, screenshots, or reproduction steps. A maintainer will provide a private channel.
+
+## Helpful information
+
+A useful report includes:
+
+- the affected Rovai release or commit;
+- operating system and architecture;
+- the affected Agent Runtime and exact version, when relevant;
+- clear reproduction steps using test data;
+- expected and observed behavior;
+- possible impact;
+- redacted logs or screenshots when needed.
+
+Please remove credentials, tokens, personal paths, private prompts, unrelated model output, and
+user data.
+
+## Especially relevant issues
+
+Please report problems such as:
+
+- approval or permission bypass;
+- data leaking across Camps, members, Sessions, or workspaces;
+- path traversal, symlink escape, or attachment-root escape;
+- secrets or private paths appearing in messages, diagnostics, evidence, or exports;
+- built-in `rovai` CLI or private IPC authorization bypass;
+- Runtime configuration, MCP, Skill, or credential isolation failures;
+- cancellation or recovery repeating an external action whose result is unknown;
+- packaged-app or update integrity problems.
+
+A poor model answer, an unsupported Runtime, or expected behavior after the user explicitly enables
+the highest permission mode is usually not a security vulnerability unless Rovai widened or
+misrepresented that permission.
+
+## What happens next
+
+We will review the report, try to reproduce it, and keep the reporter informed while a fix or
+mitigation is prepared.
+
+Please allow reasonable time for investigation before publishing details. We are happy to
+coordinate disclosure and credit after the issue is resolved.
+
+## Supported versions
+
+Rovai AI is currently pre-release. Security fixes are made against the current `main` branch and,
+after public releases begin, the latest public release. Older pre-release builds may require an
+upgrade to receive a fix.


### PR DESCRIPTION
## Summary

- add a concise, friendly `CONTRIBUTING.md`
- explain Rovai's current architecture layers and documentation map
- list the main pnpm and Cargo validation commands
- point new Runtime and ACP Adapter work to the canonical integration checklist
- add a concise `SECURITY.md` with a private reporting path and Rovai-specific vulnerability examples

## Scope

This PR adds only:

- `CONTRIBUTING.md`
- `SECURITY.md`

No product code, dependencies, lockfiles, workflows, repository visibility, Releases, or Runtime qualification state are changed.

## Validation

- branch is one commit ahead and zero commits behind `main`
- diff contains exactly the two new Markdown files
- local Markdown paths were checked against the current repository structure
- `git diff --check` and repository test commands were not run in this connector-only session; hosted documentation governance will provide the repository check when available

## Follow-up before Public

Enable GitHub Private Vulnerability Reporting so the advisory URL in `SECURITY.md` is available to external reporters. The file includes a minimal fallback when that form is unavailable.