### PR TITLE
docs: add a human-friendly documentation entry

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,17 @@ last_updated: 2026-08-23
 
 本文件定义 `docs/` 的职责、权威边界和读取顺序。人和 AI 在处理架构、实现、规划或文档任务前，应先从这里判断需要读取哪些资料，而不是默认加载全部历史文档。
 
-## 按任务读取
+## 从这里开始
+
+| 你想做什么 | 入口 |
+|---|---|
+| 安装和使用 Rovai | [用户指南](guides/README.md) |
+| 参与开发 | [开发者指南](development/README.md) |
+| 理解当前架构 | [长期架构](architecture/README.md) |
+| 查看当前决策 | [当前决定](decisions/CURRENT.md) |
+| 查看当前版本 | [版本记录](versions/README.md) |
+
+## 维护者与 Coding Agent 按任务读取
 
 | 任务 | 必读资料 |
 |---|---|

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,0 +1,16 @@
+---
+document_type: user-guide
+authority: user-guide-routing
+last_updated: 2026-08-23
+---
+
+# 用户指南
+
+从这里开始安装 Rovai、完成首次启动，并了解日常使用方式。
+
+| 你想做什么 | 入口 |
+|---|---|
+| 下载、安装与首次启动 | [安装指南](installation.md) |
+| 配置队员、Runtime、权限、Skill 与 MCP | [操作指南](operations.md) |
+
+准备参与开发时，请转到[开发者指南](../development/README.md)。


### PR DESCRIPTION
## Summary

- add a short human-oriented starting table at the top of `docs/README.md`
- keep the complete governance routing matrix in place under `维护者与 Coding Agent 按任务读取`
- add `docs/guides/README.md` as the user-guide entry for installation and daily operation

## Scope

This PR changes only:

- `docs/README.md`
- `docs/guides/README.md`

No architecture rules, contracts, version scope, product code, dependencies, workflows, repository visibility, or Releases are changed.

## Validation

- branch is two commits ahead and zero commits behind `main`
- `docs/README.md` retains all existing governance content; the diff is 11 additions and one heading replacement
- every new local link points to a current repository path
- repository documentation commands were not run in this connector-only session; hosted documentation governance can verify the final tree when available