### PR TITLE
fix(installer): allow selecting Windows install directory

### DIFF
--- a/docs/development/packaging-windows.md
+++ b/docs/development/packaging-windows.md
@@ -55,8 +55,10 @@ hash/PE/manifest 检查的 `rovai-core.exe` 与 `rovai.exe`；不得复用未清
 
 ## Package 与 unsigned CI artifact
 
-目标 package 为 x64 NSIS per-user installer，同时保留 unpacked App 用于隔离 Smoke。安装器默认不提权，不注册系统
-服务，不创建 login-start task，不更改 long-path policy。CI 使用固定 `windows-2022`（或仓库锁定的精确 image
+目标 package 为 x64 NSIS per-user assisted installer，同时保留 unpacked App 用于隔离 Smoke。安装向导允许用户选择
+安装目录；默认目录仍位于当前用户范围，且因为安装器不提权，自定义目录必须是当前用户可写路径。安装器不注册系统
+服务，不创建 login-start task，不更改 long-path policy。verifier 必须同时锁定 assisted、per-user、不可提权与可选择
+安装目录四项配置。CI 使用固定 `windows-2022`（或仓库锁定的精确 image
 revision）完成 compile、test、unpacked/NSIS build 和 unsigned verifier；不使用浮动 `windows-latest` 作为可复现证据。
 
 Unsigned CI artifact 必须标注 source commit、toolchain、lockfile、三个 PE hash、installer hash、架构、manifest 与

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -23,7 +23,8 @@ Rovai AI 可以通过桌面安装包使用，也可以从源码启动开发版�
 每个 Release 实际提供哪些平台，以该版本页面中的下载文件为准。
 Windows x64 Preview 当前未签名，SmartScreen 可能显示“未知发布者”；请只从 Rovai AI 官方 GitHub Release
 下载安装包。Windows Preview 当前只有 Claude Code 完成 Runtime 平台准入，其他目录项在各自证据完整前显示
-“Windows 尚未验证不可检查”。
+“Windows 尚未验证不可检查”。Windows 安装向导会显示安装目录选择页；默认使用当前用户目录，也可以改为其他
+当前用户可写目录。该 Preview 安装器不会请求管理员权限，因此不要选择需要管理员写入权限的系统目录。
 
 ## 第一次启动
 

--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
       "perMachine": false,
       "allowElevation": false,
       "packElevateHelper": false,
-      "allowToChangeInstallationDirectory": false,
+      "allowToChangeInstallationDirectory": true,
       "runAfterFinish": false,
       "deleteAppDataOnUninstall": false,
       "include": "build/installer.nsh",

--- a/scripts/verify-windows-release.mjs
+++ b/scripts/verify-windows-release.mjs
@@ -115,6 +115,29 @@ function verifySignature(label, path) {
   return signature
 }
 
+function verifyInstallerConfiguration() {
+  const nsis = packageMetadata.build?.nsis
+  const expected = {
+    oneClick: false,
+    perMachine: false,
+    allowElevation: false,
+    packElevateHelper: false,
+    allowToChangeInstallationDirectory: true
+  }
+  for (const [key, value] of Object.entries(expected)) {
+    if (nsis?.[key] !== value) {
+      throw new Error(`NSIS ${key} must be ${value} for the selectable per-user installer`)
+    }
+  }
+  report.push('NSIS configuration: assisted per-user install with selectable destination passed')
+  return {
+    assisted: true,
+    perMachine: false,
+    allowElevation: false,
+    selectableInstallationDirectory: true
+  }
+}
+
 async function verifyBinary(label, path) {
   if (!existsSync(path)) throw new Error(`${label} is missing: ${path}`)
   const pe = await inspectPortableExecutable(path)
@@ -208,6 +231,7 @@ function startCore(executable, dataDirectory) {
 }
 
 try {
+  const installerConfiguration = verifyInstallerConfiguration()
   const binaries = {
     app: await verifyBinary('App', appExecutable),
     core: await verifyBinary('rovai-core', coreExecutable),
@@ -265,6 +289,7 @@ try {
       pnpmLockSha256: await sha256(join(root, 'pnpm-lock.yaml'))
     },
     signedReleaseRequired: requireSigned,
+    installerConfiguration,
     files: { ...binaries, installer: installerFile },
     packagedCoreSmoke: {
       isolatedDataRoot: true,


### PR DESCRIPTION
## Summary

- Enable the destination-directory page in the Windows x64 assisted NSIS installer.
- Keep installation per-user and non-elevated; a custom destination must be writable by the current user.
- Make the Windows release verifier fail if assisted/per-user/non-elevated/selectable-directory settings regress.
- Update development and user installation documentation.

## Verification

- NSIS configuration gate: passed
- Windows x64 build and release verifier: passed
- Documentation tests and governance checks: passed
- Changed-file sensitive-information scan: 0 hits
- Installer/known-secret scan: 0 hits
- Installer SHA-256: ae1ab198d5b645c1481fdaf8c9ff50e51d62a76c9dd5cbe0e22bb5b69f489416
- Authenticode: NotSigned (Windows x64 Preview)