### PR TITLE
fix(execution): match sidecar grid spacing

### DIFF
--- a/apps/desktop/src/renderer/src/execution-console-layout.test.ts
+++ b/apps/desktop/src/renderer/src/execution-console-layout.test.ts
@@ -10,6 +10,9 @@ function styleBlock(selector: string): string | null {
 
 describe('execution console layout', () => {
   it('keeps the avatar-to-name spacing equal in the bottom dock and right sidecar', () => {
+    expect(styleBlock('.run-pulse-chip')).toMatch(/(?:^|;)\s*gap:\s*6px/)
+    expect(styleBlock('.run-pulse-inspector .run-pulse-chip') ?? '')
+      .not.toMatch(/(?:^|;)\s*gap:/)
     expect(styleBlock('.run-pulse-chip-copy')).toMatch(/margin-inline-start:\s*4px/)
     expect(styleBlock('.run-pulse-inspector .run-pulse-chip-copy') ?? '')
       .not.toMatch(/margin(?:-inline-start)?:/)

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1280,7 +1280,7 @@ html[data-rovai-platform="win32"] .unified-sidebar-drag {
 .run-pulse-inspector .execution-placement-button { grid-column: 2; grid-row: 1; justify-self: end; }
 .run-pulse-inspector .run-pulse-list { display: grid; max-height: min(172px, 28vh); grid-column: 1 / -1; grid-row: 2; gap: 2px; overflow-x: hidden; overflow-y: auto; padding-right: 2px; }
 .run-pulse-inspector .run-pulse-list > li { min-width: 0; }
-.run-pulse-inspector .run-pulse-chip { width: 100%; min-width: 0; max-width: none; min-height: 40px; grid-template-columns: 24px minmax(0, 1fr) auto; gap: 7px; padding: 5px 7px; border-color: transparent; background: transparent; }
+.run-pulse-inspector .run-pulse-chip { width: 100%; min-width: 0; max-width: none; min-height: 40px; grid-template-columns: 24px minmax(0, 1fr) auto; padding: 5px 7px; border-color: transparent; background: transparent; }
 .run-pulse-inspector .run-pulse-chip:hover { border-color: transparent; background: var(--surface-hover); }
 .run-pulse-inspector .run-pulse-chip.is-selected { border-color: var(--control-line); background: var(--brand-soft); box-shadow: none; }
 .execution-sidecar-detail { min-width: 0; min-height: 0; overflow: hidden; }


### PR DESCRIPTION
## Summary
- remove the sidecar-only 7px grid gap so the avatar/name columns inherit the bottom dock's 6px gap
- extend the presentation contract to verify both grid gap and name offset remain shared

Together with #23, both placements now compute the same 10px avatar-to-name distance.

## Verification
- pnpm exec vitest run apps/desktop/src/renderer/src/execution-console-layout.test.ts apps/desktop/src/renderer/src/App.test.ts
- pnpm typecheck
- pnpm test
- pnpm build:desktop
- Impeccable layout detector