### PR TITLE
docs: refresh release badges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ resolver = "3"
 [workspace.package]
 version = "0.0.1"
 edition = "2024"
+rust-version = "1.85"
 license = "MIT"
 
 # Daily development relies on logs and tests instead of a native debugger.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ Together, they explore, discuss, and act on real tasks — building<br>
 team chemistry and collaborative memory along the way.
 
 <p>
-  <img src="https://img.shields.io/badge/platform-macOS-111111?logo=apple&logoColor=white" alt="macOS">
-  <img src="https://img.shields.io/badge/Windows_x64-unsigned-4b8f77?logo=windows11&logoColor=white" alt="Windows x64 unsigned">
+  <a href="https://github.com/murray17/rovai-ai/releases"><img src="https://img.shields.io/badge/macOS-arm64%20%2B%20x64-111111?logo=apple&logoColor=white" alt="macOS arm64 + x64"></a>
+  <a href="https://github.com/murray17/rovai-ai/releases"><img src="https://img.shields.io/badge/Windows-x64-0078D4?logo=windows11&logoColor=white" alt="Windows x64"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-4b8f77" alt="MIT License"></a>
+  <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/Rust-1.85%2B-000000?logo=rust&logoColor=white" alt="Rust 1.85+"></a>
+  <a href="https://nodejs.org/"><img src="https://img.shields.io/badge/Node.js-24%2B-339933?logo=node.js&logoColor=white" alt="Node.js 24+"></a>
 </p>
 
 <p>


### PR DESCRIPTION
## Summary

- refresh the README release badges for macOS and Windows x64
- remove the `unsigned` label from the Windows badge
- add Rust 1.85+ and Node.js 24+ badges
- link platform badges directly to GitHub Releases
- declare `rust-version = "1.85"` in the workspace package metadata

## Notes

The installation section still documents the current Windows signing status separately; this PR only removes `unsigned` from the top-level badge so the badge represents platform support rather than signing state.