### PR TITLE
feat(settings): add GitHub release update check

### DIFF
--- a/apps/desktop/.impeccable/surfaces/settings-workspace.md
+++ b/apps/desktop/.impeccable/surfaces/settings-workspace.md
@@ -8,6 +8,7 @@ related_targets:
   - "apps/desktop/src/renderer/src/NotificationSettings.tsx"
   - "apps/desktop/src/renderer/src/SkillSettings.tsx"
   - "apps/desktop/src/renderer/src/McpSettings.tsx"
+  - "apps/desktop/src/renderer/src/AboutUpdatesSettings.tsx"
 ---
 
 # Settings workspace surface brief
@@ -156,6 +157,24 @@ rechecked after action. v5 export remains allowlisted/redacted and uses an expli
 Runtime monitoring follows its dedicated [`runtime-monitoring.md`](runtime-monitoring.md) surface
 brief. It shares this workspace's borderless header and content track while keeping sparse Usage,
 Coverage, clean-break and freshness semantics local to that page.
+
+## 关于与更新
+
+About & Updates belongs to the Support group and extends the same borderless `1040px` settings track,
+two-column section rhythm and quiet raised rows used by reviewed settings pages. The first viewport
+shows the installed Rovai AI version and one primary “检查更新” action. It is an inspect-and-handoff
+surface, not an updater dashboard or installation wizard.
+
+Checking is always a user action. One click requests the latest published full release from the public
+official `murray17/rovai-ai` GitHub Releases API, compares its semantic version with the packaged App
+version and presents a bounded plain-text Release Notes summary. When a trusted release page is
+available, a secondary action opens that exact page in the system browser. The Renderer never accepts
+or renders remote HTML and never receives an arbitrary URL.
+
+The page keeps the installed version visible through idle, checking, up-to-date, update-available,
+no-release, network failure, GitHub unavailable, rate-limited and invalid-release states. A failure
+keeps the manual action recoverable and never retries automatically. This first version has no
+background request, timer, GitHub token, automatic download, overwrite, restart or `electron-updater`.
 
 ## Inheritance and hard boundaries
 

--- a/apps/desktop/src/main/app-updates.test.ts
+++ b/apps/desktop/src/main/app-updates.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  AppUpdatesService,
+  compareVersions,
+  parseVersion,
+  summarizeReleaseNotes
+} from './app-updates'
+
+const RELEASE_URL = 'https://github.com/murray17/rovai-ai/releases/tag/v1.3.0'
+const NOW = new Date('2026-08-23T08:00:00.000Z')
+
+function release(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    tag_name: 'v1.3.0',
+    name: 'Rovai AI 1.3.0',
+    body: '## 新功能\n- 增加关于与更新页面\n- 改善启动体验',
+    html_url: RELEASE_URL,
+    published_at: '2026-08-22T09:30:00Z',
+    draft: false,
+    prerelease: false,
+    ...overrides
+  }
+}
+
+describe('app update version comparison', () => {
+  it('compares normalized stable and prerelease versions', () => {
+    expect(parseVersion('v1.2')).toMatchObject({ normalized: '1.2.0', core: [1, 2, 0] })
+    expect(compareVersions(parseVersion('1.2.1')!, parseVersion('1.2.0')!)).toBeGreaterThan(0)
+    expect(compareVersions(parseVersion('1.2.0')!, parseVersion('1.2.0-rc.2')!)).toBeGreaterThan(0)
+    expect(compareVersions(parseVersion('1.2.0-rc.10')!, parseVersion('1.2.0-rc.2')!)).toBeGreaterThan(0)
+    expect(parseVersion('1.2.3.4')).toBeNull()
+  })
+
+  it('turns markdown release notes into a bounded plain-text summary', () => {
+    expect(summarizeReleaseNotes(
+      '## 更新内容\n- [查看详情](https://example.com)\n![截图](https://example.com/a.png)\n```sh\nrm -rf /\n```'
+    )).toBe('更新内容\n查看详情\n截图')
+    expect(summarizeReleaseNotes(' '.repeat(20))).toBeNull()
+  })
+})
+
+describe('AppUpdatesService', () => {
+  it('starts idle and checks the unauthenticated official latest-release endpoint only on demand', async () => {
+    const openExternal = vi.fn(async () => undefined)
+    const fetchImpl = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      const headers = new Headers(init?.headers)
+      expect(headers.get('accept')).toBe('application/vnd.github+json')
+      expect(headers.get('x-github-api-version')).toBe('2026-03-10')
+      expect(headers.get('user-agent')).toBe('Rovai-AI/1.2.0')
+      expect(headers.has('authorization')).toBe(false)
+      return new Response(JSON.stringify(release()), {
+        status: 200,
+        headers: { etag: '"release-v1.3.0"' }
+      })
+    })
+    const service = new AppUpdatesService({
+      currentVersion: () => '1.2.0',
+      fetchImpl,
+      openExternal,
+      now: () => NOW
+    })
+
+    expect(service.get()).toMatchObject({ status: 'idle', currentVersion: '1.2.0' })
+    expect(fetchImpl).not.toHaveBeenCalled()
+
+    await expect(service.check()).resolves.toEqual({
+      currentVersion: '1.2.0',
+      status: 'update_available',
+      latestVersion: '1.3.0',
+      releaseName: 'Rovai AI 1.3.0',
+      releaseNotesSummary: '新功能\n增加关于与更新页面\n改善启动体验',
+      publishedAt: '2026-08-22T09:30:00.000Z',
+      releasePageAvailable: true,
+      checkedAt: NOW.toISOString(),
+      failureReason: null,
+      retryAt: null
+    })
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.github.com/repos/murray17/rovai-ai/releases/latest',
+      expect.objectContaining({ method: 'GET' })
+    )
+    await expect(service.openReleasePage()).resolves.toBe(true)
+    expect(openExternal).toHaveBeenCalledWith(RELEASE_URL)
+  })
+
+  it('reports up-to-date, no-release, and rate-limit outcomes without retrying', async () => {
+    const upToDate = new AppUpdatesService({
+      currentVersion: () => '1.3.0',
+      fetchImpl: async () => new Response(JSON.stringify(release()), { status: 200 }),
+      openExternal: async () => undefined,
+      now: () => NOW
+    })
+    await expect(upToDate.check()).resolves.toMatchObject({ status: 'up_to_date' })
+
+    const noReleaseFetch = vi.fn(async () => new Response('', { status: 404 }))
+    const noRelease = new AppUpdatesService({
+      currentVersion: () => '1.2.0',
+      fetchImpl: noReleaseFetch,
+      openExternal: async () => undefined,
+      now: () => NOW
+    })
+    await expect(noRelease.check()).resolves.toMatchObject({
+      status: 'no_release',
+      releasePageAvailable: false
+    })
+    expect(noReleaseFetch).toHaveBeenCalledTimes(1)
+
+    const rateLimitedFetch = vi.fn(async () => new Response('', {
+      status: 429,
+      headers: { 'retry-after': '90' }
+    }))
+    const rateLimited = new AppUpdatesService({
+      currentVersion: () => '1.2.0',
+      fetchImpl: rateLimitedFetch,
+      openExternal: async () => undefined,
+      now: () => NOW
+    })
+    await expect(rateLimited.check()).resolves.toMatchObject({
+      status: 'check_failed',
+      failureReason: 'rate_limited',
+      retryAt: '2026-08-23T08:01:30.000Z'
+    })
+    expect(rateLimitedFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects untrusted release pages and never opens them', async () => {
+    const openExternal = vi.fn(async () => undefined)
+    const service = new AppUpdatesService({
+      currentVersion: () => '1.2.0',
+      fetchImpl: async () => new Response(JSON.stringify(release({
+        html_url: 'https://example.com/murray17/rovai-ai/releases/tag/v1.3.0'
+      })), { status: 200 }),
+      openExternal,
+      now: () => NOW
+    })
+
+    await expect(service.check()).resolves.toMatchObject({
+      status: 'check_failed',
+      failureReason: 'invalid_release',
+      releasePageAvailable: false
+    })
+    await expect(service.openReleasePage()).resolves.toBe(false)
+    expect(openExternal).not.toHaveBeenCalled()
+  })
+
+  it('coalesces simultaneous manual checks into one GitHub request', async () => {
+    let resolveResponse!: (response: Response) => void
+    const pending = new Promise<Response>((resolve) => { resolveResponse = resolve })
+    const fetchImpl = vi.fn(() => pending)
+    const service = new AppUpdatesService({
+      currentVersion: () => '1.2.0',
+      fetchImpl,
+      openExternal: async () => undefined,
+      now: () => NOW
+    })
+
+    const first = service.check()
+    const second = service.check()
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    resolveResponse(new Response(JSON.stringify(release()), { status: 200 }))
+    await expect(Promise.all([first, second])).resolves.toHaveLength(2)
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/main/app-updates.ts
+++ b/apps/desktop/src/main/app-updates.ts
@@ -1,0 +1,356 @@
+import type {
+  AppUpdateFailureReason,
+  AppUpdateSnapshot
+} from '@contracts'
+
+const GITHUB_API_VERSION = '2026-03-10'
+const LATEST_RELEASE_ENDPOINT = 'https://api.github.com/repos/murray17/rovai-ai/releases/latest'
+const RELEASE_PAGE_PREFIX = '/murray17/rovai-ai/releases/tag/'
+const MAX_RESPONSE_CHARACTERS = 512 * 1024
+const MAX_RELEASE_NAME_CHARACTERS = 160
+const MAX_RELEASE_NOTES_CHARACTERS = 720
+const DEFAULT_TIMEOUT_MS = 12_000
+
+type FetchImplementation = (input: string | URL | Request, init?: RequestInit) => Promise<Response>
+
+interface ParsedVersion {
+  normalized: string
+  core: [number, number, number]
+  prerelease: Array<number | string>
+}
+
+interface GitHubReleasePayload {
+  tagName: string
+  name: string | null
+  body: string | null
+  htmlUrl: string
+  publishedAt: string | null
+  draft: boolean
+  prerelease: boolean
+}
+
+interface AppUpdatesServiceOptions {
+  currentVersion(): string
+  openExternal(url: string): Promise<void>
+  fetchImpl?: FetchImplementation
+  now?: () => Date
+  timeoutMs?: number
+}
+
+export class AppUpdatesService {
+  readonly #currentVersion: () => string
+  readonly #openExternal: (url: string) => Promise<void>
+  readonly #fetch: FetchImplementation
+  readonly #now: () => Date
+  readonly #timeoutMs: number
+  #snapshot: AppUpdateSnapshot
+  #releasePageUrl: string | null = null
+  #etag: string | null = null
+  #inFlight: Promise<AppUpdateSnapshot> | null = null
+
+  constructor(options: AppUpdatesServiceOptions) {
+    this.#currentVersion = options.currentVersion
+    this.#openExternal = options.openExternal
+    this.#fetch = options.fetchImpl ?? globalThis.fetch
+    this.#now = options.now ?? (() => new Date())
+    this.#timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+    this.#snapshot = idleSnapshot(this.#currentVersion())
+  }
+
+  get(): AppUpdateSnapshot {
+    return structuredClone(this.#snapshot)
+  }
+
+  check(): Promise<AppUpdateSnapshot> {
+    if (this.#inFlight) return this.#inFlight.then((snapshot) => structuredClone(snapshot))
+    const request = this.#performCheck().finally(() => {
+      this.#inFlight = null
+    })
+    this.#inFlight = request
+    return request.then((snapshot) => structuredClone(snapshot))
+  }
+
+  async openReleasePage(): Promise<boolean> {
+    if (!this.#releasePageUrl) return false
+    await this.#openExternal(this.#releasePageUrl)
+    return true
+  }
+
+  async #performCheck(): Promise<AppUpdateSnapshot> {
+    const currentVersion = this.#currentVersion()
+    const checkedAt = this.#now().toISOString()
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), this.#timeoutMs)
+    timeout.unref?.()
+
+    let response: Response
+    try {
+      response = await this.#fetch(LATEST_RELEASE_ENDPOINT, {
+        method: 'GET',
+        headers: {
+          Accept: 'application/vnd.github+json',
+          'User-Agent': `Rovai-AI/${safeUserAgentVersion(currentVersion)}`,
+          'X-GitHub-Api-Version': GITHUB_API_VERSION,
+          ...(this.#etag ? { 'If-None-Match': this.#etag } : {})
+        },
+        redirect: 'follow',
+        signal: controller.signal
+      })
+    } catch {
+      return this.#acceptFailure(currentVersion, 'network', checkedAt)
+    } finally {
+      clearTimeout(timeout)
+    }
+
+    if (response.status === 304 && this.#releasePageUrl && hasRelease(this.#snapshot)) {
+      this.#snapshot = { ...this.#snapshot, checkedAt }
+      return this.#snapshot
+    }
+    if (response.status === 404) {
+      this.#releasePageUrl = null
+      this.#etag = null
+      this.#snapshot = {
+        ...idleSnapshot(currentVersion),
+        status: 'no_release',
+        checkedAt
+      }
+      return this.#snapshot
+    }
+    if (response.status === 403 || response.status === 429) {
+      return this.#acceptFailure(
+        currentVersion,
+        'rate_limited',
+        checkedAt,
+        rateLimitRetryAt(response.headers, this.#now())
+      )
+    }
+    if (!response.ok) {
+      return this.#acceptFailure(currentVersion, 'github_unavailable', checkedAt)
+    }
+
+    const declaredLength = Number(response.headers.get('content-length'))
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_RESPONSE_CHARACTERS) {
+      return this.#acceptFailure(currentVersion, 'invalid_release', checkedAt)
+    }
+
+    let raw: string
+    try {
+      raw = await response.text()
+    } catch {
+      return this.#acceptFailure(currentVersion, 'network', checkedAt)
+    }
+    if (raw.length > MAX_RESPONSE_CHARACTERS) {
+      return this.#acceptFailure(currentVersion, 'invalid_release', checkedAt)
+    }
+
+    let release: GitHubReleasePayload | null = null
+    try {
+      release = parseGitHubRelease(JSON.parse(raw) as unknown)
+    } catch {
+      release = null
+    }
+    const current = parseVersion(currentVersion)
+    const latest = release ? parseVersion(release.tagName) : null
+    const releasePageUrl = release ? trustedReleasePageUrl(release.htmlUrl) : null
+    if (!release || release.draft || release.prerelease || !current || !latest || !releasePageUrl) {
+      return this.#acceptFailure(currentVersion, 'invalid_release', checkedAt)
+    }
+
+    this.#etag = response.headers.get('etag')
+    this.#releasePageUrl = releasePageUrl
+    this.#snapshot = {
+      currentVersion,
+      status: compareVersions(latest, current) > 0 ? 'update_available' : 'up_to_date',
+      latestVersion: latest.normalized,
+      releaseName: boundedSingleLine(release.name ?? release.tagName, MAX_RELEASE_NAME_CHARACTERS),
+      releaseNotesSummary: summarizeReleaseNotes(release.body),
+      publishedAt: validIsoDate(release.publishedAt),
+      releasePageAvailable: true,
+      checkedAt,
+      failureReason: null,
+      retryAt: null
+    }
+    return this.#snapshot
+  }
+
+  #acceptFailure(
+    currentVersion: string,
+    reason: AppUpdateFailureReason,
+    checkedAt: string,
+    retryAt: string | null = null
+  ): AppUpdateSnapshot {
+    this.#releasePageUrl = null
+    this.#etag = null
+    this.#snapshot = {
+      ...idleSnapshot(currentVersion),
+      status: 'check_failed',
+      checkedAt,
+      failureReason: reason,
+      retryAt
+    }
+    return this.#snapshot
+  }
+}
+
+export function parseVersion(value: string): ParsedVersion | null {
+  const match = value.trim().match(
+    /^v?(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?(?:\.(0|[1-9]\d*))?(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/
+  )
+  if (!match) return null
+  const core = [match[1], match[2] ?? '0', match[3] ?? '0'].map(Number)
+  if (core.some((part) => !Number.isSafeInteger(part))) return null
+  const prerelease = match[4]
+    ? match[4].split('.').map((identifier) => /^(0|[1-9]\d*)$/.test(identifier)
+        ? Number(identifier)
+        : identifier)
+    : []
+  return {
+    normalized: `${core.join('.')}${match[4] ? `-${match[4]}` : ''}`,
+    core: core as [number, number, number],
+    prerelease
+  }
+}
+
+export function compareVersions(left: ParsedVersion, right: ParsedVersion): number {
+  for (let index = 0; index < left.core.length; index += 1) {
+    if (left.core[index] !== right.core[index]) return left.core[index] - right.core[index]
+  }
+  if (left.prerelease.length === 0 || right.prerelease.length === 0) {
+    return left.prerelease.length === right.prerelease.length
+      ? 0
+      : left.prerelease.length === 0 ? 1 : -1
+  }
+  const length = Math.max(left.prerelease.length, right.prerelease.length)
+  for (let index = 0; index < length; index += 1) {
+    const leftPart = left.prerelease[index]
+    const rightPart = right.prerelease[index]
+    if (leftPart === undefined || rightPart === undefined) {
+      return leftPart === rightPart ? 0 : leftPart === undefined ? -1 : 1
+    }
+    if (leftPart === rightPart) continue
+    if (typeof leftPart === 'number' && typeof rightPart === 'number') return leftPart - rightPart
+    if (typeof leftPart === 'number') return -1
+    if (typeof rightPart === 'number') return 1
+    return leftPart.localeCompare(rightPart)
+  }
+  return 0
+}
+
+export function summarizeReleaseNotes(body: string | null): string | null {
+  if (!body?.trim()) return null
+  const lines = body
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/<[^>]{1,240}>/g, ' ')
+    .split(/\r?\n/)
+    .map((line) => line
+      .replace(/^\s{0,3}(?:#{1,6}|>|[-*+] |\d+[.)] )\s*/, '')
+      .replace(/^\s*\[[ xX]\]\s*/, '')
+      .replace(/[*_~`]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim())
+    .filter(Boolean)
+    .slice(0, 6)
+  if (lines.length === 0) return null
+  return boundedMultiline(lines.join('\n'), MAX_RELEASE_NOTES_CHARACTERS)
+}
+
+function idleSnapshot(currentVersion: string): AppUpdateSnapshot {
+  return {
+    currentVersion,
+    status: 'idle',
+    latestVersion: null,
+    releaseName: null,
+    releaseNotesSummary: null,
+    publishedAt: null,
+    releasePageAvailable: false,
+    checkedAt: null,
+    failureReason: null,
+    retryAt: null
+  }
+}
+
+function hasRelease(snapshot: AppUpdateSnapshot): boolean {
+  return snapshot.releasePageAvailable
+    && snapshot.latestVersion !== null
+    && (snapshot.status === 'up_to_date' || snapshot.status === 'update_available')
+}
+
+function parseGitHubRelease(value: unknown): GitHubReleasePayload | null {
+  if (!isRecord(value)) return null
+  if (typeof value.tag_name !== 'string'
+      || (typeof value.name !== 'string' && value.name !== null)
+      || (typeof value.body !== 'string' && value.body !== null)
+      || typeof value.html_url !== 'string'
+      || (typeof value.published_at !== 'string' && value.published_at !== null)
+      || typeof value.draft !== 'boolean'
+      || typeof value.prerelease !== 'boolean') return null
+  return {
+    tagName: value.tag_name,
+    name: value.name,
+    body: value.body,
+    htmlUrl: value.html_url,
+    publishedAt: value.published_at,
+    draft: value.draft,
+    prerelease: value.prerelease
+  }
+}
+
+function trustedReleasePageUrl(value: string): string | null {
+  try {
+    const url = new URL(value)
+    if (url.protocol !== 'https:'
+        || url.hostname.toLowerCase() !== 'github.com'
+        || url.port
+        || url.username
+        || url.password
+        || url.search
+        || url.hash
+        || !url.pathname.startsWith(RELEASE_PAGE_PREFIX)
+        || url.pathname.length <= RELEASE_PAGE_PREFIX.length) return null
+    return url.toString()
+  } catch {
+    return null
+  }
+}
+
+function rateLimitRetryAt(headers: Headers, now: Date): string | null {
+  const retryAfter = headers.get('retry-after')
+  const retryAfterSeconds = retryAfter === null ? Number.NaN : Number(retryAfter)
+  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0) {
+    return new Date(now.getTime() + retryAfterSeconds * 1000).toISOString()
+  }
+  const resetSeconds = Number(headers.get('x-ratelimit-reset'))
+  if (Number.isFinite(resetSeconds) && resetSeconds > 0) {
+    return new Date(resetSeconds * 1000).toISOString()
+  }
+  return null
+}
+
+function validIsoDate(value: string | null): string | null {
+  if (!value) return null
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString()
+}
+
+function boundedSingleLine(value: string, maximum: number): string {
+  const normalized = value.replace(/\s+/g, ' ').trim()
+  return normalized.length <= maximum ? normalized : `${normalized.slice(0, maximum - 1).trimEnd()}…`
+}
+
+function boundedMultiline(value: string, maximum: number): string {
+  if (value.length <= maximum) return value
+  const candidate = value.slice(0, maximum - 1)
+  const boundary = Math.max(candidate.lastIndexOf(' '), candidate.lastIndexOf('\n'))
+  return `${candidate.slice(0, boundary > maximum * 0.72 ? boundary : candidate.length).trimEnd()}…`
+}
+
+function safeUserAgentVersion(value: string): string {
+  return value.replace(/[^0-9A-Za-z.+-]/g, '_').slice(0, 80) || 'unknown'
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}

--- a/apps/desktop/src/main/general-preferences.test.ts
+++ b/apps/desktop/src/main/general-preferences.test.ts
@@ -32,6 +32,18 @@ describe('general preferences', () => {
 
   it('accepts only the exact schema and finite enums', () => {
     expect(parseGeneralPreferences({
+      schemaVersion: 3,
+      startupLocationMode: 'last_location',
+      lastSettingsSection: 'about',
+      executionConsolePlacement: 'bottom',
+      newConversationDefaults: null,
+      newConversationDefaultsRequireConfirmation: false,
+      oneClickNewConversationEnabled: false
+    })).toEqual({
+      ...DEFAULT_GENERAL_PREFERENCES,
+      lastSettingsSection: 'about'
+    })
+    expect(parseGeneralPreferences({
       schemaVersion: 1,
       startupLocationMode: 'quick_chat',
       lastSettingsSection: 'diagnostics'

--- a/apps/desktop/src/main/general-preferences.ts
+++ b/apps/desktop/src/main/general-preferences.ts
@@ -19,7 +19,8 @@ const SETTINGS_SECTIONS = new Set<SettingsSection>([
   'appearance',
   'notifications',
   'monitoring',
-  'diagnostics'
+  'diagnostics',
+  'about'
 ])
 
 export const DEFAULT_GENERAL_PREFERENCES: GeneralPreferencesSnapshot = {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -76,6 +76,7 @@ import {
   prepareWindowsDataRoot,
   resolveWindowsDataRoot
 } from './windows-data-root'
+import { AppUpdatesService } from './app-updates'
 
 const mainStartupStartedAt = performance.now()
 console.info('[startup] stage=main_module_loaded elapsed_ms=0.0')
@@ -218,6 +219,10 @@ const isolatedAcceptanceInstance =
 const primaryInstance = isolatedAcceptanceInstance || app.requestSingleInstanceLock()
 if (!primaryInstance) app.quit()
 const core = new CoreClient(coreDataPath)
+const appUpdates = new AppUpdatesService({
+  currentVersion: () => app.getVersion(),
+  openExternal: (url) => shell.openExternal(url)
+})
 let mainWindow: BrowserWindow | null = null
 let themePreference: ThemePreference = 'system'
 let appearanceFilePath = ''
@@ -523,6 +528,21 @@ ipcMain.handle('rovai:appearance-set', async (_event, preference: unknown) => {
   themePreference = preference
   nativeTheme.themeSource = nativeThemeSource(preference)
   return publishAppearance()
+})
+
+ipcMain.handle('rovai:app-updates-get', (event) => {
+  requireMainWindow(event.sender)
+  return appUpdates.get()
+})
+
+ipcMain.handle('rovai:app-updates-check', (event) => {
+  requireMainWindow(event.sender)
+  return appUpdates.check()
+})
+
+ipcMain.handle('rovai:app-updates-open-release', (event) => {
+  requireMainWindow(event.sender)
+  return appUpdates.openReleasePage()
 })
 
 ipcMain.handle('rovai:window-application-menu-popup', (event, input: unknown) => {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -48,6 +48,17 @@ const api: RovaiApi = {
       return () => ipcRenderer.removeListener('rovai:appearance-changed', handler)
     }
   },
+  appUpdates: {
+    get() {
+      return ipcRenderer.invoke('rovai:app-updates-get')
+    },
+    check() {
+      return ipcRenderer.invoke('rovai:app-updates-check')
+    },
+    openReleasePage() {
+      return ipcRenderer.invoke('rovai:app-updates-open-release')
+    }
+  },
   desktopSession: {
     getStartupSnapshot() {
       return ipcRenderer.invoke('rovai:desktop-session-get-startup')

--- a/apps/desktop/src/renderer/src/AboutUpdatesSettings.test.ts
+++ b/apps/desktop/src/renderer/src/AboutUpdatesSettings.test.ts
@@ -1,0 +1,97 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import type { AppUpdateSnapshot } from '@contracts'
+import { AboutUpdatesSettingsView } from './AboutUpdatesSettings'
+
+function snapshot(overrides: Partial<AppUpdateSnapshot> = {}): AppUpdateSnapshot {
+  return {
+    currentVersion: '0.0.1',
+    status: 'idle',
+    latestVersion: null,
+    releaseName: null,
+    releaseNotesSummary: null,
+    publishedAt: null,
+    releasePageAvailable: false,
+    checkedAt: null,
+    failureReason: null,
+    retryAt: null,
+    ...overrides
+  }
+}
+
+function render(value: AppUpdateSnapshot | null, options: {
+  loading?: boolean
+  checking?: boolean
+  loadError?: boolean
+} = {}): string {
+  return renderToStaticMarkup(createElement(AboutUpdatesSettingsView, {
+    snapshot: value,
+    canCheck: true,
+    loading: options.loading ?? false,
+    checking: options.checking ?? false,
+    openingRelease: false,
+    loadError: options.loadError ?? false,
+    openError: false,
+    onCheck: () => undefined,
+    onOpenRelease: () => undefined
+  }))
+}
+
+describe('AboutUpdatesSettingsView', () => {
+  it('shows the installed version and a manual-only check action', () => {
+    const markup = render(snapshot())
+    expect(markup).toContain('<h1>关于与更新</h1>')
+    expect(markup).toContain('<code>v0.0.1</code>')
+    expect(markup).toContain('>检查更新</button>')
+    expect(markup).toContain('点击“检查更新”后才会连接 GitHub')
+    expect(markup).toContain('不会下载或安装内容')
+    expect(markup).not.toContain('Release Notes 摘要')
+  })
+
+  it('presents an available release summary and its GitHub handoff', () => {
+    const markup = render(snapshot({
+      status: 'update_available',
+      latestVersion: '0.2.0',
+      releaseName: 'Rovai AI 0.2.0',
+      releaseNotesSummary: '新增轻量更新入口。',
+      publishedAt: '2026-08-22T09:30:00.000Z',
+      releasePageAvailable: true,
+      checkedAt: '2026-08-23T08:00:00.000Z'
+    }))
+    expect(markup).toContain('发现新版本 v0.2.0')
+    expect(markup).toContain('Release Notes 摘要')
+    expect(markup).toContain('新增轻量更新入口。')
+    expect(markup).toContain('在 GitHub 查看此 Release')
+    expect(markup).toContain('>重新检查</button>')
+  })
+
+  it('keeps no-release and rate-limit failures recoverable', () => {
+    expect(render(snapshot({ status: 'no_release', checkedAt: '2026-08-23T08:00:00.000Z' })))
+      .toContain('暂未找到正式 Release')
+    const limited = render(snapshot({
+      status: 'check_failed',
+      checkedAt: '2026-08-23T08:00:00.000Z',
+      failureReason: 'rate_limited',
+      retryAt: '2026-08-23T09:00:00.000Z'
+    }))
+    expect(limited).toContain('GitHub 请求暂时受限')
+    expect(limited).toContain('role="alert"')
+    expect(limited).not.toContain('在 GitHub 查看此 Release')
+  })
+
+  it('disables duplicate checks while a request is running', () => {
+    const markup = render(snapshot(), { checking: true })
+    expect(markup).toContain('aria-disabled="true" aria-busy="true"')
+    expect(markup).not.toContain('disabled=""')
+    expect(markup).toContain('正在检查…')
+    expect(markup).toContain('正在检查官方 Release')
+    expect(markup).not.toContain('尚未检查更新')
+  })
+
+  it('allows an in-page retry when the initial version read fails', () => {
+    const markup = render(null, { loadError: true })
+    expect(markup).toContain('可直接点击“检查更新”重试')
+    expect(markup).not.toContain('disabled=""')
+  })
+})

--- a/apps/desktop/src/renderer/src/AboutUpdatesSettings.tsx
+++ b/apps/desktop/src/renderer/src/AboutUpdatesSettings.tsx
@@ -1,0 +1,331 @@
+/*
+ * THESIS: One quiet, inspectable release check; no updater dashboard or installation wizard.
+ * OWN-WORLD: Rovai's open Porcelain/Graphite settings plane, Steel action, aligned evidence rows.
+ * STORY: Read the installed version, check once on demand, review the latest notes, open GitHub.
+ * FIRST VIEWPORT: Borderless settings header, version row, then one update row with the sole primary action.
+ * FORM: Established settings-surface extension; no concept seed. Key: about-updates-lightweight-release-check.
+ * FINISH: unreviewed and undocumented is unfinished; this build ends with the finish review and surface brief.
+ */
+import { useEffect, useState } from 'react'
+import type {
+  AppUpdateFailureReason,
+  AppUpdateSnapshot,
+  AppUpdatesApi
+} from '@contracts'
+import { SettingsPageHeader } from './SettingsPageHeader'
+
+export function AboutUpdatesSettings({
+  api
+}: {
+  api?: AppUpdatesApi
+}): React.JSX.Element {
+  const resolvedApi = api ?? (typeof window === 'undefined' ? null : window.rovai.appUpdates)
+  const [snapshot, setSnapshot] = useState<AppUpdateSnapshot | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [checking, setChecking] = useState(false)
+  const [openingRelease, setOpeningRelease] = useState(false)
+  const [loadError, setLoadError] = useState(false)
+  const [openError, setOpenError] = useState(false)
+
+  useEffect(() => {
+    let active = true
+    if (!resolvedApi) {
+      setLoading(false)
+      setLoadError(true)
+      return () => { active = false }
+    }
+    void resolvedApi.get()
+      .then((next) => {
+        if (!active) return
+        setSnapshot(next)
+        setLoadError(false)
+      })
+      .catch(() => {
+        if (active) setLoadError(true)
+      })
+      .finally(() => {
+        if (active) setLoading(false)
+      })
+    return () => { active = false }
+  }, [resolvedApi])
+
+  const checkForUpdates = async (): Promise<void> => {
+    if (!resolvedApi || checking) return
+    setChecking(true)
+    setOpenError(false)
+    try {
+      setSnapshot(await resolvedApi.check())
+      setLoadError(false)
+    } catch {
+      if (snapshot) {
+        setSnapshot({
+          ...snapshot,
+          status: 'check_failed',
+          checkedAt: new Date().toISOString(),
+          failureReason: 'network',
+          retryAt: null
+        })
+        setLoadError(false)
+      } else {
+        setLoadError(true)
+      }
+    } finally {
+      setChecking(false)
+    }
+  }
+
+  const openReleasePage = async (): Promise<void> => {
+    if (!resolvedApi || openingRelease) return
+    setOpeningRelease(true)
+    setOpenError(false)
+    try {
+      if (!await resolvedApi.openReleasePage()) setOpenError(true)
+    } catch {
+      setOpenError(true)
+    } finally {
+      setOpeningRelease(false)
+    }
+  }
+
+  return (
+    <AboutUpdatesSettingsView
+      snapshot={snapshot}
+      canCheck={Boolean(resolvedApi)}
+      loading={loading}
+      checking={checking}
+      openingRelease={openingRelease}
+      loadError={loadError}
+      openError={openError}
+      onCheck={() => void checkForUpdates()}
+      onOpenRelease={() => void openReleasePage()}
+    />
+  )
+}
+
+export function AboutUpdatesSettingsView({
+  snapshot,
+  canCheck,
+  loading,
+  checking,
+  openingRelease,
+  loadError,
+  openError,
+  onCheck,
+  onOpenRelease
+}: {
+  snapshot: AppUpdateSnapshot | null
+  canCheck: boolean
+  loading: boolean
+  checking: boolean
+  openingRelease: boolean
+  loadError: boolean
+  openError: boolean
+  onCheck(): void
+  onOpenRelease(): void
+}): React.JSX.Element {
+  const status = updateStatus(snapshot, loading, loadError, checking, canCheck)
+  const releaseVisible = Boolean(
+    snapshot?.releasePageAvailable
+    && snapshot.latestVersion
+    && (snapshot.status === 'up_to_date' || snapshot.status === 'update_available')
+  )
+
+  return (
+    <div className="about-updates-settings">
+      <SettingsPageHeader
+        eyebrow="Settings / About & Updates"
+        title="关于与更新"
+        description="查看当前版本，按需检查官方 GitHub Releases。"
+      />
+
+      <div className="about-updates-body">
+        <section className="section-block about-updates-section" aria-labelledby="about-version-heading">
+          <div className="section-heading">
+            <div><h2 id="about-version-heading">版本</h2><p>当前安装</p></div>
+          </div>
+          <div className="about-version-row">
+            <div className="about-product-name">
+              <strong>Rovai AI</strong>
+              <small>桌面应用</small>
+            </div>
+            <div className="about-version-value">
+              <span>当前版本</span>
+              <code>{snapshot ? displayVersion(snapshot.currentVersion) : loading ? '读取中…' : '暂不可用'}</code>
+            </div>
+          </div>
+        </section>
+
+        <section className="section-block about-updates-section" aria-labelledby="about-update-heading">
+          <div className="section-heading">
+            <div><h2 id="about-update-heading">更新</h2><p>手动检查</p></div>
+          </div>
+          <div className="about-update-body">
+            <div className="about-update-control">
+              <div>
+                <strong>GitHub Releases</strong>
+                <p>仅在你点击时读取一次公开 Release 信息；不会下载或安装内容。</p>
+              </div>
+              <button
+                className="primary-button"
+                type="button"
+                disabled={!canCheck || (loading && !snapshot)}
+                aria-disabled={checking || undefined}
+                aria-busy={checking || undefined}
+                aria-describedby="about-update-status"
+                onClick={onCheck}
+              >
+                {checking && <span className="about-update-spinner" aria-hidden="true" />}
+                {checking ? '正在检查…' : snapshot?.checkedAt ? '重新检查' : '检查更新'}
+              </button>
+            </div>
+
+            <div
+              id="about-update-status"
+              className={`about-update-status is-${status.tone}`}
+              role={status.tone === 'error' ? 'alert' : 'status'}
+              aria-live="polite"
+            >
+              <span className="about-update-status-mark" aria-hidden="true" />
+              <div><strong>{status.title}</strong><p>{status.detail}</p></div>
+            </div>
+
+            {releaseVisible && snapshot && (
+              <section className="about-release-notes" aria-labelledby="about-release-notes-heading">
+                <div className="about-release-notes-heading">
+                  <div>
+                    <h3 id="about-release-notes-heading">Release Notes 摘要</h3>
+                    <p>{snapshot.releaseName?.trim() || displayVersion(snapshot.latestVersion ?? '')}</p>
+                  </div>
+                  <span>{releaseMetadata(snapshot)}</span>
+                </div>
+                <p className="about-release-notes-copy">
+                  {snapshot.releaseNotesSummary ?? '此版本没有提供可显示的 Release Notes 摘要。请前往 GitHub 查看完整内容。'}
+                </p>
+                <div className="about-release-notes-action">
+                  <button
+                    className="quiet-button compact"
+                    type="button"
+                    disabled={openingRelease}
+                    onClick={onOpenRelease}
+                  >
+                    {openingRelease ? '正在打开…' : '在 GitHub 查看此 Release'}
+                  </button>
+                  {openError && <span role="alert">无法打开 GitHub Release，请稍后重试。</span>}
+                </div>
+              </section>
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}
+
+function updateStatus(
+  snapshot: AppUpdateSnapshot | null,
+  loading: boolean,
+  loadError: boolean,
+  checking: boolean,
+  canCheck: boolean
+): { tone: 'neutral' | 'success' | 'attention' | 'error'; title: string; detail: string } {
+  if (loading) return { tone: 'neutral', title: '正在读取当前版本', detail: '更新检查尚未开始。' }
+  if (checking) {
+    return {
+      tone: 'neutral',
+      title: '正在检查官方 Release',
+      detail: '完成后将显示当前版本与最新正式版本的比较结果。'
+    }
+  }
+  if (loadError || !snapshot) {
+    return {
+      tone: 'error',
+      title: '无法读取应用版本',
+      detail: canCheck ? '可直接点击“检查更新”重试。' : '请重新打开此页面后再试。'
+    }
+  }
+  switch (snapshot.status) {
+    case 'idle':
+      return {
+        tone: 'neutral',
+        title: '尚未检查更新',
+        detail: '点击“检查更新”后才会连接 GitHub。'
+      }
+    case 'up_to_date':
+      return {
+        tone: 'success',
+        title: '当前已是最新正式版本',
+        detail: `已与官方 GitHub Releases 中的 ${displayVersion(snapshot.latestVersion ?? snapshot.currentVersion)} 完成比较。`
+      }
+    case 'update_available':
+      return {
+        tone: 'attention',
+        title: `发现新版本 ${displayVersion(snapshot.latestVersion ?? '')}`,
+        detail: '可先阅读下方摘要，再前往 GitHub Release 页面选择安装包。'
+      }
+    case 'no_release':
+      return {
+        tone: 'neutral',
+        title: '暂未找到正式 Release',
+        detail: '官方 GitHub Releases 目前没有可用于比较的正式版本。'
+      }
+    case 'check_failed':
+      return failureStatus(snapshot.failureReason, snapshot.retryAt)
+  }
+}
+
+function failureStatus(
+  reason: AppUpdateFailureReason | null,
+  retryAt: string | null
+): { tone: 'error'; title: string; detail: string } {
+  if (reason === 'rate_limited') {
+    return {
+      tone: 'error',
+      title: 'GitHub 请求暂时受限',
+      detail: retryAt
+        ? `未使用 Token 的公开请求已达到限制，请在 ${formatTime(retryAt)} 后重试。`
+        : '未使用 Token 的公开请求已达到限制，请稍后重试。'
+    }
+  }
+  if (reason === 'invalid_release') {
+    return {
+      tone: 'error',
+      title: 'Release 信息无法验证',
+      detail: '返回的版本或下载页信息不符合 Rovai 的公开 Release 规则。'
+    }
+  }
+  if (reason === 'github_unavailable') {
+    return { tone: 'error', title: 'GitHub 暂时不可用', detail: '本次检查没有完成，请稍后重试。' }
+  }
+  return { tone: 'error', title: '无法连接 GitHub', detail: '请检查网络连接后重试。' }
+}
+
+function displayVersion(value: string): string {
+  const trimmed = value.trim().replace(/^v/i, '')
+  return trimmed ? `v${trimmed}` : '版本未知'
+}
+
+function releaseMetadata(snapshot: AppUpdateSnapshot): string {
+  const version = displayVersion(snapshot.latestVersion ?? '')
+  if (!snapshot.publishedAt) return version
+  try {
+    const date = new Intl.DateTimeFormat('zh-CN', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric'
+    }).format(new Date(snapshot.publishedAt))
+    return `${version} · ${date}`
+  } catch {
+    return version
+  }
+}
+
+function formatTime(value: string): string {
+  try {
+    return new Intl.DateTimeFormat('zh-CN', {
+      hour: '2-digit',
+      minute: '2-digit'
+    }).format(new Date(value))
+  } catch {
+    return '限制解除'
+  }
+}

--- a/apps/desktop/src/renderer/src/App.test.ts
+++ b/apps/desktop/src/renderer/src/App.test.ts
@@ -1949,11 +1949,14 @@ describe('task event projections', () => {
     expect(capabilitiesGroup.indexOf('<strong>MCP</strong>')).toBeLessThan(capabilitiesGroup.indexOf('<strong>Agent 运行时</strong>'))
     expect(supportGroup).toContain('<strong>诊断与修复</strong>')
     expect(supportGroup).toContain('<strong>运行监控</strong>')
+    expect(supportGroup).toContain('<strong>关于与更新</strong>')
     expect(supportGroup).toContain('data-navigation-icon="chart-line"')
     expect(supportGroup).toContain('data-navigation-icon="stethoscope"')
+    expect(supportGroup).toContain('data-navigation-icon="info"')
+    expect(supportGroup.indexOf('<strong>运行监控</strong>')).toBeLessThan(supportGroup.indexOf('<strong>诊断与修复</strong>'))
+    expect(supportGroup.indexOf('<strong>诊断与修复</strong>')).toBeLessThan(supportGroup.indexOf('<strong>关于与更新</strong>'))
     expect(markup).toContain('data-navigation-icon="arrow-left"')
     expect(markup).toContain('class="active" type="button" aria-current="page"')
-    expect(markup).not.toContain('关于与更新')
     expect(markup).not.toContain('新对话')
     expect(markup).not.toContain('快速对话')
     expect(markup).not.toContain('Core')
@@ -1978,7 +1981,8 @@ describe('task event projections', () => {
       appearance: '外观',
       notifications: '提醒',
       monitoring: '运行监控',
-      diagnostics: '诊断与修复'
+      diagnostics: '诊断与修复',
+      about: '关于与更新'
     }
     for (const [section, heading] of Object.entries(contentBySection) as Array<[NavigationSettingsSection, string]>) {
       const markup = renderToStaticMarkup(createElement(SettingsView, { ...baseProps, section }))

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -66,6 +66,7 @@ import { NewConversationDialog } from './NewConversationDialog'
 import { openRuntimeModelCatalog } from './runtime-check'
 import { PanelToggleIcon } from './PanelToggleIcon'
 import { AppearanceSettings } from './AppearanceSettings'
+import { AboutUpdatesSettings } from './AboutUpdatesSettings'
 import {
   NotificationAttentionController,
   type NotificationNavigationResult
@@ -3117,6 +3118,9 @@ export function SettingsView({
         )}
         {section === 'diagnostics' && (
           <DiagnosticsCenter onNavigate={onDiagnosticsNavigate} platform={platform} />
+        )}
+        {section === 'about' && (
+          <AboutUpdatesSettings />
         )}
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/CampNavigation.tsx
+++ b/apps/desktop/src/renderer/src/CampNavigation.tsx
@@ -822,7 +822,8 @@ const SETTINGS_SIDEBAR_GROUPS: SettingsSidebarGroup[] = [
     label: '支持',
     items: [
       { key: 'monitoring', icon: 'chart-line', label: '运行监控' },
-      { key: 'diagnostics', icon: 'stethoscope', label: '诊断与修复' }
+      { key: 'diagnostics', icon: 'stethoscope', label: '诊断与修复' },
+      { key: 'about', icon: 'info', label: '关于与更新' }
     ]
   }
 ]

--- a/apps/desktop/src/renderer/src/NavigationIcon.tsx
+++ b/apps/desktop/src/renderer/src/NavigationIcon.tsx
@@ -5,6 +5,7 @@ export type NavigationIconName =
   | 'brain'
   | 'chart-line'
   | 'cpu'
+  | 'info'
   | 'settings'
   | 'sliders-horizontal'
   | 'sparkles'
@@ -57,6 +58,8 @@ function navigationIconPaths(name: NavigationIconName): React.JSX.Element {
       return <><rect x="3" y="3" width="7" height="7" rx="1.5" /><rect x="14" y="3" width="7" height="7" rx="1.5" /><rect x="8.5" y="14" width="7" height="7" rx="1.5" /><path d="M6.5 10v2h11v-2" /><path d="M12 12v2" /></>
     case 'cpu':
       return <><rect x="4" y="4" width="16" height="16" rx="2" /><rect x="9" y="9" width="6" height="6" rx="1" /><path d="M9 1v3" /><path d="M15 1v3" /><path d="M9 20v3" /><path d="M15 20v3" /><path d="M20 9h3" /><path d="M20 14h3" /><path d="M1 9h3" /><path d="M1 14h3" /></>
+    case 'info':
+      return <><circle cx="12" cy="12" r="9" /><path d="M12 11v6" /><path d="M12 7.25h.01" /></>
     case 'stethoscope':
       return <><path d="M5 3v5a4 4 0 0 0 8 0V3" /><path d="M5 3H4" /><path d="M13 3h1" /><path d="M9 12v3a4 4 0 0 0 4 4h1" /><circle cx="17" cy="17" r="3" /></>
   }

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -3087,6 +3087,51 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
 .general-settings-section .section-heading { align-self: start; align-items: flex-start; margin: 0; }
 .general-settings-section .section-heading h2 { margin: 0; color: var(--ink); font-size: 15px; font-weight: 620; }
 .general-settings-section .section-heading p { margin: 6px 0 0; color: var(--faint); font-size: 10px; line-height: 1.45; }
+.about-updates-settings { display: grid; width: min(1040px, 100%); max-width: 1040px; padding-bottom: 24px; }
+.about-updates-body { display: grid; }
+.about-updates-section { display: grid; grid-template-columns: minmax(98px, 132px) minmax(0, 1fr); align-items: start; gap: clamp(22px, 4vw, 42px); margin: 0; padding: 30px 0; border: 0; border-bottom: 1px solid var(--line); }
+.about-updates-section:last-child { border-bottom: 0; }
+.about-updates-section .section-heading { align-self: start; align-items: flex-start; margin: 0; }
+.about-updates-section .section-heading h2 { margin: 0; color: var(--ink); font-size: 15px; font-weight: 620; }
+.about-updates-section .section-heading p { margin: 6px 0 0; color: var(--faint); font-size: 10px; line-height: 1.45; }
+.about-version-row { display: flex; min-height: 76px; align-items: center; justify-content: space-between; gap: 24px; padding: 15px 17px; border-radius: 10px; background: var(--workspace-surface-raised); }
+.about-product-name { display: grid; min-width: 0; gap: 4px; }
+.about-product-name strong { color: var(--ink); font-size: 13px; font-weight: 650; }
+.about-product-name small { color: var(--muted); font-size: 10.5px; }
+.about-version-value { display: grid; flex: 0 0 auto; justify-items: end; gap: 5px; }
+.about-version-value span { color: var(--faint); font-size: 9.5px; }
+.about-version-value code { color: var(--ink); font: 650 12px/1.25 ui-monospace, SFMono-Regular, Menlo, monospace; font-variant-numeric: tabular-nums; }
+.about-update-body { display: grid; min-width: 0; gap: 10px; }
+.about-update-control { display: flex; min-height: 76px; align-items: center; justify-content: space-between; gap: 22px; padding: 15px 17px; border-radius: 10px; background: var(--workspace-surface-raised); }
+.about-update-control > div { display: grid; min-width: 0; gap: 5px; }
+.about-update-control strong { color: var(--ink); font-size: 12.5px; font-weight: 650; }
+.about-update-control p { max-width: 560px; margin: 0; color: var(--muted); font-size: 10.5px; line-height: 1.55; }
+.about-update-control > button { display: inline-flex; flex: 0 0 auto; align-items: center; gap: 7px; justify-content: center; }
+.about-update-control > .primary-button[aria-disabled="true"],
+.about-update-control > .primary-button[aria-disabled="true"]:hover { border-color: var(--brand); background: var(--brand); cursor: wait; opacity: .76; }
+.about-update-control > .primary-button[aria-disabled="true"]:active { transform: none; }
+.about-update-status { display: grid; min-height: 54px; grid-template-columns: 8px minmax(0, 1fr); align-items: start; gap: 10px; padding: 11px 13px; border-radius: 9px; color: var(--muted); background: var(--workspace-surface-subtle); }
+.about-update-status-mark { width: 7px; height: 7px; margin-top: 4px; border-radius: 50%; color: var(--neutral); background: currentColor; }
+.about-update-status > div { display: grid; min-width: 0; gap: 3px; }
+.about-update-status strong { color: var(--ink); font-size: 11px; font-weight: 650; }
+.about-update-status p { margin: 0; color: var(--muted); font-size: 10.5px; line-height: 1.5; }
+.about-update-status.is-success .about-update-status-mark { color: var(--success); }
+.about-update-status.is-attention .about-update-status-mark { color: var(--attention); }
+.about-update-status.is-error { background: var(--danger-soft); }
+.about-update-status.is-error .about-update-status-mark,
+.about-update-status.is-error strong,
+.about-update-status.is-error p { color: var(--danger); }
+.about-release-notes { display: grid; gap: 12px; margin-top: 3px; padding: 16px 17px; border-radius: 10px; background: var(--workspace-surface-subtle); }
+.about-release-notes-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; }
+.about-release-notes-heading > div { display: grid; min-width: 0; gap: 4px; }
+.about-release-notes-heading h3 { margin: 0; color: var(--ink); font-size: 12px; font-weight: 650; }
+.about-release-notes-heading p { overflow: hidden; margin: 0; color: var(--muted); font-size: 10.5px; text-overflow: ellipsis; white-space: nowrap; }
+.about-release-notes-heading > span { flex: 0 0 auto; color: var(--faint); font: 550 9.5px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace; font-variant-numeric: tabular-nums; white-space: nowrap; }
+.about-release-notes-copy { max-width: 76ch; margin: 0; white-space: pre-line; overflow-wrap: anywhere; color: var(--muted); font-size: 10.5px; line-height: 1.65; }
+.about-release-notes-action { display: flex; align-items: center; flex-wrap: wrap; gap: 9px; padding-top: 1px; }
+.about-release-notes-action > span { color: var(--danger); font-size: 10.5px; line-height: 1.45; }
+.about-update-spinner { width: 11px; height: 11px; border: 1.5px solid color-mix(in srgb, currentColor 36%, transparent); border-top-color: currentColor; border-radius: 50%; animation: about-update-spin 650ms linear infinite; }
+@keyframes about-update-spin { to { transform: rotate(360deg); } }
 .general-section-body { min-width: 0; }
 .general-save-state { display: inline-flex; align-items: center; gap: 7px; color: var(--success); font-size: 10.5px; white-space: nowrap; }
 .general-save-state::before { width: 7px; height: 7px; border-radius: 50%; background: currentColor; content: ""; }
@@ -3673,7 +3718,7 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
 .skill-eyebrow { margin: 0; color: var(--brand-ink); font-size: 9px; font-weight: 750; letter-spacing: 0.13em; text-transform: uppercase; }
 .settings-page-note, .skill-section-count { flex: 0 0 auto; padding: 5px 8px; border: 1px solid var(--line); border-radius: 999px; color: var(--muted); background: var(--surface); font: 700 9px/1 ui-monospace, SFMono-Regular, Menlo, monospace; white-space: nowrap; }
 .settings-page-note { border-color: color-mix(in srgb, var(--brand) 32%, var(--line)); color: var(--brand-ink); background: var(--brand-soft); }
-.settings-content .settings-panel:is(.settings-panel-general, .settings-panel-appearance, .settings-panel-notifications, .settings-panel-skills, .settings-panel-mcp, .settings-panel-runtime, .settings-panel-monitoring, .settings-panel-diagnostics) {
+.settings-content .settings-panel:is(.settings-panel-general, .settings-panel-appearance, .settings-panel-notifications, .settings-panel-skills, .settings-panel-mcp, .settings-panel-runtime, .settings-panel-monitoring, .settings-panel-diagnostics, .settings-panel-about) {
   border-top: 0;
   background: var(--surface);
 }
@@ -3682,7 +3727,8 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
 .settings-panel-mcp > .mcp-settings,
 .settings-panel-runtime > *,
 .settings-panel-monitoring > .runtime-monitoring,
-.settings-panel-diagnostics > .diagnostics-center {
+.settings-panel-diagnostics > .diagnostics-center,
+.settings-panel-about > .about-updates-settings {
   width: min(1040px, 100%);
   max-width: 1040px;
 }
@@ -3692,6 +3738,7 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
 .settings-panel-runtime > .settings-page-heading,
 .settings-panel-monitoring > .runtime-monitoring > .settings-page-heading,
 .settings-panel-diagnostics > .diagnostics-center > .settings-page-heading,
+.settings-panel-about > .about-updates-settings > .settings-page-heading,
 .settings-panel:is(.settings-panel-appearance, .settings-panel-notifications) > .settings-page-heading {
   padding-bottom: 24px;
   border-bottom: 0;
@@ -3702,6 +3749,7 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
 .settings-panel-runtime > .settings-page-heading .settings-page-heading-copy,
 .settings-panel-monitoring > .runtime-monitoring > .settings-page-heading .settings-page-heading-copy,
 .settings-panel-diagnostics > .diagnostics-center > .settings-page-heading .settings-page-heading-copy,
+.settings-panel-about > .about-updates-settings > .settings-page-heading .settings-page-heading-copy,
 .settings-panel:is(.settings-panel-appearance, .settings-panel-notifications) > .settings-page-heading .settings-page-heading-copy {
   padding-left: 0;
 }
@@ -3711,6 +3759,7 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
 .settings-panel-runtime > .settings-page-heading .settings-page-heading-copy::before,
 .settings-panel-monitoring > .runtime-monitoring > .settings-page-heading .settings-page-heading-copy::before,
 .settings-panel-diagnostics > .diagnostics-center > .settings-page-heading .settings-page-heading-copy::before,
+.settings-panel-about > .about-updates-settings > .settings-page-heading .settings-page-heading-copy::before,
 .settings-panel:is(.settings-panel-appearance, .settings-panel-notifications) > .settings-page-heading .settings-page-heading-copy::before {
   content: none;
 }
@@ -3720,16 +3769,17 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
 .settings-panel-runtime > .settings-page-heading h1,
 .settings-panel-monitoring > .runtime-monitoring > .settings-page-heading h1,
 .settings-panel-diagnostics > .diagnostics-center > .settings-page-heading h1,
+.settings-panel-about > .about-updates-settings > .settings-page-heading h1,
 .settings-panel:is(.settings-panel-appearance, .settings-panel-notifications) > .settings-page-heading h1 {
   font-weight: 620;
 }
-.settings-panel:is(.settings-panel-general, .settings-panel-skills, .settings-panel-mcp, .settings-panel-runtime, .settings-panel-monitoring, .settings-panel-diagnostics) :is(.section-heading, .skill-section-heading) {
+.settings-panel:is(.settings-panel-general, .settings-panel-skills, .settings-panel-mcp, .settings-panel-runtime, .settings-panel-monitoring, .settings-panel-diagnostics, .settings-panel-about) :is(.section-heading, .skill-section-heading) {
   padding-left: 0;
 }
-.settings-panel:is(.settings-panel-general, .settings-panel-skills, .settings-panel-mcp, .settings-panel-runtime, .settings-panel-monitoring, .settings-panel-diagnostics) :is(.section-heading, .skill-section-heading)::before {
+.settings-panel:is(.settings-panel-general, .settings-panel-skills, .settings-panel-mcp, .settings-panel-runtime, .settings-panel-monitoring, .settings-panel-diagnostics, .settings-panel-about) :is(.section-heading, .skill-section-heading)::before {
   content: none;
 }
-.settings-panel:is(.settings-panel-general, .settings-panel-skills, .settings-panel-mcp, .settings-panel-runtime, .settings-panel-monitoring, .settings-panel-diagnostics) :is(.section-heading, .skill-section-heading) h2 {
+.settings-panel:is(.settings-panel-general, .settings-panel-skills, .settings-panel-mcp, .settings-panel-runtime, .settings-panel-monitoring, .settings-panel-diagnostics, .settings-panel-about) :is(.section-heading, .skill-section-heading) h2 {
   color: var(--ink);
   font-weight: 620;
 }
@@ -6223,6 +6273,13 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
   .settings-page-heading-aside { width: 100%; flex-wrap: wrap; }
   .general-settings-section { grid-template-columns: minmax(0, 1fr); gap: 13px; padding: 23px 0; }
   .general-settings-section .section-heading p { display: none; }
+  .about-updates-section { grid-template-columns: minmax(0, 1fr); gap: 13px; padding: 23px 0; }
+  .about-updates-section .section-heading p { display: none; }
+  .about-version-row,
+  .about-update-control { align-items: flex-start; flex-direction: column; gap: 13px; }
+  .about-version-value { justify-items: start; }
+  .about-update-control > button { width: fit-content; }
+  .about-release-notes-heading { flex-direction: column; gap: 7px; }
   .startup-location-options { grid-template-columns: minmax(0, 1fr); }
   .general-default-member-list { grid-template-columns: minmax(0, 1fr); }
   .general-default-lead { grid-template-columns: minmax(0, 1fr); gap: 8px; }

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1789,6 +1789,38 @@ export interface AppearanceApi {
   onChanged(listener: (snapshot: AppearanceSnapshot) => void): () => void
 }
 
+export type AppUpdateStatus =
+  | 'idle'
+  | 'up_to_date'
+  | 'update_available'
+  | 'no_release'
+  | 'check_failed'
+
+export type AppUpdateFailureReason =
+  | 'network'
+  | 'rate_limited'
+  | 'github_unavailable'
+  | 'invalid_release'
+
+export interface AppUpdateSnapshot {
+  currentVersion: string
+  status: AppUpdateStatus
+  latestVersion: string | null
+  releaseName: string | null
+  releaseNotesSummary: string | null
+  publishedAt: string | null
+  releasePageAvailable: boolean
+  checkedAt: string | null
+  failureReason: AppUpdateFailureReason | null
+  retryAt: string | null
+}
+
+export interface AppUpdatesApi {
+  get(): Promise<AppUpdateSnapshot>
+  check(): Promise<AppUpdateSnapshot>
+  openReleasePage(): Promise<boolean>
+}
+
 export type StartupLocationMode = 'last_location' | 'quick_chat'
 
 export type ExecutionConsolePlacement = 'bottom' | 'inspector'
@@ -1802,6 +1834,7 @@ export type SettingsSection =
   | 'notifications'
   | 'monitoring'
   | 'diagnostics'
+  | 'about'
 
 export type MemberWorkspaceLocationTab = 'identity' | 'runtime'
 
@@ -2542,6 +2575,7 @@ export interface RovaiApi {
     onOpenCamp(listener: (request: { campId: string }) => void): () => void
   }
   appearance: AppearanceApi
+  appUpdates: AppUpdatesApi
   desktopSession: DesktopSessionApi
   generalPreferences: GeneralPreferencesApi
   onboarding: OnboardingApi


### PR DESCRIPTION
Adds the About & Updates settings page with a manual public GitHub Releases check, semantic version comparison, bounded plain-text release notes, and a trusted release-page handoff. No auto-download, auto-install, restart, token, timer, or electron-updater.\n\nValidated with TypeScript checks, 522 Vitest tests, desktop production build, macOS package, documentation gates, and isolated Day/Night UI acceptance.