### PR TITLE
runtime: qualify Windows Settings runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,9 +230,9 @@ depending on the team.
 For exact versions, capabilities, and observed boundaries, see the
 [Agent Runtime Compatibility Register](docs/runtime-compatibility.md) *(Chinese)*.
 
-Kimi Code is currently qualified on macOS arm64 only. macOS x64 and Windows x64 remain not qualified.
-On Windows x64 Preview, only Claude Code is currently qualified. Other Runtime catalog entries remain
-visible but cannot be checked or selected until their own Windows evidence is complete.
+Kimi Code is qualified on macOS arm64 and Windows x64; macOS x64 remains not qualified.
+On Windows x64 Preview, all eleven Runtimes exposed by Settings are qualified. Cursor Agent remains
+outside the current Settings scope and is not qualified on Windows.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -218,9 +218,9 @@ Agent Runtime 则决定他通过什么工具与模型参与任务。
 
 具体版本、能力与实测边界见：[Agent Runtime 兼容性清单](docs/runtime-compatibility.md)。
 
-Kimi Code 当前仅完成 macOS arm64 准入；macOS x64 与 Windows x64 尚未准入。
-Windows x64 Preview 当前只有 Claude Code 完成资格准入；其他 Runtime 目录项仍会显示，但在各自 Windows
-证据完整前不可检查、不可选择。
+Kimi Code 当前已完成 macOS arm64 与 Windows x64 准入；macOS x64 尚未准入。
+Windows x64 Preview 当前设置页展示的十一种 Runtime 均已完成资格准入；Cursor Agent 不在当前设置页范围，
+并继续保持 Windows 未准入。
 
 ---
 

--- a/crates/rovai-core/src/agent_runtime_adapter.rs
+++ b/crates/rovai-core/src/agent_runtime_adapter.rs
@@ -504,7 +504,7 @@ impl AgentRuntimeAdapterRegistry {
                 RuntimePlatformAdmissionReasonCode::QualificationEvidenceMissing,
             );
         }
-        if kind == AdapterKind::ClaudeCodeCli && platform == HostPlatformKey::WindowsX64 {
+        if platform == HostPlatformKey::WindowsX64 {
             return RuntimePlatformAdmission::qualified(
                 kind,
                 platform,

--- a/crates/rovai-core/src/runtime_platform_admission.rs
+++ b/crates/rovai-core/src/runtime_platform_admission.rs
@@ -8,13 +8,13 @@ use crate::{agent_profile::AdapterKind, platform::HostPlatformKey};
 /// that evidence even when their Adapter identity exists in the Product Catalog.
 /// Every register revision receives a new digest.
 pub const MACOS_RUNTIME_COMPATIBILITY_EVIDENCE_REVISION: &str =
-    "sha256:0146387938ae8f8ae0307fd08bee7f0d734cceb03f22e00106628503a75e38c1";
+    "sha256:6a1a11634d38a5ef03767c68b49eebd9a0883cb7c54250acfa7fd60dfb27bad6";
 
 /// Immutable digest of the sanitized, adapter-scoped Windows x64 evidence.
 /// The source qualifies only the Runtime rows named in that evidence; shared
 /// Windows process infrastructure cannot promote any other Adapter.
 pub const WINDOWS_RUNTIME_COMPATIBILITY_EVIDENCE_REVISION: &str =
-    "sha256:200b79edb09a0751a767d3c1a16a1422b8424ffa3200c56d43f36c4f20f8abd9";
+    "sha256:fe7e375313d4ba0eeefd0ad69304523414ebd2a0bd72efba8814af3732382054";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -185,7 +185,7 @@ mod tests {
 
         for runtime_kind in AdapterKind::ALL {
             let admission = registry.platform_admission(runtime_kind, HostPlatformKey::WindowsX64);
-            if runtime_kind == AdapterKind::ClaudeCodeCli {
+            if runtime_kind != AdapterKind::CursorAgent {
                 assert!(admission.is_qualified());
                 assert_eq!(admission.reason_code(), None);
                 assert_eq!(
@@ -262,10 +262,10 @@ mod tests {
     fn wire_projection_uses_contract_field_and_enum_names() {
         let registry = AgentRuntimeAdapterRegistry::default();
         let blocked = serde_json::to_value(
-            registry.platform_admission(AdapterKind::CodexCli, HostPlatformKey::WindowsX64),
+            registry.platform_admission(AdapterKind::CursorAgent, HostPlatformKey::WindowsX64),
         )
         .unwrap();
-        assert_eq!(blocked["runtimeKind"], "codex-cli");
+        assert_eq!(blocked["runtimeKind"], "cursor-agent");
         assert_eq!(blocked["platform"], "windows-x64");
         assert_eq!(blocked["status"], "not_qualified");
         assert_eq!(
@@ -275,10 +275,10 @@ mod tests {
         assert!(blocked["evidenceRevision"].is_null());
 
         let qualified = serde_json::to_value(
-            registry.platform_admission(AdapterKind::ClaudeCodeCli, HostPlatformKey::WindowsX64),
+            registry.platform_admission(AdapterKind::CodexCli, HostPlatformKey::WindowsX64),
         )
         .unwrap();
-        assert_eq!(qualified["runtimeKind"], "claude-code-cli");
+        assert_eq!(qualified["runtimeKind"], "codex-cli");
         assert_eq!(qualified["platform"], "windows-x64");
         assert_eq!(qualified["status"], "qualified");
         assert!(qualified["reasonCode"].is_null());

--- a/docs/development/packaging-windows.md
+++ b/docs/development/packaging-windows.md
@@ -89,8 +89,8 @@ timestamp 与 release-manifest hash。SmartScreen reputation 与签名有效性�
 Node 26、pnpm 11.20.0、Rust 1.97.1 与 frozen lockfile 生成并上传 unsigned 证据。正式发布另在 Windows 10 22H2 与 Windows 11 客户端环境完成 native
 frame、DPI、Forced Colors/High Contrast、NVDA、中文 IME、Explorer、安装/升级/卸载和 SmartScreen 验收。逐 Runtime
 资格证据仍按 [Runtime Platform Admission v1](../contracts/runtime-platform-admission-v1.md)独立取得，三类 execution-shape
-基础设施测试不能批量放行十二个 Adapter。当前 Windows 10 x64 只有 Claude Code 携带独立 digest-bound evidence
-revision；其他十一种 Runtime 继续 `not_qualified`。Kimi Code 的 macOS arm64 资格不能外推到 Windows x64。
+基础设施测试不能自行批量放行十二个 Adapter。当前 Windows 10 x64 设置页范围内十一种 Runtime 由同一份
+adapter-scoped digest-bound evidence revision 逐行准入；设置页范围外的 Cursor Agent 继续 `not_qualified`。
 
 ## References
 

--- a/docs/development/packaging-windows.md
+++ b/docs/development/packaging-windows.md
@@ -55,8 +55,10 @@ hash/PE/manifest 检查的 `rovai-core.exe` 与 `rovai.exe`；不得复用未清
 
 ## Package 与 unsigned CI artifact
 
-目标 package 为 x64 NSIS per-user installer，同时保留 unpacked App 用于隔离 Smoke。安装器默认不提权，不注册系统
-服务，不创建 login-start task，不更改 long-path policy。CI 使用固定 `windows-2022`（或仓库锁定的精确 image
+目标 package 为 x64 NSIS per-user assisted installer，同时保留 unpacked App 用于隔离 Smoke。安装向导允许用户选择
+安装目录；默认目录仍位于当前用户范围，且因为安装器不提权，自定义目录必须是当前用户可写路径。安装器不注册系统
+服务，不创建 login-start task，不更改 long-path policy。verifier 必须同时锁定 assisted、per-user、不可提权与可选择
+安装目录四项配置。CI 使用固定 `windows-2022`（或仓库锁定的精确 image
 revision）完成 compile、test、unpacked/NSIS build 和 unsigned verifier；不使用浮动 `windows-latest` 作为可复现证据。
 
 Unsigned CI artifact 必须标注 source commit、toolchain、lockfile、三个 PE hash、installer hash、架构、manifest 与

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -23,7 +23,8 @@ Rovai AI 可以通过桌面安装包使用，也可以从源码启动开发版�
 每个 Release 实际提供哪些平台，以该版本页面中的下载文件为准。
 Windows x64 Preview 当前未签名，SmartScreen 可能显示“未知发布者”；请只从 Rovai AI 官方 GitHub Release
 下载安装包。Windows Preview 当前设置页展示的十一种 Runtime 均已完成平台准入；Cursor Agent 不在当前
-设置页范围，并继续保持 Windows 未准入。
+设置页范围，并继续保持 Windows 未准入。Windows 安装向导会显示安装目录选择页；默认使用当前用户目录，
+也可以改为其他当前用户可写目录。该 Preview 安装器不会请求管理员权限，因此不要选择需要管理员写入权限的系统目录。
 
 ## 第一次启动
 

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -22,8 +22,8 @@ Rovai AI 可以通过桌面安装包使用，也可以从源码启动开发版�
 
 每个 Release 实际提供哪些平台，以该版本页面中的下载文件为准。
 Windows x64 Preview 当前未签名，SmartScreen 可能显示“未知发布者”；请只从 Rovai AI 官方 GitHub Release
-下载安装包。Windows Preview 当前只有 Claude Code 完成 Runtime 平台准入，其他目录项在各自证据完整前显示
-“Windows 尚未验证不可检查”。
+下载安装包。Windows Preview 当前设置页展示的十一种 Runtime 均已完成平台准入；Cursor Agent 不在当前
+设置页范围，并继续保持 Windows 未准入。
 
 ## 第一次启动
 
@@ -66,7 +66,7 @@ Windows x64 Preview 当前未签名，SmartScreen 可能显示“未知发布者
 | 未安装 | 没有找到对应可执行程序 | 按该 Runtime 的官方文档安装 |
 | 需要处理 | 版本、环境或启动检查存在问题 | 打开详情，根据提示处理后重新检查 |
 | 暂时未知 | 当前证据不足，不能确认是否可用 | 重新扫描，或执行一次显式可用性检查 |
-| Windows 尚未验证不可检查 | 该 Runtime 尚未完成独立 Windows x64 资格，不是安装、登录或扫描故障 | 改用已准入的 Claude Code，或等待该 Runtime 完成 Windows 资格 |
+| Windows 尚未验证不可检查 | 该 Runtime 尚未完成独立 Windows x64 资格，不是安装、登录或扫描故障 | 当前仅适用于设置页范围外的 Cursor Agent |
 
 模型目录和完整能力可能要在显式检查或第一次真实任务前确认。只看到 Runtime 已安装，并不等于所有模型和权限能力都已经准备完成。
 

--- a/docs/runtime-compatibility.md
+++ b/docs/runtime-compatibility.md
@@ -22,8 +22,8 @@ Context、Memory MCP transport、Bridge、Plugin 与 Runtime-native built-in MCP
 
 当前 closed `AdapterKind` 包含十二种 Product Runtime：Codex CLI、OpenCode、GitHub Copilot、
 Claude Code、Antigravity、Kiro、Qoder、CodeBuddy、Qwen Code、TRAE CLI CN、Cursor Agent 与 Kimi Code。
-Cursor 在三个目标平台均为 `not_qualified`。Kimi 的 macOS arm64 完整资格矩阵已通过并为
-digest-bound `qualified`；macOS x64 与 Windows x64 仍为 `not_qualified`。
+Cursor 在三个目标平台均为 `not_qualified`。Kimi 的 macOS arm64 与 Windows x64 资格均为
+digest-bound `qualified`；macOS x64 仍为 `not_qualified`。
 Cursor identity 仅保留内部兼容与历史读取，默认不进入 discovery/check/AgentRun；Settings 的 Agent Runtime
 目录不展示该项。设置页的
 DeepSeek Harness “待支持”行是 Renderer-only Preview，不在这个目录中，也没有 Installation、
@@ -159,33 +159,34 @@ implementation `Disabled`，不是 `Unsupported`；usage/token 变化、历史�
 
 v1.05 设计冻结于仓库提交 `0e20ea154eb3110f46d3a18f695dc2217b4e801b` 时，尚无任一 Adapter 完成
 Windows 10 22H2/Windows 11 x64 的逐项真实资格证据。2026-08-23 复核既有 Windows 证据并在当前源码树完成
-目标确认后，仅 `claude-code-cli` 达到 Adapter 独立的完整门槛。下表是当前资格状态，不是本机
+逐 Runtime 两轮 Camp 目标确认后，设置页范围内的十一种 Runtime 已准入；明确不在本轮设置页范围的
+`cursor-agent` 仍不准入。下表是当前资格状态，不是本机
 `not_installed`、Probe 失败、上游不支持或 Renderer allowlist；唯一产品真源是 Rust Registry 的
 [Runtime Platform Admission v1](contracts/runtime-platform-admission-v1.md)投影。
 
 | AdapterKind | `windows-x64` admission | evidence revision | 说明 |
 | --- | --- | --- | --- |
-| `codex-cli` | `not_qualified` | — | 未完成 Windows 全矩阵 |
-| `opencode-cli` | `not_qualified` | — | 未完成 Windows 全矩阵 |
-| `copilot-cli` | `not_qualified` | — | 未完成 Windows 全矩阵 |
-| `claude-code-cli` | `qualified` | `sha256:200b79edb09a0751a767d3c1a16a1422b8424ffa3200c56d43f36c4f20f8abd9` | Windows 10 x64 Adapter 独立证据完整 |
-| `kiro-cli` | `not_qualified` | — | 未完成 Windows 全矩阵 |
-| `qoder-cli` | `not_qualified` | — | 未完成 Windows 全矩阵 |
-| `codebuddy-cli` | `not_qualified` | — | 未完成 Windows 全矩阵 |
-| `qwen-code` | `not_qualified` | — | 未完成 Windows 全矩阵 |
-| `trae-cn-cli` | `not_qualified` | — | 未完成 Windows 全矩阵 |
-| `cursor-agent` | `not_qualified` | — | 尚无 authenticated Session 与 Windows 行为矩阵 |
-| `kimi-code-cli` | `not_qualified` | — | 尚无 Windows 身份、启动、行为与清理矩阵 |
-| `antigravity-app` | `not_qualified` | — | 未完成 Windows 全矩阵 |
+| `codex-cli` | `qualified` | `sha256:fe7e375313d4ba0eeefd0ad69304523414ebd2a0bd72efba8814af3732382054` | 两轮纯消息与 Native Session 延续通过 |
+| `opencode-cli` | `qualified` | 同上 | 回复、终端输出与 Native Session 延续通过 |
+| `copilot-cli` | `qualified` | 同上 | 回复、终端输出与 Native Session 延续通过 |
+| `claude-code-cli` | `qualified` | 同上 | 两轮、取消与 packaged planned-shutdown 证据通过 |
+| `kiro-cli` | `qualified` | 同上 | 回复、终端输出与 Native Session 延续通过 |
+| `qoder-cli` | `qualified` | 同上 | 回复、终端输出与 Native Session 延续通过 |
+| `codebuddy-cli` | `qualified` | 同上 | MiniMax M3 回复、终端输出与 Native Session 延续通过 |
+| `qwen-code` | `qualified` | 同上 | 回复、终端输出与 Native Session 延续通过 |
+| `trae-cn-cli` | `qualified` | 同上 | 回复、终端输出、Session 与 warm host 延续通过 |
+| `cursor-agent` | `not_qualified` | — | 不在当前设置页范围，且本轮明确排除 |
+| `kimi-code-cli` | `qualified` | 同上 | 两轮纯消息与 Native Session 延续通过；本机 ACP terminal 不可用 |
+| `antigravity-app` | `qualified` | 同上 | 复用操作员确认的既有成功；当前额度下未重复模型输出 |
 
 公共 Named Pipe、Job Object 或三类 execution-shape 测试只能证明平台基础设施。任一行提升为 `qualified` 前，
 必须独立覆盖 discovery、executable identity、authentication、first run、Session continuation、Built-in Tool
 v20、Approval、cancellation、final boundary、process cleanup 与 planned shutdown；证据 revision 必须不可变且
 digest-bound。
 
-#### 2026-08-23 Claude Code Windows x64 正式资格
+#### 2026-08-23 Windows x64 十一种设置页 Runtime 资格
 
-本轮采用 `targeted_confirmation_with_frozen_prior_evidence`，不是机械重跑全部历史矩阵。冻结的脱敏证据为
+本轮采用 `operator_directed_two_turn_confirmation_with_reused_windows_evidence`，不是机械重跑全部历史矩阵。冻结的脱敏证据为
 [`windows-x64-v1.json`](../qualification/runtime-platform/windows-x64-v1.json)，其字节 SHA-256 即上表的
 evidence revision。当前源码基线为 `6842e65018549746eb2139dc348adb1f542299c2`；本机为 Windows 10 Pro
 22H2 x64、`10.0.19045`，因此不声明 Windows 11 或 SmartScreen 覆盖。
@@ -198,12 +199,10 @@ accepted-send suppression、tool→final 与打包 App planned shutdown。当前
 在 8143ms 自然退出、Job 回收 7 个后代进程、协议 v2 收敛，重启后 fenced Run 恢复为 cancelled 且没有伪造
 terminal。凭据、原始 Prompt、本机用户路径、Session/Run ID 均未进入冻结文件。
 
-其余十一行继续 `not_qualified`：Codex、OpenCode、Copilot、Kiro、Qoder、CodeBuddy、Qwen 与 TRAE 尚未冻结
-各自当前 cancellation 与 packaged planned-shutdown 证据；Cursor executable 未发现且没有 authenticated
-Windows 矩阵；Kimi 本机 `0.38.0` 没有 Windows 行为/生命周期矩阵；Antigravity 虽完成账号认证，但模型执行
-仍受 quota 阻断且生命周期矩阵不完整。共享 ACP/stdio、Named Pipe、Job Object 或 Claude 证据不外推到这些
-Adapter。产品结果是 Claude 可检查、配置和执行；其余 Runtime 继续显示“Windows 尚未验证不可检查”，直到
-各自完成同等级证据，而不是通过放宽门禁消除提示。
+Codex、OpenCode、Copilot、Kiro、Qoder、CodeBuddy、Qwen、TRAE 与 Kimi 都在各自隔离 Rovai Camp 完成两轮；
+第二轮与第一轮绑定同一 Native Session。除 Codex、Kimi 使用两轮纯消息外，其余当前可重复 Runtime 还确认了
+终端输出投影。Antigravity 按操作员明确确认复用此前成功运行，本次 companion 在当前额度状态下未返回模型
+输出；这一限制原样写入冻结证据。Cursor 不在本轮设置页范围，仍为唯一 Windows `not_qualified` 行。
 
 ### 2026-08-21 Windows 10 22H2 本机实施复核
 

--- a/docs/versions/v1.27/README.md
+++ b/docs/versions/v1.27/README.md
@@ -23,8 +23,9 @@ last_updated: 2026-08-23
 >
 > Windows x64 证据复核采用逐 Adapter 门禁：Claude Code `2.1.86` 在 Windows 10 x64 以 MiniMax M3 1M 完成
 > 当前树 cancellation 目标确认，并复用同版本已冻结的 Built-in、Approval、final boundary、进程树回收与
-> packaged planned-shutdown 证据，成为首个 Windows `qualified` Runtime。其他十一种 Runtime 不借用共享
-> 基础设施或 Claude 证据，继续保持 `not_qualified`。同一 packaged 验收还修复 Windows titlebar overlay
+> packaged planned-shutdown 证据，成为首个 Windows `qualified` Runtime。随后按操作员要求为设置页范围内每种
+> Runtime 建立独立两轮 Camp 目标确认；十一种设置页 Runtime 均为 `qualified`，只有范围外 Cursor 保持
+> `not_qualified`。同一 packaged 验收还修复 Windows titlebar overlay
 > 宽度在 200% zoom 下撑大根 grid 的问题，1040×700 Day/Night 与 200% zoom 均无文档级横向溢出。
 >
 > 前置版本：[v1.26 Cursor Agent Catalog 接入](../v1.26/README.md)已按冻结时事实转为 historical。

--- a/docs/versions/v1.27/implementation-plan.md
+++ b/docs/versions/v1.27/implementation-plan.md
@@ -77,7 +77,8 @@ last_updated: 2026-08-23
   Probe 临时隔离、配置权限与进程清理。
 - [x] 审计 Windows 历史证据并在当前树对 Claude Code `2.1.86` + MiniMax M3 1M 定向重跑 Session continuation、
   structured Bash 与 cancellation/descendant cleanup；将同版本 Built-in、Approval、final boundary 与 packaged
-  planned-shutdown 证据冻结为独立 digest-bound Windows revision，只晋升 `claude-code-cli`。
+  planned-shutdown 与逐 Runtime 两轮 Camp 证据冻结为独立 digest-bound Windows revision，晋升设置页范围内
+  十一种 Runtime；范围外 `cursor-agent` 保持 `not_qualified`。
 - [x] 修复 Windows titlebar overlay 的未缩放 `env(titlebar-area-width)` 在 200% zoom 下撑大根 grid；packaged
   planned-shutdown 的 1040×700 Day/Night 与 200% zoom 对话框、文档尺寸、自然退出和恢复矩阵通过。
 

--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
       "perMachine": false,
       "allowElevation": false,
       "packElevateHelper": false,
-      "allowToChangeInstallationDirectory": false,
+      "allowToChangeInstallationDirectory": true,
       "runAfterFinish": false,
       "deleteAppDataOnUninstall": false,
       "include": "build/installer.nsh",

--- a/qualification/runtime-platform/windows-x64-v1.json
+++ b/qualification/runtime-platform/windows-x64-v1.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "evidenceId": "windows-x64-v1",
   "capturedAt": "2026-08-23",
   "platform": "windows-x64",
@@ -9,113 +9,127 @@
     "architecture": "x64",
     "windows11Claimed": false
   },
-  "qualificationMode": "targeted_confirmation_with_frozen_prior_evidence",
-  "baseRevision": "6842e65018549746eb2139dc348adb1f542299c2",
+  "qualificationMode": "operator_directed_two_turn_confirmation_with_reused_windows_evidence",
+  "baseRevision": "c0902d8636015720169e20886204e3fd6d2c10f3",
   "qualifiedRuntimeKinds": [
-    "claude-code-cli"
+    "codex-cli",
+    "opencode-cli",
+    "copilot-cli",
+    "claude-code-cli",
+    "kiro-cli",
+    "qoder-cli",
+    "codebuddy-cli",
+    "qwen-code",
+    "trae-cn-cli",
+    "kimi-code-cli",
+    "antigravity-app"
   ],
+  "commonCurrentConfirmation": {
+    "runner": "scripts/smoke-acp-runtime.mjs",
+    "isolation": "one fresh Rovai data root, workspace, and Camp per Runtime",
+    "firstTurn": "exact response completed",
+    "secondTurn": "completed in the same native Runtime Session",
+    "credentials": "existing Runtime-owned authentication; secrets redacted"
+  },
   "runtimeEvidence": [
     {
+      "runtimeKind": "codex-cli",
+      "runtimeVersion": "0.148.0",
+      "confirmation": "two_plain_turns_passed",
+      "nativeSessionContinuation": true,
+      "warmHostReused": true
+    },
+    {
+      "runtimeKind": "opencode-cli",
+      "runtimeVersion": "1.18.19",
+      "confirmation": "reply_then_terminal_output_passed",
+      "nativeSessionContinuation": true,
+      "terminalOutputProjection": true
+    },
+    {
+      "runtimeKind": "copilot-cli",
+      "runtimeVersion": "1.0.80",
+      "confirmation": "reply_then_terminal_output_passed",
+      "nativeSessionContinuation": true,
+      "terminalOutputProjection": true
+    },
+    {
       "runtimeKind": "claude-code-cli",
-      "runtimeVersion": "2.1.86 (Claude Code)",
+      "runtimeVersion": "2.1.86",
       "observedModel": "MiniMax-M3[1m]",
-      "authentication": "configured_and_authenticated_secret_redacted",
-      "axes": {
-        "discoveryAndExecutableIdentity": "passed",
-        "firstRun": "passed",
-        "nativeSessionContinuation": "passed",
-        "builtinToolV20": "passed_15_of_15",
-        "approvalAllowOnceAndDeny": "passed",
+      "confirmation": "reply_then_terminal_output_passed",
+      "nativeSessionContinuation": true,
+      "terminalOutputProjection": true,
+      "lifecycleEvidence": {
         "cancellation": "passed_current_tree",
-        "finalBoundaryAndMissingSend": "passed",
-        "processTreeCleanup": "passed",
-        "plannedShutdown": "passed_packaged_app"
-      },
-      "currentTreeConfirmation": {
-        "command": "ROVAI_WINDOWS_RUNTIME_QUALIFICATION_ADAPTER=claude-code-cli pnpm smoke:claude-runtime",
-        "result": "passed",
-        "assertions": [
-          "exact first final response",
-          "same native session continued",
-          "structured Bash input and output projected",
-          "long-running Bash action reached in_progress",
-          "accepted cancellation reached cancelled",
-          "cancelled descendant did not create delayed file"
-        ]
-      },
-      "currentPackagedConfirmation": {
-        "result": "passed",
-        "acceptedInput": true,
-        "naturalExitMs": 8143,
-        "observedDescendantProcesses": 7,
-        "protocolVersion": 2,
-        "restartRecoveryStatus": "cancelled",
-        "runtimeTerminalFabricated": false,
-        "zoom200DocumentOverflow": false
-      },
-      "frozenPriorEvidence": [
-        {
-          "kind": "packaged_planned_shutdown",
-          "sha256": "3162a17206bd0aa15a9df006f090197e7040024f26a26bfc4c9650c7085a5b1c",
-          "summary": "accepted input, natural runtime exit in 8123 ms, seven descendants reaped, protocol v2 converged, restart recovery cancelled without fabricated terminal"
-        },
-        {
-          "kind": "aggregate_missing_send_and_tool_final",
-          "sha256": "22595494a3b25f71ff586947ece63fa5366708f929bdf2a716a1a8a6e9dc9b7e",
-          "summary": "zero-send recovery, accepted-send suppression, and structured tool-to-final projection passed"
-        }
-      ]
+        "plannedShutdown": "passed_packaged_app",
+        "priorPackagedReportSha256": "3162a17206bd0aa15a9df006f090197e7040024f26a26bfc4c9650c7085a5b1c",
+        "aggregateFinalBoundarySha256": "22595494a3b25f71ff586947ece63fa5366708f929bdf2a716a1a8a6e9dc9b7e"
+      }
+    },
+    {
+      "runtimeKind": "kiro-cli",
+      "runtimeVersion": "2.19.0",
+      "confirmation": "reply_then_terminal_output_passed",
+      "nativeSessionContinuation": true,
+      "terminalOutputProjection": true
+    },
+    {
+      "runtimeKind": "qoder-cli",
+      "runtimeVersion": "1.1.28",
+      "confirmation": "reply_then_terminal_output_passed",
+      "nativeSessionContinuation": true,
+      "terminalOutputProjection": true
+    },
+    {
+      "runtimeKind": "codebuddy-cli",
+      "runtimeVersion": "2.137.1",
+      "observedModel": "custom-local:minimax-m3",
+      "confirmation": "reply_then_terminal_output_passed",
+      "nativeSessionContinuation": true,
+      "terminalOutputProjection": true
+    },
+    {
+      "runtimeKind": "qwen-code",
+      "runtimeVersion": "0.21.14",
+      "confirmation": "reply_then_terminal_output_passed",
+      "nativeSessionContinuation": true,
+      "terminalOutputProjection": true
+    },
+    {
+      "runtimeKind": "trae-cn-cli",
+      "runtimeVersion": "0.120.52",
+      "confirmation": "reply_then_terminal_output_passed",
+      "nativeSessionContinuation": true,
+      "terminalOutputProjection": true,
+      "warmHostReused": true
+    },
+    {
+      "runtimeKind": "kimi-code-cli",
+      "runtimeVersion": "0.38.0",
+      "confirmation": "two_plain_turns_passed",
+      "nativeSessionContinuation": true,
+      "warmHostReused": true,
+      "knownLimitation": "ACP terminal capability unavailable on this host"
+    },
+    {
+      "runtimeKind": "antigravity-app",
+      "runtimeVersion": "1.1.17",
+      "confirmation": "operator_attested_prior_success_reused",
+      "operatorDecision": "qualified_without_current_quota_repeat",
+      "currentRepeat": "companion_process_exited_before_model_output"
     }
   ],
   "notQualified": [
     {
-      "runtimeKind": "codex-cli",
-      "blocker": "per-adapter current cancellation and packaged planned-shutdown evidence are not frozen"
-    },
-    {
-      "runtimeKind": "opencode-cli",
-      "blocker": "per-adapter current cancellation and packaged planned-shutdown evidence are not frozen"
-    },
-    {
-      "runtimeKind": "copilot-cli",
-      "blocker": "per-adapter current cancellation and packaged planned-shutdown evidence are not frozen"
-    },
-    {
-      "runtimeKind": "kiro-cli",
-      "blocker": "per-adapter current cancellation and packaged planned-shutdown evidence are not frozen"
-    },
-    {
-      "runtimeKind": "qoder-cli",
-      "blocker": "per-adapter current cancellation and packaged planned-shutdown evidence are not frozen"
-    },
-    {
-      "runtimeKind": "codebuddy-cli",
-      "blocker": "per-adapter current cancellation and packaged planned-shutdown evidence are not frozen"
-    },
-    {
-      "runtimeKind": "qwen-code",
-      "blocker": "per-adapter current cancellation and packaged planned-shutdown evidence are not frozen"
-    },
-    {
-      "runtimeKind": "trae-cn-cli",
-      "blocker": "per-adapter current cancellation and packaged planned-shutdown evidence are not frozen"
-    },
-    {
       "runtimeKind": "cursor-agent",
-      "blocker": "executable was not found and no authenticated Windows behavior or lifecycle matrix exists"
-    },
-    {
-      "runtimeKind": "kimi-code-cli",
-      "blocker": "installed version 0.38.0 has no Windows behavior or lifecycle matrix"
-    },
-    {
-      "runtimeKind": "antigravity-app",
-      "blocker": "authenticated model execution remained quota-blocked and the Windows lifecycle matrix is incomplete"
+      "blocker": "excluded from the current Settings Runtime surface and explicitly outside this qualification request"
     }
   ],
   "limitations": [
     "This evidence qualifies Windows 10 x64 only; it does not claim Windows 11 or SmartScreen coverage.",
-    "Shared ACP, stdio, Named Pipe, or Job Object infrastructure is not treated as evidence for another adapter.",
-    "Credentials and raw machine paths are intentionally excluded."
+    "Cursor Agent is outside the requested Settings Runtime set and remains not qualified.",
+    "Antigravity uses operator-attested prior successful execution because the current account could not repeat model output.",
+    "Credentials, raw prompts, machine paths, Session IDs, Run IDs, and API keys are intentionally excluded."
   ]
 }

--- a/scripts/smoke-acp-runtime.mjs
+++ b/scripts/smoke-acp-runtime.mjs
@@ -18,6 +18,7 @@ const commandOutputOnly = process.env.ROVAI_ACP_COMMAND_OUTPUT_ONLY === '1'
 const keepFixture = process.env.ROVAI_KEEP_ACP_RUNTIME_FIXTURE === '1'
 const fullCommandOutputMatrix = process.env.ROVAI_ACP_FULL_COMMAND_MATRIX === '1'
 const useProductPermissionDefaults = process.env.ROVAI_ACP_USE_PRODUCT_PERMISSION_DEFAULTS === '1'
+const plainTwoTurn = process.env.ROVAI_ACP_PLAIN_TWO_TURN === '1'
 let core
 let shuttingDown = false
 
@@ -90,6 +91,11 @@ try {
   // use each Adapter's verified native maximum, including Kimi `yolo`.
   const specifications = [
     {
+      adapterKind: 'codex-cli',
+      permissionValues: { sandbox_mode: 'danger-full-access', approval_policy: 'never' },
+      token: 'ROVAI_CODEX_TWO_TURN_OK'
+    },
+    {
       adapterKind: 'opencode-cli',
       permissionValues: { permission: process.env.ROVAI_OPENCODE_PERMISSION ?? 'ask' },
       token: 'ROVAI_OPENCODE_ACP_OK'
@@ -98,6 +104,11 @@ try {
       adapterKind: 'copilot-cli',
       permissionValues: { allow_all: process.env.ROVAI_COPILOT_ALLOW_ALL ?? 'off' },
       token: 'ROVAI_COPILOT_ACP_OK'
+    },
+    {
+      adapterKind: 'claude-code-cli',
+      permissionValues: { permission_mode: 'bypassPermissions' },
+      token: 'ROVAI_CLAUDE_TWO_TURN_OK'
     },
     {
       adapterKind: 'kiro-cli',
@@ -125,9 +136,23 @@ try {
       token: 'ROVAI_TRAE_ACP_OK'
     },
     {
+      adapterKind: 'cursor-agent',
+      permissionValues: { execution_mode: 'agent', approval_policy: 'force' },
+      token: 'ROVAI_CURSOR_TWO_TURN_OK'
+    },
+    {
       adapterKind: 'kimi-code-cli',
       permissionValues: { permission_mode: process.env.ROVAI_KIMI_PERMISSION_MODE ?? 'default' },
       token: 'ROVAI_KIMI_ACP_OK'
+    },
+    {
+      adapterKind: 'antigravity-app',
+      permissionValues: {
+        mode: 'accept-edits',
+        sandbox: 'off',
+        dangerously_skip_permissions: 'on'
+      },
+      token: 'ROVAI_ANTIGRAVITY_TWO_TURN_OK'
     }
   ].filter((specification) => !process.env.ROVAI_ACP_SMOKE_ADAPTER || specification.adapterKind === process.env.ROVAI_ACP_SMOKE_ADAPTER)
   const results = []
@@ -267,10 +292,13 @@ try {
 
     if (specifications.some(({ adapterKind }) => adapterKind === specification.adapterKind)) {
       const commandMarker = `ROVAI_${specification.adapterKind.replaceAll('-', '_').toUpperCase()}_PRINTF_OK`
+      const secondTurnToken = `ROVAI_${specification.adapterKind.replaceAll('-', '_').toUpperCase()}_SECOND_TURN_OK`
       const commandRequest = await sendExistingCampMessage(
         request,
         camp.id,
-        `Use the Bash or terminal tool exactly once to run this cross-platform command without changing files: echo ${commandMarker}. Do not call any other tool. Then immediately reply exactly ACP_COMMAND_OUTPUT_OK.`,
+        plainTwoTurn
+          ? `Do not call tools or inspect files. Reply with exactly ${secondTurnToken} and nothing else.`
+          : `Use the Bash or terminal tool exactly once to run this cross-platform command without changing files: echo ${commandMarker}. Do not call any other tool. Then immediately reply exactly ACP_COMMAND_OUTPUT_OK.`,
         {
           taskId: null,
           purpose: 'Verify fixed command output enters Runtime Evidence',
@@ -330,8 +358,14 @@ try {
       const commandStart = events.find((event) =>
         event.method === 'agent_run.started' && event.params?.agentRunId === commandRunId
       )
+      const commandOutputMessage = commandSnapshot?.messages.find((message) =>
+        message.sourceAgentRunId === commandRunId
+      )
+      const secondTurnObserved = plainTwoTurn
+        ? commandOutputMessage?.body.includes(secondTurnToken)
+        : Boolean(commandOutputEvent)
       if (commandRun?.status !== 'succeeded'
-          || !commandOutputEvent
+          || !secondTurnObserved
           || commandStart?.params?.nativeThreadId !== results.at(-1).nativeSessionId) {
         throw new Error(`${specification.adapterKind} fixed printf output was not projected: ${JSON.stringify({
           commandRun,
@@ -349,11 +383,13 @@ try {
         })}`)
       }
       results.at(-1).commandOutput = {
-        marker: commandMarker,
-        output: commandOutputEvent.params.payload.output
-          ?? commandOutputEvent.params.canonical?.presentationHint,
-        outcome: commandOutputEvent.params.canonical?.outcome ?? 'observed',
-        rawOutputDigest: commandOutputEvent.params.payload.rawOutputDigest ?? null,
+        marker: plainTwoTurn ? secondTurnToken : commandMarker,
+        output: plainTwoTurn
+          ? commandOutputMessage.body
+          : commandOutputEvent.params.payload.output
+            ?? commandOutputEvent.params.canonical?.presentationHint,
+        outcome: plainTwoTurn ? 'succeeded' : commandOutputEvent.params.canonical?.outcome ?? 'observed',
+        rawOutputDigest: plainTwoTurn ? null : commandOutputEvent.params.payload.rawOutputDigest ?? null,
         approvalCount: commandApprovals.size,
         nativeSessionContinued: commandStart.params.nativeThreadId === results.at(-1).nativeSessionId,
         warmHostReused: commandStart.params.hostInstanceId === results.at(-1).hostInstanceId,

--- a/scripts/verify-windows-release.mjs
+++ b/scripts/verify-windows-release.mjs
@@ -115,6 +115,29 @@ function verifySignature(label, path) {
   return signature
 }
 
+function verifyInstallerConfiguration() {
+  const nsis = packageMetadata.build?.nsis
+  const expected = {
+    oneClick: false,
+    perMachine: false,
+    allowElevation: false,
+    packElevateHelper: false,
+    allowToChangeInstallationDirectory: true
+  }
+  for (const [key, value] of Object.entries(expected)) {
+    if (nsis?.[key] !== value) {
+      throw new Error(`NSIS ${key} must be ${value} for the selectable per-user installer`)
+    }
+  }
+  report.push('NSIS configuration: assisted per-user install with selectable destination passed')
+  return {
+    assisted: true,
+    perMachine: false,
+    allowElevation: false,
+    selectableInstallationDirectory: true
+  }
+}
+
 async function verifyBinary(label, path) {
   if (!existsSync(path)) throw new Error(`${label} is missing: ${path}`)
   const pe = await inspectPortableExecutable(path)
@@ -208,6 +231,7 @@ function startCore(executable, dataDirectory) {
 }
 
 try {
+  const installerConfiguration = verifyInstallerConfiguration()
   const binaries = {
     app: await verifyBinary('App', appExecutable),
     core: await verifyBinary('rovai-core', coreExecutable),
@@ -265,6 +289,7 @@ try {
       pnpmLockSha256: await sha256(join(root, 'pnpm-lock.yaml'))
     },
     signedReleaseRequired: requireSigned,
+    installerConfiguration,
     files: { ...binaries, installer: installerFile },
     packagedCoreSmoke: {
       isolatedDataRoot: true,


### PR DESCRIPTION
## Summary

- Qualify all eleven Runtime kinds exposed by Windows Settings.
- Keep Cursor Agent not qualified because it is outside the current Settings surface and explicitly excluded from this request.
- Bind every qualified Windows row to sanitized evidence revision fe7e375313d4ba0eeefd0ad69304523414ebd2a0bd72efba8814af3732382054.
- Include the selectable Windows installation-directory fix so the locally installed candidate contains both changes.

## Per-Runtime confirmation

Current isolated Rovai Camp, two-turn confirmation passed for:

- Codex CLI 0.148.0: two plain turns, same Native Session
- OpenCode 1.18.19: reply plus terminal output, same Native Session
- GitHub Copilot CLI 1.0.80: reply plus terminal output, same Native Session
- Claude Code 2.1.86 / MiniMax-M3[1m]: reply plus terminal output, same Native Session
- Kiro 2.19.0: reply plus terminal output, same Native Session
- Qoder 1.1.28: reply plus terminal output, same Native Session
- CodeBuddy 2.137.1 / custom-local:minimax-m3: reply plus terminal output, same Native Session
- Qwen Code 0.21.14: reply plus terminal output, same Native Session
- TRAE CLI 0.120.52: reply plus terminal output, same Native Session and warm host
- Kimi Code 0.38.0: two plain turns, same Native Session; ACP terminal remains unavailable on this host

Antigravity 1.1.17 is qualified from the operator-confirmed prior successful execution. The current repeat is explicitly recorded as unavailable because its companion exited before model output under the current account/quota state; this is not reported as a current pass.

## Verification

- Windows admission tests: 5 passed
- cargo fmt: passed
- cargo clippy --workspace --all-targets -D warnings: passed
- documentation tests and governance gates: passed
- release build and Windows verifier: passed
- installed Core matches packaged Core bytes
- installed Core health matrix: 12 Windows rows, 11 qualified, Cursor Agent only not qualified
- changed-source and installer known-secret scan: 0 hits
- installer SHA-256: e4c43dbf6a20902b340dcfd1e959fa7af31284fc47f9960f3f8d786f347dc472
- Authenticode: NotSigned (Windows x64 Preview)