### PR TITLE
fix(windows): qualify user automation transport

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -474,16 +474,14 @@ if (primaryInstance) void app.whenReady().then(async () => {
       process.platform
     ) ?? undefined
   })
-  if (process.platform !== 'win32') {
-    userAutomation = await startUserAutomationOptional(
-      () => new UserAutomationServer(
-        userAutomationRoot(app.getPath('appData'), userDataPath, hasExplicitUserDataDirectory),
-        { core, openCamp: openCampFromAutomation, appVersion: app.getVersion() }
-      )
+  userAutomation = await startUserAutomationOptional(
+    () => new UserAutomationServer(
+      userAutomationRoot(app.getPath('appData'), userDataPath, hasExplicitUserDataDirectory),
+      { core, openCamp: openCampFromAutomation, appVersion: app.getVersion() }
     )
-    if (userAutomation) {
-      console.info('[startup] stage=user_automation_ready contract_version=1')
-    }
+  )
+  if (userAutomation) {
+    console.info('[startup] stage=user_automation_ready contract_version=1')
   }
 
   app.on('activate', () => {

--- a/apps/desktop/src/main/user-automation.test.ts
+++ b/apps/desktop/src/main/user-automation.test.ts
@@ -8,7 +8,9 @@ import {
   dispatchUserAutomation,
   startUserAutomationOptional,
   UserAutomationError,
-  UserAutomationServer
+  UserAutomationServer,
+  userAutomationAvailableOnPlatform,
+  WINDOWS_USER_AUTOMATION_QUALIFICATION_ENV
 } from './user-automation'
 
 async function socketRequest(path: string, request: unknown): Promise<Record<string, unknown>> {
@@ -255,10 +257,14 @@ describe('User Automation transport', () => {
     expect(diagnostics).toEqual([unavailable])
   })
 
-  it.runIf(process.platform !== 'win32')(
-    'binds each socket request to the published App instance and removes discovery on stop',
+  it(
+    'binds each local IPC request to the published App instance and removes discovery on stop',
     async () => {
       const root = await mkdtemp(join(tmpdir(), 'rovai-automation-'))
+      const previousQualification = process.env[WINDOWS_USER_AUTOMATION_QUALIFICATION_ENV]
+      if (process.platform === 'win32') {
+        process.env[WINDOWS_USER_AUTOMATION_QUALIFICATION_ENV] = '1'
+      }
       const core = {
         async request<T>(method: CoreMethod): Promise<T> {
           if (method === 'app.info') return { version: 'core-test' } as T
@@ -276,9 +282,11 @@ describe('User Automation transport', () => {
           contractVersion: number
           instanceId: string
           credential: string
-          endpoint: { path: string }
+          endpoint: { path?: string; name?: string }
         }
-        const accepted = await socketRequest(context.endpoint.path, {
+        const endpoint = context.endpoint.path ?? context.endpoint.name
+        expect(endpoint).toBeTruthy()
+        const accepted = await socketRequest(endpoint!, {
           contractVersion: context.contractVersion,
           instanceId: context.instanceId,
           credential: context.credential,
@@ -292,7 +300,7 @@ describe('User Automation transport', () => {
           result: { appRunning: true, instanceId: context.instanceId }
         })
 
-        const rejected = await socketRequest(context.endpoint.path, {
+        const rejected = await socketRequest(endpoint!, {
           contractVersion: context.contractVersion,
           instanceId: 'another-instance',
           credential: context.credential,
@@ -309,28 +317,19 @@ describe('User Automation transport', () => {
         await server.stop()
         await expect(readFile(server.contextPath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
         await rm(root, { recursive: true, force: true })
+        if (previousQualification === undefined) {
+          delete process.env[WINDOWS_USER_AUTOMATION_QUALIFICATION_ENV]
+        } else {
+          process.env[WINDOWS_USER_AUTOMATION_QUALIFICATION_ENV] = previousQualification
+        }
       }
     }
   )
 
-  it.runIf(process.platform === 'win32')(
-    'fails closed before publishing discovery when Unix-domain automation is unavailable',
-    async () => {
-      const root = await mkdtemp(join(tmpdir(), 'rovai-automation-windows-'))
-      const server = new UserAutomationServer(root, {
-        core: { request: async <T>() => ({} as T) },
-        openCamp: async (campId) => ({ campId, opened: true }),
-        appVersion: 'app-test'
-      })
-      try {
-        await expect(server.start()).rejects.toMatchObject({
-          code: 'automation_platform_unsupported'
-        })
-        await expect(readFile(server.contextPath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
-      } finally {
-        await server.stop()
-        await rm(root, { recursive: true, force: true })
-      }
-    }
-  )
+  it('keeps Windows Automation behind the explicit local qualification gate', () => {
+    expect(userAutomationAvailableOnPlatform('win32', undefined)).toBe(false)
+    expect(userAutomationAvailableOnPlatform('win32', '0')).toBe(false)
+    expect(userAutomationAvailableOnPlatform('win32', '1')).toBe(true)
+    expect(userAutomationAvailableOnPlatform('darwin', undefined)).toBe(true)
+  })
 })

--- a/apps/desktop/src/main/user-automation.ts
+++ b/apps/desktop/src/main/user-automation.ts
@@ -19,6 +19,8 @@ import type {
 
 export const USER_AUTOMATION_CONTRACT_VERSION = 1
 export const USER_AUTOMATION_CONTEXT_ENV = 'ROVAI_APP_AUTOMATION_CONTEXT'
+export const WINDOWS_USER_AUTOMATION_QUALIFICATION_ENV =
+  'ROVAI_WINDOWS_USER_AUTOMATION_QUALIFICATION'
 const MAX_FRAME_BYTES = 4 * 1024 * 1024
 const REQUEST_TIMEOUT_MILLISECONDS = 60_000
 
@@ -45,7 +47,9 @@ type AutomationContext = {
   contractVersion: 1
   instanceId: string
   pid: number
-  endpoint: { transport: 'unix_socket'; path: string }
+  endpoint:
+    | { transport: 'unix_socket'; path: string }
+    | { transport: 'windows_named_pipe'; name: string }
   credential: string
 }
 
@@ -70,6 +74,13 @@ export class UserAutomationError extends Error {
   constructor(readonly code: string, message: string) {
     super(message)
   }
+}
+
+export function userAutomationAvailableOnPlatform(
+  platform: NodeJS.Platform,
+  windowsQualification: string | undefined
+): boolean {
+  return platform !== 'win32' || windowsQualification === '1'
 }
 
 function record(value: unknown, label: string): RecordValue {
@@ -454,10 +465,13 @@ export class UserAutomationServer {
   }
 
   async start(): Promise<void> {
-    if (process.platform === 'win32') {
+    if (!userAutomationAvailableOnPlatform(
+      process.platform,
+      process.env[WINDOWS_USER_AUTOMATION_QUALIFICATION_ENV]
+    )) {
       throw new UserAutomationError(
         'automation_platform_unsupported',
-        'User Automation V1 currently requires a Unix-domain socket.'
+        'Windows User Automation is available only in an explicit local qualification run.'
       )
     }
     await mkdir(this.rootPath, { recursive: true, mode: 0o700 })
@@ -469,13 +483,17 @@ export class UserAutomationServer {
       )
     }
     await chmod(this.rootPath, 0o700)
-    const endpointPath = join(this.rootPath, 'app.sock')
-    await removeStaleSocket(endpointPath)
+    const endpointPath = process.platform === 'win32'
+      ? `\\\\.\\pipe\\rovai-ai-${process.pid}-${randomUUID()}`
+      : join(this.rootPath, 'app.sock')
+    if (process.platform !== 'win32') await removeStaleSocket(endpointPath)
     const context: AutomationContext = {
       contractVersion: USER_AUTOMATION_CONTRACT_VERSION,
       instanceId: randomUUID(),
       pid: process.pid,
-      endpoint: { transport: 'unix_socket', path: endpointPath },
+      endpoint: process.platform === 'win32'
+        ? { transport: 'windows_named_pipe', name: endpointPath }
+        : { transport: 'unix_socket', path: endpointPath },
       credential: randomBytes(32).toString('hex')
     }
     const server = createServer((socket) => this.#handle(socket, context))
@@ -489,11 +507,11 @@ export class UserAutomationServer {
       })
     })
     try {
-      await chmod(endpointPath, 0o600)
+      if (process.platform !== 'win32') await chmod(endpointPath, 0o600)
       await atomicWritePrivateJson(this.contextPath, context)
     } catch (error) {
       await new Promise<void>((resolve) => server.close(() => resolve()))
-      await unlink(endpointPath).catch(() => undefined)
+      if (process.platform !== 'win32') await unlink(endpointPath).catch(() => undefined)
       throw error
     }
     this.#server = server
@@ -509,7 +527,9 @@ export class UserAutomationServer {
       await new Promise<void>((resolve) => server.close(() => resolve()))
     }
     if (context) {
-      await unlink(context.endpoint.path).catch(() => undefined)
+      if (context.endpoint.transport === 'unix_socket') {
+        await unlink(context.endpoint.path).catch(() => undefined)
+      }
       try {
         const published = JSON.parse(await readFile(this.contextPath, 'utf8')) as AutomationContext
         if (published.instanceId === context.instanceId) await unlink(this.contextPath)

--- a/crates/rovai-core/src/bin/rovai/app_cli.rs
+++ b/crates/rovai-core/src/bin/rovai/app_cli.rs
@@ -1690,6 +1690,7 @@ fn atomic_write_private_json(path: &Path, value: &Value) -> Result<()> {
     write_private(&temporary, &bytes)?;
     fs::rename(&temporary, path)?;
     restrict_private_file(path)?;
+    #[cfg(unix)]
     if let Some(parent) = path.parent() {
         OpenOptions::new().read(true).open(parent)?.sync_all()?;
     }
@@ -1725,12 +1726,31 @@ fn restrict_private_file(_path: &Path) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(windows)]
+    use super::atomic_write_private_json;
     use super::{
         Flags, camp_create_params, command_result_exit_code, event_belongs_to_run,
         launch_result_exit_code, member_create_params, member_runtime_set_params,
         parse_duration_seconds, terminal_exit_code, terminal_status,
     };
     use serde_json::json;
+
+    #[cfg(windows)]
+    #[test]
+    fn atomic_private_journal_write_does_not_open_a_windows_directory_as_a_file() {
+        let directory = std::env::temp_dir().join(format!(
+            "rovai-automation-journal-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir(&directory).unwrap();
+        let path = directory.join("trial.journal.json");
+
+        atomic_write_private_json(&path, &json!({ "phase": "prepared" })).unwrap();
+
+        assert!(path.is_file());
+        std::fs::remove_file(path).unwrap();
+        std::fs::remove_dir(directory).unwrap();
+    }
 
     #[test]
     fn duration_parser_freezes_supported_units_and_caps_at_one_day() {


### PR DESCRIPTION
## Summary
- enable qualification-gated Windows User Automation over named pipes
- keep discovery and cleanup platform-safe
- avoid Windows directory fsync failures in Trial journal writes
- add Windows transport and journal regression coverage

## Validation
- `cargo test -p rovai-core --bin rovai` (26 passed)
- `vitest run apps/desktop/src/main/user-automation.test.ts` (8 passed)
- `pnpm typecheck`
- `cargo fmt --all -- --check`
- Windows installed-App Runtime and Command View acceptance completed locally