### PR TITLE
chore: harden GitHub Actions boundaries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,13 @@
 # Documentation governance and every future version/topic use the same owner boundary.
 /docs/ @murray17
 /AGENTS.md @murray17
+/CONTRIBUTING.md @murray17
+/SECURITY.md @murray17
 /scripts/check-doc-*.mjs @murray17
 /scripts/generate-doc-adr.mjs @murray17
 /scripts/lib/doc-adr* @murray17
 /package.json @murray17
 /pnpm-lock.yaml @murray17
-/.github/workflows/docs-governance.yml @murray17
+/.github/workflows/ @murray17
+/.github/dependabot.yml @murray17
 /.github/CODEOWNERS @murray17

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: chore
+      include: scope

--- a/.github/workflows/docs-governance.yml
+++ b/.github/workflows/docs-governance.yml
@@ -17,23 +17,26 @@ jobs:
   docs-governance:
     name: docs-governance
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Check out repository and PR base history
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 11.20.0
           run_install: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install locked dependencies without lifecycle scripts
         run: pnpm install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/macos-signed-build.yml
+++ b/.github/workflows/macos-signed-build.yml
@@ -6,9 +6,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: macos-signed-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   require-main:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Require main branch
         shell: bash
@@ -23,6 +28,8 @@ jobs:
     needs: require-main
     name: macOS ${{ matrix.arch }} signed build
     runs-on: ${{ matrix.runner }}
+    environment: release-signing
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -39,6 +46,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
@@ -168,3 +177,4 @@ jobs:
             dist/*.dmg
             dist/signing-report-*.txt
           if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/rust-nightly.yml
+++ b/.github/workflows/rust-nightly.yml
@@ -16,17 +16,20 @@ jobs:
   full:
     name: Rust all-features suite
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: clippy, rustfmt
 
       - name: Restore Cargo cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
 
       - name: Check formatting
         run: cargo fmt --all --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,17 +28,20 @@ jobs:
   lint:
     name: Rust fmt and clippy
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: clippy, rustfmt
 
       - name: Restore Cargo cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
 
       - name: Check formatting
         run: cargo fmt --all --check
@@ -49,15 +52,18 @@ jobs:
   fast-tests:
     name: Rust fast tests
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Restore Cargo cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
 
       - name: Run fast Rust tests
         run: cargo test -p rovai-core --lib
@@ -65,15 +71,18 @@ jobs:
   db-smoke:
     name: Rust database smoke
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Restore Cargo cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
 
       - name: Run database smoke tests
         run: >-
@@ -82,17 +91,20 @@ jobs:
   windows-x64-check:
     name: Windows x64 compile gate
     runs-on: windows-2022
+    timeout-minutes: 120
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: x86_64-pc-windows-msvc
 
       - name: Restore Cargo cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
 
       - name: Check all Windows targets
         run: >-

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -39,10 +39,14 @@ concurrency:
 jobs:
   unsigned-package:
     name: Windows x64 unsigned package
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: windows-2022
+    timeout-minutes: 120
     steps:
       - name: Check out repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
@@ -64,6 +68,7 @@ jobs:
         run: pnpm dist:windows:x64
 
       - name: Upload unsigned package evidence
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: rovai-windows-x64-unsigned-${{ github.sha }}
@@ -74,3 +79,4 @@ jobs:
             dist/windows-verification-report.txt
             dist/win-unpacked/**
           if-no-files-found: error
+          retention-days: 7


### PR DESCRIPTION
## Summary

- pin every mutable third-party Action reference in documentation and Rust workflows to an immutable full commit SHA
- disable checkout credential persistence in every workflow
- add explicit job timeouts and artifact retention limits
- route macOS signing through a dedicated `release-signing` environment
- prevent fork Pull Requests from running the costly Windows packaging job
- stop uploading unsigned Windows installers from Pull Request code
- expand CODEOWNERS coverage for all workflows, Dependabot configuration, and community security files
- add weekly grouped Dependabot updates for GitHub Actions

## Security boundaries

- workflow tokens remain `contents: read`
- no workflow uses `pull_request_target`
- signed builds remain manual and restricted to `main`
- signing secrets are not added, changed, or printed
- no product code, dependencies, lockfiles, Runtime qualification, Release, or repository visibility is changed

## Files

- `.github/CODEOWNERS`
- `.github/dependabot.yml`
- `.github/workflows/docs-governance.yml`
- `.github/workflows/macos-signed-build.yml`
- `.github/workflows/rust-nightly.yml`
- `.github/workflows/rust.yml`
- `.github/workflows/windows-package.yml`

## Validation

- branch is one commit ahead and zero commits behind `main`
- diff is limited to the seven GitHub configuration files above
- all `uses:` references in the changed workflows are full 40-character SHAs
- pinned tag resolutions were checked against the upstream repositories
- existing workflow permissions remain read-only
- GitHub accepted the workflow syntax and created the expected Documentation, Rust, and Windows jobs
- every hosted job still failed before its first step and exposes no step list or logs, matching the existing private-repository Actions scheduling/billing limitation rather than a workflow assertion failure

## Manual settings still required before Public

1. Create or configure the `release-signing` environment, restrict it to `main`, require approval where practical, and move `MAC_CSC_LINK` / `MAC_CSC_KEY_PASSWORD` to environment secrets.
2. Set the default `GITHUB_TOKEN` permission to read-only and disable Actions from creating or approving Pull Requests.
3. After the repository becomes public, protect `main`: require Pull Requests, CODEOWNERS review, resolved conversations, and block force-pushes and deletion.
4. Enable Private Vulnerability Reporting.
5. Update the repository About description, which still contains the old positioning text.