### PR TITLE
docs: finalize v0.0.1 release status

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -44,8 +44,8 @@ coordinates them while preserving which facts came from Rovai Core and which cam
   retained but are not backfilled or included in current Usage denominators.
 - Runtime-reported cost, public-price estimates and Provider billing buckets remain distinct grains.
 - User workspaces, Runtime-native configuration and credentials remain user-owned and local.
-- The product is pre-release; compatibility labels describe Rovai's verified evidence, not upstream
-  support promises.
+- Rovai AI publishes versioned public releases; compatibility labels describe Rovai's verified evidence,
+  not upstream support promises.
 
 ## Brand Commitments
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ depending on the team.
 | [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli) | Added alongside native | Added alongside native | Re-delivered after compaction |
 | [Antigravity](https://www.antigravity.google/docs/cli-getting-started) | Runtime-native only | Added alongside native | Based on Runtime capabilities |
 | [Kiro CLI](https://kiro.dev/docs/cli/) | Added alongside native | Added alongside native | Re-delivered after compaction |
-| [Qoder CLI](https://docs.qoder.com/cli/) | Added alongside native | Added alongside native | Re-delivered after compaction |
+| [Qoder CLI](https://docs.qoder.com/cli/installation) | Added alongside native | Added alongside native | Re-delivered after compaction |
 | [CodeBuddy](https://www.codebuddy.ai/docs/cli/installation) | Added alongside native | Added alongside native | Re-delivered after compaction |
 | [Qwen Code](https://qwenlm.github.io/qwen-code-docs/en/users/quickstart/) | Added alongside native | Added alongside native | Re-delivered after compaction |
 | [TRAE CLI CN](https://www.trae.cn/) | Added alongside native | Added alongside native | Based on Runtime capabilities |

--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ Together, they explore, discuss, and act on real tasks — building<br>
 team chemistry and collaborative memory along the way.
 
 <p>
-  <img src="https://img.shields.io/badge/status-preview-7c6f64" alt="Preview">
   <img src="https://img.shields.io/badge/platform-macOS-111111?logo=apple&logoColor=white" alt="macOS">
-  <img src="https://img.shields.io/badge/Windows_x64-Preview_unsigned-4b8f77?logo=windows11&logoColor=white" alt="Windows x64 Preview unsigned">
+  <img src="https://img.shields.io/badge/Windows_x64-unsigned-4b8f77?logo=windows11&logoColor=white" alt="Windows x64 unsigned">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-4b8f77" alt="MIT License"></a>
 </p>
 
@@ -178,9 +177,9 @@ Download the installer for your device from
 |---|---|---|
 | **macOS · Apple Silicon** | A `.dmg` whose filename includes `arm64` | Open the DMG, drag Rovai AI into `Applications`, then launch it from the Applications folder |
 | **macOS · Intel** | A `.dmg` whose filename includes `x64` | Open the DMG, drag Rovai AI into `Applications`, then launch it from the Applications folder |
-| **Windows · x64 Preview — unsigned** | An `.exe` installer explicitly labeled for Windows x64 | Run the per-user installer and follow the setup wizard |
+| **Windows · x64 — unsigned** | An `.exe` installer explicitly labeled for Windows x64 | Run the per-user installer and follow the setup wizard |
 
-The Windows x64 Preview is currently unsigned. Windows SmartScreen may show an unknown publisher
+The Windows x64 installer is currently unsigned. Windows SmartScreen may show an unknown publisher
 warning. Download the installer only from the official Rovai AI GitHub Release.
 
 #### Run from source (for developers)
@@ -221,7 +220,7 @@ depending on the team.
 | [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli) | Added alongside native | Added alongside native | Re-delivered after compaction |
 | [Antigravity](https://www.antigravity.google/docs/cli-getting-started) | Runtime-native only | Added alongside native | Based on Runtime capabilities |
 | [Kiro CLI](https://kiro.dev/docs/cli/) | Added alongside native | Added alongside native | Re-delivered after compaction |
-| [Qoder CLI](https://docs.qoder.com/cli/installation) | Added alongside native | Added alongside native | Re-delivered after compaction |
+| [Qoder CLI](https://docs.qoder.com/cli/) | Added alongside native | Added alongside native | Re-delivered after compaction |
 | [CodeBuddy](https://www.codebuddy.ai/docs/cli/installation) | Added alongside native | Added alongside native | Re-delivered after compaction |
 | [Qwen Code](https://qwenlm.github.io/qwen-code-docs/en/users/quickstart/) | Added alongside native | Added alongside native | Re-delivered after compaction |
 | [TRAE CLI CN](https://www.trae.cn/) | Added alongside native | Added alongside native | Based on Runtime capabilities |
@@ -231,7 +230,7 @@ For exact versions, capabilities, and observed boundaries, see the
 [Agent Runtime Compatibility Register](docs/runtime-compatibility.md) *(Chinese)*.
 
 Kimi Code is qualified on macOS arm64 and Windows x64; macOS x64 remains not qualified.
-On Windows x64 Preview, all eleven Runtimes exposed by Settings are qualified. Cursor Agent remains
+On Windows x64, all eleven Runtimes exposed by Settings are qualified. Cursor Agent remains
 outside the current Settings scope and is not qualified on Windows.
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,9 +9,8 @@ Rovai AI 让你像组建冒险团一样，招募个性鲜明的长期队员。<b
 属于这支队伍的默契与协作记忆。
 
 <p>
-  <img src="https://img.shields.io/badge/status-preview-7c6f64" alt="Preview">
   <img src="https://img.shields.io/badge/platform-macOS-111111?logo=apple&logoColor=white" alt="macOS">
-  <img src="https://img.shields.io/badge/Windows_x64-Preview_unsigned-4b8f77?logo=windows11&logoColor=white" alt="Windows x64 Preview unsigned">
+  <img src="https://img.shields.io/badge/Windows_x64-unsigned-4b8f77?logo=windows11&logoColor=white" alt="Windows x64 unsigned">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-4b8f77" alt="MIT License"></a>
 </p>
 
@@ -171,9 +170,9 @@ Rovai AI 让你像组建冒险团一样，招募个性鲜明的长期队员。<b
 |---|---|---|
 | **macOS · Apple Silicon** | 文件名标记为 `arm64` 的 `.dmg` | 打开 DMG，将 Rovai AI 拖入 `Applications`，再从应用程序目录启动 |
 | **macOS · Intel** | 文件名标记为 `x64` 的 `.dmg` | 打开 DMG，将 Rovai AI 拖入 `Applications`，再从应用程序目录启动 |
-| **Windows · x64 Preview — unsigned** | Release 中明确标记为 Windows x64 的 `.exe` 安装包 | 运行当前用户安装程序并按照向导完成安装 |
+| **Windows · x64 — unsigned** | Release 中明确标记为 Windows x64 的 `.exe` 安装包 | 运行当前用户安装程序并按照向导完成安装 |
 
-Windows x64 Preview 当前未签名，Windows SmartScreen 可能显示“未知发布者”警告。请只从 Rovai AI 官方
+Windows x64 安装包当前未签名，Windows SmartScreen 可能显示“未知发布者”警告。请只从 Rovai AI 官方
 GitHub Release 下载安装包。
 
 #### 从源码运行（开发者）
@@ -219,7 +218,7 @@ Agent Runtime 则决定他通过什么工具与模型参与任务。
 具体版本、能力与实测边界见：[Agent Runtime 兼容性清单](docs/runtime-compatibility.md)。
 
 Kimi Code 当前已完成 macOS arm64 与 Windows x64 准入；macOS x64 尚未准入。
-Windows x64 Preview 当前设置页展示的十一种 Runtime 均已完成资格准入；Cursor Agent 不在当前设置页范围，
+Windows x64 当前设置页展示的十一种 Runtime 均已完成资格准入；Cursor Agent 不在当前设置页范围，
 并继续保持 Windows 未准入。
 
 ---

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -18,13 +18,13 @@ Rovai AI 可以通过桌面安装包使用，也可以从源码启动开发版�
 |---|---|---|
 | macOS · Apple Silicon | 文件名标记为 `arm64` 的 `.dmg` | 打开 DMG，将 Rovai AI 拖入 `Applications` |
 | macOS · Intel | 文件名标记为 `x64` 的 `.dmg` | 打开 DMG，将 Rovai AI 拖入 `Applications` |
-| Windows · x64 Preview — unsigned | Release 中提供的 Windows x64 `.exe` | 运行当前用户安装程序并按照向导完成安装 |
+| Windows · x64 — unsigned | Release 中提供的 Windows x64 `.exe` | 运行当前用户安装程序并按照向导完成安装 |
 
 每个 Release 实际提供哪些平台，以该版本页面中的下载文件为准。
-Windows x64 Preview 当前未签名，SmartScreen 可能显示“未知发布者”；请只从 Rovai AI 官方 GitHub Release
-下载安装包。Windows Preview 当前设置页展示的十一种 Runtime 均已完成平台准入；Cursor Agent 不在当前
+Windows x64 安装包当前未签名，SmartScreen 可能显示“未知发布者”；请只从 Rovai AI 官方 GitHub Release
+下载安装包。Windows 当前设置页展示的十一种 Runtime 均已完成平台准入；Cursor Agent 不在当前
 设置页范围，并继续保持 Windows 未准入。Windows 安装向导会显示安装目录选择页；默认使用当前用户目录，
-也可以改为其他当前用户可写目录。该 Preview 安装器不会请求管理员权限，因此不要选择需要管理员写入权限的系统目录。
+也可以改为其他当前用户可写目录。该安装器不会请求管理员权限，因此不要选择需要管理员写入权限的系统目录。
 
 ## 第一次启动
 


### PR DESCRIPTION
## Summary

- remove Preview labeling from the public v0.0.1 release surface
- keep the Windows x64 unsigned/SmartScreen disclosure explicit
- state that all eleven Windows Settings Runtimes are qualified while Cursor Agent remains outside the current Windows Settings scope
- update the product context from pre-release to versioned public releases

## Scope

Documentation/status wording only. No product code, package version, Runtime admission, signing, workflow, tag, or GitHub Release is changed.

## Release intent

This prepares `v0.0.1` to be published as a normal GitHub Release (`prerelease=false`) while accurately disclosing that the Windows x64 installer is unsigned.