### PR TITLE
fix(settings): remove system theme helper copy

### DIFF
--- a/apps/desktop/src/renderer/src/AppearanceSettings.test.ts
+++ b/apps/desktop/src/renderer/src/AppearanceSettings.test.ts
@@ -14,7 +14,7 @@ describe('appearance settings', () => {
     expect(markup).toContain('跟随系统')
     expect(markup).toContain('Porcelain Day')
     expect(markup).toContain('Steel Night')
-    expect(markup).toContain('随系统外观自动使用瓷灰日间或 Steel Night')
+    expect(markup).not.toContain('随系统外观自动使用瓷灰日间或 Steel Night')
     expect(markup).not.toContain('冷瓷灰与克制的 Steel 强调')
     expect(markup).not.toContain('冷石墨表面')
     expect(markup).not.toContain('选择偏好不会生成对话事件、消息或审计记录')

--- a/apps/desktop/src/renderer/src/theme.ts
+++ b/apps/desktop/src/renderer/src/theme.ts
@@ -10,7 +10,7 @@ export const THEME_OPTIONS: ReadonlyArray<{
     value: 'system',
     label: '跟随系统',
     englishLabel: 'System',
-    description: '随系统外观自动使用瓷灰日间或 Steel Night。'
+    description: ''
   },
   {
     value: 'day',


### PR DESCRIPTION
## Summary

- remove the redundant system-theme helper sentence from Appearance settings
- retain System, Porcelain Day, and Steel Night labels and all theme behavior
- update the Renderer regression to keep the sentence absent

## Verification

- `pnpm exec vitest run apps/desktop/src/renderer/src/AppearanceSettings.test.ts apps/desktop/src/renderer/src/theme.test.ts`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build:desktop`
- Impeccable detector: no findings