### PR TITLE
test(desktop): run Core shutdown tests on a supported POSIX host

### DIFF
--- a/apps/desktop/src/main/core-client.test.ts
+++ b/apps/desktop/src/main/core-client.test.ts
@@ -22,10 +22,16 @@ import {
 } from './core-client'
 
 const temporaryRoots: string[] = []
+const originalPlatform = process.platform
+
+function useSupportedPosixHost(): void {
+  Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+}
 
 afterEach(() => {
   vi.useRealTimers()
   vi.restoreAllMocks()
+  Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
   delete process.env.ROVAI_CORE_BIN
   delete process.env.ROVAI_CORE_TEST_USER_DATA
   for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true })
@@ -96,6 +102,7 @@ describe('CoreClient planned shutdown', () => {
   it.runIf(process.platform !== 'win32')(
     'reuses one Promise, keeps shutdown Main-only, and waits for the child exit',
     async () => {
+      useSupportedPosixHost()
       const root = mkdtempSync(join(tmpdir(), 'rovai-core-client-shutdown-'))
       temporaryRoots.push(root)
       const fakeCore = join(root, 'fake-core.sh')
@@ -154,6 +161,7 @@ done
   it.runIf(process.platform !== 'win32')(
     'uses SIGTERM only after the Core deadline and outer grace expire',
     async () => {
+      useSupportedPosixHost()
       vi.useFakeTimers()
       vi.spyOn(console, 'error').mockImplementation(() => undefined)
       const root = mkdtempSync(join(tmpdir(), 'rovai-core-client-sigterm-'))
@@ -190,6 +198,7 @@ done
   it.runIf(process.platform !== 'win32')(
     'escalates to SIGKILL when the child ignores SIGTERM',
     async () => {
+      useSupportedPosixHost()
       vi.useFakeTimers()
       vi.spyOn(console, 'error').mockImplementation(() => undefined)
       const root = mkdtempSync(join(tmpdir(), 'rovai-core-client-sigkill-'))


### PR DESCRIPTION
## Summary

- reproduce the first real Public Actions failure from `Documentation governance`
- keep Linux outside Rovai's supported sidecar target matrix
- run the POSIX shutdown integration tests with `process.platform` modeled as `darwin`
- restore the original platform value after each test

## Why

The public Ubuntu runner now executes the full repository suite. Three `CoreClient planned shutdown` tests use an explicit fake Core binary, but `resolveCoreBinary()` validates the host sidecar target first and rejects `linux-x64` before the fake binary can run.

These tests exercise POSIX process and signal behavior, not Linux product support. Modeling the supported POSIX product host keeps the production sidecar matrix closed to macOS and Windows while allowing the tests to run on GitHub's Ubuntu runner.

## Scope

This PR changes only:

- `apps/desktop/src/main/core-client.test.ts`

No production code, platform support claim, Runtime qualification, workflow, dependency, lockfile, Release, or repository setting is changed.

## Validation

- branch is one commit ahead and zero commits behind `main`
- diff is limited to 10 additions and 1 deletion in one test file
- the previous public run passed documentation governance, Skill checks, and 501 tests before failing only these three shutdown tests
- GitHub Actions will run the full public suite for this PR