### PR TITLE
fix(execution): equalize sidecar member spacing

### DIFF
--- a/apps/desktop/src/renderer/src/execution-console-layout.test.ts
+++ b/apps/desktop/src/renderer/src/execution-console-layout.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const styles = readFileSync(new URL('./styles.css', import.meta.url), 'utf8')
+
+function styleBlock(selector: string): string | null {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return styles.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`))?.[1] ?? null
+}
+
+describe('execution console layout', () => {
+  it('keeps the avatar-to-name spacing equal in the bottom dock and right sidecar', () => {
+    expect(styleBlock('.run-pulse-chip-copy')).toMatch(/margin-inline-start:\s*4px/)
+    expect(styleBlock('.run-pulse-inspector .run-pulse-chip-copy') ?? '')
+      .not.toMatch(/margin(?:-inline-start)?:/)
+  })
+})

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1283,7 +1283,6 @@ html[data-rovai-platform="win32"] .unified-sidebar-drag {
 .run-pulse-inspector .run-pulse-chip { width: 100%; min-width: 0; max-width: none; min-height: 40px; grid-template-columns: 24px minmax(0, 1fr) auto; gap: 7px; padding: 5px 7px; border-color: transparent; background: transparent; }
 .run-pulse-inspector .run-pulse-chip:hover { border-color: transparent; background: var(--surface-hover); }
 .run-pulse-inspector .run-pulse-chip.is-selected { border-color: var(--control-line); background: var(--brand-soft); box-shadow: none; }
-.run-pulse-inspector .run-pulse-chip-copy { margin-inline-start: 0; }
 .execution-sidecar-detail { min-width: 0; min-height: 0; overflow: hidden; }
 .execution-sidecar-empty { display: grid; height: 100%; place-items: center; padding: 24px; color: var(--faint); text-align: center; font-size: 11px; line-height: 1.55; }
 .execution-drawer-inspector { height: 100%; max-height: none; border-top: 0; }


### PR DESCRIPTION
## Summary
- let the right-side execution console inherit the bottom dock's 4px avatar-to-name spacing
- add a CSS presentation contract test to prevent a sidecar-only spacing reset

## Verification
- pnpm exec vitest run apps/desktop/src/renderer/src/execution-console-layout.test.ts apps/desktop/src/renderer/src/App.test.ts
- pnpm typecheck
- pnpm test
- pnpm build:desktop
- Impeccable layout detector