### PR TITLE
docs: add LINUX DO community badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ team chemistry and collaborative memory along the way.
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-4b8f77" alt="MIT License"></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/Rust-1.85%2B-000000?logo=rust&logoColor=white" alt="Rust 1.85+"></a>
   <a href="https://nodejs.org/"><img src="https://img.shields.io/badge/Node.js-24%2B-339933?logo=node.js&logoColor=white" alt="Node.js 24+"></a>
+  <a href="https://linux.do/"><img src="https://img.shields.io/badge/LINUX%20DO-Community-1f6feb" alt="LINUX DO Community"></a>
 </p>
 
 <p>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,6 +14,7 @@ Rovai AI 像一座属于你的 Agent 公会，你可以招募不同性格与分�
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-4b8f77" alt="MIT License"></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/Rust-1.85%2B-000000?logo=rust&logoColor=white" alt="Rust 1.85+"></a>
   <a href="https://nodejs.org/"><img src="https://img.shields.io/badge/Node.js-24%2B-339933?logo=node.js&logoColor=white" alt="Node.js 24+"></a>
+  <a href="https://linux.do/"><img src="https://img.shields.io/badge/LINUX%20DO-Community-1f6feb" alt="LINUX DO Community"></a>
 </p>
 
 <p>


### PR DESCRIPTION
Add a LINUX DO community badge to the top badge row in both English and Chinese READMEs. The badge links to https://linux.do/.