### PR TITLE
test(runtime): refresh Windows qualification fixture

### DIFF
--- a/crates/rovai-core/src/main.rs
+++ b/crates/rovai-core/src/main.rs
@@ -17488,14 +17488,14 @@ while IFS= read -r _ignored; do :; done
     fn local_windows_qualification_updates_the_projected_admission_only_when_allowed() {
         let registry = AgentRuntimeAdapterRegistry::default();
         let denied = apply_windows_runtime_qualification_override(
-            registry.platform_admission(AdapterKind::CodexCli, HostPlatformKey::WindowsX64),
+            registry.platform_admission(AdapterKind::CursorAgent, HostPlatformKey::WindowsX64),
             false,
         );
         assert!(!denied.is_qualified());
         assert_eq!(denied.evidence_revision(), None);
 
         let qualified = apply_windows_runtime_qualification_override(
-            registry.platform_admission(AdapterKind::CodexCli, HostPlatformKey::WindowsX64),
+            registry.platform_admission(AdapterKind::CursorAgent, HostPlatformKey::WindowsX64),
             true,
         );
         assert!(qualified.is_qualified());


### PR DESCRIPTION
Fix the Rust nightly regression introduced when the Windows admission matrix promoted all Settings runtimes except Cursor Agent. The local qualification override test still used Codex as its denied fixture even though Codex is now formally qualified.\n\nThis updates the existing test to use Cursor Agent for the denied and local-debug qualification paths while preserving the macOS non-override assertion.\n\nValidated locally:\n- cargo fmt --all --check\n- cargo clippy --workspace --all-targets --all-features -- -D warnings\n- cargo test --workspace --all-features