### PR TITLE
feat(runtime): qualify Kimi on Intel macOS

### DIFF
--- a/apps/desktop/.impeccable/surfaces/member-workspace.md
+++ b/apps/desktop/.impeccable/surfaces/member-workspace.md
@@ -1,5 +1,5 @@
 ---
-version: 4
+version: 5
 slug: "member-workspace"
 primary_target: "apps/desktop/src/renderer/src/MemberManagement.tsx"
 related_targets:
@@ -89,10 +89,9 @@ future contract explicitly opens it. A historically persisted Cursor configurati
 unrelated member edits preserve that Runtime subobject exactly, while the Renderer must not manufacture its
 `execution_mode` or `approval_policy` defaults or offer a new Cursor selection.
 
-Kimi Code follows the same admission-first rule. macOS arm64 currently remains not qualified because its
-Built-in CLI qualification matrix did not produce operation evidence; therefore its model and
-`default | plan | auto | yolo` permission selector stay disabled. macOS x64 and Windows x64 also stay disabled.
-Read-only workspace always projects effective `plan` once a future platform is qualified; provider
+Kimi Code follows the same admission-first rule and is currently qualified on macOS arm64, macOS x64 and
+Windows x64. Its model and `default | plan | auto | yolo` permission selector therefore follow the ordinary
+available Runtime flow when machine readiness also passes. Read-only workspace always projects effective `plan`; provider
 credentials remain private Core configuration and never appear in this surface. Kimi/MiniMax thinking is not
 forcibly disabled; process detail may retain it while final public output excludes raw reasoning tags.
 

--- a/apps/desktop/.impeccable/surfaces/settings-workspace.md
+++ b/apps/desktop/.impeccable/surfaces/settings-workspace.md
@@ -1,5 +1,5 @@
 ---
-version: 4
+version: 5
 slug: "settings-workspace"
 primary_target: "apps/desktop/src/renderer/src/SettingsPageHeader.tsx"
 related_targets:
@@ -121,8 +121,8 @@ Windows admissions are all `not_qualified` and the product chain has not passed.
 Runtime settings directory until a later qualified integration explicitly reopens that surface. This is not a
 Renderer-only preview and must not be relabeled “待支持”.
 
-Kimi Code is a Product Runtime Catalog row and is qualified on macOS arm64 after its complete Built-in CLI
-matrix passed. macOS x64 and Windows x64 remain `not_qualified` and expose no machine action. Settings never
+Kimi Code is a Product Runtime Catalog row and is qualified on macOS arm64, macOS x64 and Windows x64.
+Each platform follows the ordinary machine availability flow after platform admission. Settings never
 renders the private provider file, token or base URL, and does not expose a Rovai-owned switch that forces
 Kimi/MiniMax thinking off.
 

--- a/apps/desktop/src/renderer/src/App.test.ts
+++ b/apps/desktop/src/renderer/src/App.test.ts
@@ -5112,7 +5112,6 @@ function runtimeAdmissionRows(
   ]
   return runtimeKinds.map((runtimeKind) => {
     const requiresQualification = runtimeKind === 'cursor-agent'
-      || (runtimeKind === 'kimi-code-cli' && platform !== 'macos-arm64')
     const effectiveStatus = requiresQualification && status === 'qualified'
       ? 'not_qualified'
       : status

--- a/crates/rovai-core/src/agent_runtime_adapter.rs
+++ b/crates/rovai-core/src/agent_runtime_adapter.rs
@@ -511,20 +511,6 @@ impl AgentRuntimeAdapterRegistry {
                 WINDOWS_RUNTIME_COMPATIBILITY_EVIDENCE_REVISION,
             );
         }
-        if kind == AdapterKind::KimiCodeCli {
-            if platform == HostPlatformKey::MacosArm64 {
-                return RuntimePlatformAdmission::qualified(
-                    kind,
-                    platform,
-                    MACOS_RUNTIME_COMPATIBILITY_EVIDENCE_REVISION,
-                );
-            }
-            return RuntimePlatformAdmission::not_qualified(
-                kind,
-                platform,
-                RuntimePlatformAdmissionReasonCode::QualificationEvidenceMissing,
-            );
-        }
         match platform {
             HostPlatformKey::MacosArm64 | HostPlatformKey::MacosX64 => {
                 RuntimePlatformAdmission::qualified(

--- a/crates/rovai-core/src/runtime_platform_admission.rs
+++ b/crates/rovai-core/src/runtime_platform_admission.rs
@@ -8,7 +8,7 @@ use crate::{agent_profile::AdapterKind, platform::HostPlatformKey};
 /// that evidence even when their Adapter identity exists in the Product Catalog.
 /// Every register revision receives a new digest.
 pub const MACOS_RUNTIME_COMPATIBILITY_EVIDENCE_REVISION: &str =
-    "sha256:6a1a11634d38a5ef03767c68b49eebd9a0883cb7c54250acfa7fd60dfb27bad6";
+    "sha256:b36d537e224e81d07e839841e7d114bb26295faf2757abc9d092c41ce82bb49d";
 
 /// Immutable digest of the sanitized, adapter-scoped Windows x64 evidence.
 /// The source qualifies only the Runtime rows named in that evidence; shared
@@ -212,12 +212,12 @@ mod tests {
     }
 
     #[test]
-    fn existing_macos_catalog_rows_remain_qualified_with_digest_bound_evidence() {
+    fn macos_catalog_qualifies_every_runtime_except_cursor_with_digest_bound_evidence() {
         let registry = AgentRuntimeAdapterRegistry::default();
 
         for runtime_kind in AdapterKind::ALL
             .into_iter()
-            .filter(|kind| !matches!(kind, AdapterKind::CursorAgent | AdapterKind::KimiCodeCli))
+            .filter(|kind| *kind != AdapterKind::CursorAgent)
         {
             for platform in [HostPlatformKey::MacosArm64, HostPlatformKey::MacosX64] {
                 let admission = registry.platform_admission(runtime_kind, platform);
@@ -242,20 +242,6 @@ mod tests {
             );
             assert_eq!(admission.evidence_revision(), None);
         }
-        let kimi_arm =
-            registry.platform_admission(AdapterKind::KimiCodeCli, HostPlatformKey::MacosArm64);
-        assert!(kimi_arm.is_qualified());
-        assert_eq!(kimi_arm.reason_code(), None);
-        assert_eq!(
-            kimi_arm.evidence_revision(),
-            Some(MACOS_RUNTIME_COMPATIBILITY_EVIDENCE_REVISION)
-        );
-        let kimi_x64 =
-            registry.platform_admission(AdapterKind::KimiCodeCli, HostPlatformKey::MacosX64);
-        assert_eq!(
-            kimi_x64.status(),
-            RuntimePlatformAdmissionStatus::NotQualified
-        );
     }
 
     #[test]

--- a/docs/architecture/runtime-catalog-boundaries.md
+++ b/docs/architecture/runtime-catalog-boundaries.md
@@ -3,7 +3,7 @@ document_type: architecture
 architecture: runtime-catalog-boundaries
 authority: runtime-catalog-and-preview-boundaries
 status: accepted
-last_updated: 2026-08-23
+last_updated: 2026-08-24
 ---
 
 # Runtime Catalog Boundaries
@@ -254,8 +254,9 @@ advertisement 只安全路由为私有 metadata，当前没有产品消费者，
 Missing-Send、cancel 与 cleanup。早期 Built-in CLI `0/15` 是 fixture 在第一项 canonical operation 前错误检查
 legacy stdin 非法输入退出码；改为当前 CLI 合同的 `2` 后，十五项 operation、三种输入、Gather、conflict、
 lease fencing、exact successor read 与 logical/native continuation 全部通过，共产生 56 条 full-run evidence。
-因此 snapshot 声明 built-in transport，macOS arm64 为 digest-bound `qualified`；macOS x64 与 Windows x64
-没有对应证据，保持 `not_qualified / runtime_platform.qualification_evidence_missing`。字段级行为见
+因此 snapshot 声明 built-in transport。macOS arm64、macOS x64 与 Windows x64 当前均为 digest-bound
+`qualified`：arm64 由完整 Kimi 资格矩阵准入，macOS x64 由维护者完成平台验收后的独立发布确认准入，Windows
+x64 由独立 Windows 资格证据准入。三者都进入普通 discovery、检查、成员配置和 AgentRun 路径。字段级行为见
 [Runtime Launch and Verification v25](../contracts/runtime-launch-and-verification-v25.md)，证据状态见
 [Runtime 兼容性清单](../runtime-compatibility.md)。
 

--- a/docs/contracts/runtime-launch-and-verification-v25.md
+++ b/docs/contracts/runtime-launch-and-verification-v25.md
@@ -4,14 +4,16 @@ name: Runtime Launch and Verification
 version: v25
 status: accepted
 source_version: v1.27
-last_updated: 2026-08-23
+last_updated: 2026-08-24
 ---
 
 # Runtime Launch and Verification v25
 
 v25 replaces [v24](runtime-launch-and-verification-v24.md). v24 的用户原生 Runtime Home、Probe 隔离、
-continuation、External MCP、逐平台准入及十二种 Runtime 原生最高权限默认全部保持不变；本版把 Cursor 的
+continuation、External MCP、逐平台准入字段与消费规则及十二种 Runtime 原生最高权限默认全部保持不变；本版把 Cursor 的
 默认隐藏边界扩展到普通成员 Runtime selector，修正 Settings 与队员配置入口之间的 Renderer 漂移。
+精确 `AdapterKind × HostPlatformKey` 行由 Runtime Platform Admission Registry 与 digest-bound evidence
+拥有，不由本合同冻结；后续平台证据晋升无需改写本合同的 launch、verification 或 permission 语义。
 
 ## Cursor 普通产品入口
 

--- a/docs/decisions/CURRENT.md
+++ b/docs/decisions/CURRENT.md
@@ -1,7 +1,7 @@
 ---
 document_type: current-decision-navigation
 authority: current-authority-and-rationale-routing
-last_updated: 2026-08-23
+last_updated: 2026-08-24
 ---
 
 # 当前规范与决定理由导航
@@ -34,7 +34,7 @@ last_updated: 2026-08-23
 
 - 当前规范：[Runtime 基础不变量](../architecture/foundational-invariants.md#runtime-catalog-installation)、[Runtime Catalog](../architecture/runtime-catalog-boundaries.md)、[AgentRun Recovery](../architecture/agent-run-recovery.md)、[Planned Shutdown](../architecture/planned-shutdown.md)、[Camp Published Attachment View](../architecture/camp-published-attachment-view.md)、[Windows Platform](../architecture/windows-desktop-platform.md)、[Runtime Launch and Verification v25](../contracts/runtime-launch-and-verification-v25.md)、[Runtime Platform Admission v1](../contracts/runtime-platform-admission-v1.md)和[Managed Runtime Process v1](../contracts/managed-runtime-process-v1.md)。
 - 当前 Cursor identity、同名 `agent` 碰撞与未准入策略的理由：[V1.26-D01](../versions/v1.26/decisions.md#v1-26-d01)。
-- 当前 Kimi provider 凭据隔离理由：[V1.27-D01](../versions/v1.27/decisions.md#v1-27-d01)；Built-in fixture 修正与 macOS arm64 准入理由：[V1.27-D03](../versions/v1.27/decisions.md#v1-27-d03)；warm Host、External MCP 与 async catalog 边界理由：[V1.27-D04](../versions/v1.27/decisions.md#v1-27-d04)；Kimi 原生完成帧的初始 idle ACP 准入理由：[V1.27-D05](../versions/v1.27/decisions.md#v1-27-d05)；正式 AgentRun 继承用户原生 Home、Probe 独立隔离的理由：[V1.27-D06](../versions/v1.27/decisions.md#v1-27-d06)；Active Prompt lifecycle correlation 与 blocked 保留 pending 的当前理由：[V1.27-D07](../versions/v1.27/decisions.md#v1-27-d07)。
+- 当前 Kimi provider 凭据隔离理由：[V1.27-D01](../versions/v1.27/decisions.md#v1-27-d01)；Built-in fixture 修正与 macOS arm64 准入理由：[V1.27-D03](../versions/v1.27/decisions.md#v1-27-d03)；warm Host、External MCP 与 async catalog 边界理由：[V1.27-D04](../versions/v1.27/decisions.md#v1-27-d04)；Kimi 原生完成帧的初始 idle ACP 准入理由：[V1.27-D05](../versions/v1.27/decisions.md#v1-27-d05)；正式 AgentRun 继承用户原生 Home、Probe 独立隔离的理由：[V1.27-D06](../versions/v1.27/decisions.md#v1-27-d06)；Active Prompt lifecycle correlation 与 blocked 保留 pending 的当前理由：[V1.27-D07](../versions/v1.27/decisions.md#v1-27-d07)；macOS x64 独立平台验收后的准入理由：[V1.27-D09](../versions/v1.27/decisions.md#v1-27-d09)。
 - 理由来源：[v0.16](../versions/v0.16/decisions.md)、[v0.17](../versions/v0.17/decisions.md)、[v0.19](../versions/v0.19/decisions.md)、[v0.20](../versions/v0.20/decisions.md)、[v0.58](../versions/v0.58/decisions.md)、[v0.64](../versions/v0.64/decisions.md)、[v0.66](../versions/v0.66/decisions.md)、[v1.01](../versions/v1.01/decisions.md)、[v1.03](../versions/v1.03/decisions.md)、[v1.04](../versions/v1.04/decisions.md)、[v1.05](../versions/v1.05/decisions.md)、[v1.11](../versions/v1.11/decisions.md)、[v1.12](../versions/v1.12/decisions.md)、[v1.13](../versions/v1.13/decisions.md)、[V1.15-D04](../versions/v1.15/decisions.md#v1-15-d04)、[V1.15-D06](../versions/v1.15/decisions.md#v1-15-d06)、[V1.17-D02](../versions/v1.17/decisions.md#v1-17-d02)、[V1.19-D01](../versions/v1.19/decisions.md#v1-19-d01)、[V1.20-D02](../versions/v1.20/decisions.md#v1-20-d02)、[V1.21-D03](../versions/v1.21/decisions.md#v1-21-d03)、[V1.22-D01](../versions/v1.22/decisions.md#v1-22-d01)、[V1.24-D01](../versions/v1.24/decisions.md#v1-24-d01)。
 
 ## Session、Context 与 Bootstrap

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -169,7 +169,7 @@ pnpm build:desktop
 | 命令 | 主要范围 | 外部要求 |
 | --- | --- | --- |
 | `pnpm smoke:core` | 全新数据库、普通目录、空 Git 仓库、导航、重启和删除 | Git；不调用模型 |
-| `pnpm smoke:member-config` | 十二种产品目录 identity、Installation、成员 Runtime 配置、Readiness 和重启 | 不调用模型；可用 `ROVAI_*_BIN` 覆盖发现；Cursor 验证 Catalog/Admission 阻断，不制造 Installation 或配置；macOS arm64 Kimi 已准入，在 PATH 隔离 fixture 中按缺少 executable 返回 `runtime_configuration_unavailable`；Settings Preview 不进入该矩阵 |
+| `pnpm smoke:member-config` | 十二种产品目录 identity、Installation、成员 Runtime 配置、Readiness 和重启 | 不调用模型；可用 `ROVAI_*_BIN` 覆盖发现；Cursor 验证 Catalog/Admission 阻断，不制造 Installation 或配置；macOS arm64/x64 Kimi 已准入，在 PATH 隔离 fixture 中按缺少 executable 返回 `runtime_configuration_unavailable`；Settings Preview 不进入该矩阵 |
 | `pnpm smoke:memory` | Memory Migration、治理、Revision、导出、投影恢复和权限 | 不调用模型 |
 
 ### 真实 Runtime Smoke

--- a/docs/research/kimi-code-runtime-research.md
+++ b/docs/research/kimi-code-runtime-research.md
@@ -4,14 +4,14 @@ runtime: kimi-code-cli
 upstream: MoonshotAI/kimi-code
 authority: research-evidence-only
 status: implemented
-admission: macos_arm64_qualified
-last_updated: 2026-08-23
+admission: shipped_platforms_qualified
+last_updated: 2026-08-24
 ---
 
 # Kimi Code CLI Runtime 接入研究
 
 > 本文按 [`runtime-integration-checklist.md`](https://github.com/murray17/rovai-ai/blob/main/docs/development/runtime-integration-checklist.md) 整理。
-> 第 1–11 节保留接入前研究快照；其假设不能覆盖后续真实证据。当前实施与准入结论见第 12 节及
+> 第 1–11 节保留接入前研究快照；其假设不能覆盖后续真实证据。当前实施与准入结论见第 12、13 节及
 > [Runtime 兼容性清单](../runtime-compatibility.md)。
 
 ## 基本结论
@@ -23,8 +23,8 @@ Runtime: Kimi Code CLI
 建议接入形态: vendor_extended_acp
 Exact launch command: kimi acp
 Transport: stdio / JSON-RPC 2.0 / ACP v1
-当前 Admission: macOS arm64 qualified；macOS x64 / Windows x64 not_qualified
-一句话结论: Kimi 0.32.0 + MiniMax M3 已完成 ACP 与 Built-in CLI 十五项完整矩阵，macOS arm64 准入；其他平台仍需独立取证。
+当前 Admission: macOS arm64 / macOS x64 / Windows x64 qualified
+一句话结论: Kimi 0.32.0 + MiniMax M3 已完成 ACP 与 Built-in CLI 十五项完整矩阵；三个 shipped 平台分别完成准入。
 最接近的现有 Adapter: TRAE/Kiro ACP Host，加上 Kimi 私有 Session、Skill catalog 与交互扩展处理。
 ```
 
@@ -328,22 +328,32 @@ Shell override: KIMI_SHELL_PATH
   initial/resumed lease fencing、logical conversation 与 native Session continuation 全部通过，产生 56 条
   full-run evidence。
 
-基于以上证据，macOS arm64 为 digest-bound `qualified`；macOS x64 与 Windows x64 保持
-`not_qualified / runtime_platform.qualification_evidence_missing`。
+基于本节 2026-08-22 当时的证据，macOS arm64 为 digest-bound `qualified`；macOS x64 与 Windows x64 当时
+保持 `not_qualified / runtime_platform.qualification_evidence_missing`。后续平台晋升见第 13 节。
+
+## 13. 后续逐平台准入
+
+Windows x64 随同当前版本的逐 Adapter Windows 资格矩阵使用独立 Windows evidence revision 晋升。2026-08-24，
+维护者确认 Kimi Code 的 x86_64 macOS 平台验收已经完成，并明确批准开放；`kimi-code-cli × macos-x64` 因此
+使用更新后的 macOS compatibility-register digest 晋升为 `qualified`。
+
+这两项结论不改写第 12 节在 2026-08-22 的 arm64 实测事实，也不把 arm64 结果静默外推。本次 macOS x64
+准入提交运行于 arm64 主机，只复核确定性 Registry、投影与文档门禁；x86_64 资格来源是维护者完成平台验收后
+的明确发布确认。三个 shipped 平台现在都进入普通 discovery、检查、成员配置和 AgentRun 路径。
 
 ## 最终决定
 
 ```text
-Qualified capabilities on macOS arm64: ACP AgentRun、Approval、command output、Missing-Send、cancel/cleanup、managed Skill、Built-in CLI、warm Host/Session reuse、cold Host native resume
+Qualified capabilities: ACP AgentRun、Approval、command output、Missing-Send、cancel/cleanup、managed Skill、Built-in CLI、warm Host/Session reuse、cold Host native resume
 Product continuation: compatible warm Host/Session + user-native Kimi Home；停止/淘汰后 cold exact resume；load-only 时使用 History Restore quarantine；Probe only 使用临时 Home
 External MCP: AdditivePerRun / RovaiWins；ACP session/new/resume/load.mcpServers；stdio 与 Streamable HTTP Verified
 Best-effort capabilities: Kimi-only Prompt lifecycle correlation + idle/detached ACP `compaction.completed` exact-frame detector
 Disabled capabilities: Usage/Cost monitoring
 Verified upstream-only boundaries: 同 Host 并发 Session 隔离、跨隔离 home Unknown session、ACP stdio MCP happy path 与相邻 Session 隔离
-Unverified capabilities: macOS x64、Windows x64
+Platform qualification: macOS arm64 / macOS x64 / Windows x64 qualified
 Known boundary: Client fs write 需要 Core one-time authorization；Runtime 预拒绝不得伪造用户 deny
 Non-blocking gaps: Usage/Cost、Compaction 自动/手动真实 Core observation smoke
-Admission decision: macOS arm64 qualified；macOS x64 / Windows x64 not_qualified
+Admission decision: macOS arm64 / macOS x64 / Windows x64 qualified
 ```
 
 ## 上游来源

--- a/docs/runtime-compatibility.md
+++ b/docs/runtime-compatibility.md
@@ -1,7 +1,7 @@
 ---
 document_type: runtime-compatibility-register
 authority: runtime-validation-evidence
-last_updated: 2026-08-23
+last_updated: 2026-08-24
 ---
 
 # Agent Runtime 兼容性清单
@@ -22,12 +22,23 @@ Context、Memory MCP transport、Bridge、Plugin 与 Runtime-native built-in MCP
 
 当前 closed `AdapterKind` 包含十二种 Product Runtime：Codex CLI、OpenCode、GitHub Copilot、
 Claude Code、Antigravity、Kiro、Qoder、CodeBuddy、Qwen Code、TRAE CLI CN、Cursor Agent 与 Kimi Code。
-Cursor 在三个目标平台均为 `not_qualified`。Kimi 的 macOS arm64 与 Windows x64 资格均为
-digest-bound `qualified`；macOS x64 仍为 `not_qualified`。
+Cursor 在三个目标平台均为 `not_qualified`。Kimi 在 macOS arm64、macOS x64 与 Windows x64 均为
+digest-bound `qualified`。
 Cursor identity 仅保留内部兼容与历史读取，默认不进入 discovery/check/AgentRun；Settings 的 Agent Runtime
 目录不展示该项。设置页的
 DeepSeek Harness “待支持”行是 Renderer-only Preview，不在这个目录中，也没有 Installation、
 Probe、成员选择、诊断或 AgentRun 语义。
+
+### 2026-08-24 Kimi Code macOS x64 准入晋升
+
+维护者确认 Kimi Code 的 x86_64 macOS 平台验收已经完成，并明确批准开放该平台。`kimi-code-cli × macos-x64`
+因此从 `not_qualified / runtime_platform.qualification_evidence_missing` 晋升为 digest-bound `qualified`，与
+macOS arm64 一样进入普通 discovery、检查、成员配置和 AgentRun 路径。
+
+本次晋升只改变 Runtime Platform Admission 行，不新增 Adapter、权限、provider、Session、External MCP、Usage
+或 Compaction 语义；现有 Kimi `0.32.0` + MiniMax M3 能力边界继续由下方完整资格复核拥有。当前提交所在主机
+是 macOS arm64，未在本提交内重跑 x86_64 真实模型 Smoke；x86_64 资格依据是维护者已完成验收后的明确发布
+确认，而不是把 arm64 结果静默外推。Windows x64 已由独立 Windows 资格证据准入，不受本次变更影响。
 
 ### 2026-08-22 Kimi Code `0.32.0` + MiniMax M3 macOS arm64 完整资格复核
 
@@ -59,8 +70,8 @@ diagnostics 或本文。国内 `https://api.minimaxi.com/v1` 接受该 Token Pla
 `ROVAI_KIMI_CODE_CLI_PRINTF_OK`，allow 与 deny 都完成真实 Approval roundtrip。基础 AgentRun 可用于隔离诊断，
 修正过期 fixture 后 Built-in hard gate 已通过，所以 macOS arm64 为 digest-bound `qualified`；snapshot 声明
 Built-in transport，普通产品与默认资格 Smoke 包含 Kimi。External MCP 与兼容 warm Host 已由独立产品矩阵
-启用；Kimi Compaction compatibility detector 独立以 `best_effort` 启用，该结论不扩大为 Usage、macOS x64
-或 Windows x64 产品资格。native resume 使用用户原生 Kimi Home，History Restore 只作为 load-only
+启用；Kimi Compaction compatibility detector 独立以 `best_effort` 启用。该次 2026-08-22 arm64 结论当时
+没有外推为 macOS x64 或 Windows x64 产品资格；两者后来分别通过自己的发布准入。native resume 使用用户原生 Kimi Home，History Restore 只作为 load-only
 fallback。异步 command catalog 没有当前产品消费者，不再作为
 功能空缺跟踪。
 

--- a/docs/versions/v1.27/README.md
+++ b/docs/versions/v1.27/README.md
@@ -6,7 +6,7 @@ authority: version-scope-and-status
 design_status: confirmed
 implementation_status: in_progress
 model_context_change: false
-last_updated: 2026-08-23
+last_updated: 2026-08-24
 ---
 
 # Rovai-ai v1.27：Kimi Code + MiniMax M3 本地 Runtime 接入
@@ -14,8 +14,9 @@ last_updated: 2026-08-23
 > 当前状态：Kimi Code `0.32.0` 已作为第十二种 Product Runtime identity 接入，并在 macOS arm64 上使用
 > MiniMax 国内 Token Plan、`MiniMax-M3` 与 OpenAI-compatible endpoint 完成基础 ACP、真实 Approval、
 > command-output、Missing-Send、cancel 与进程清理验收。修正 Built-in CLI fixture 的过期退出码断言后，
-> 完整资格矩阵通过十五项 operation 并产生 56 条 full-run evidence；macOS arm64 已晋升为 `qualified`，
-> macOS x64 与 Windows x64 仍未准入。
+> 完整资格矩阵通过十五项 operation 并产生 56 条 full-run evidence；macOS arm64 已晋升为 `qualified`。
+> Windows x64 随后由独立 Windows 资格证据准入；维护者在 2026-08-24 确认 x86_64 macOS 平台验收完成并
+> 明确批准开放。Kimi 当前在 macOS arm64、macOS x64 与 Windows x64 三个 shipped 平台均为 `qualified`。
 >
 > 同版本另修复首次训练在零可用 Runtime 时的永久阻断：Desktop onboarding schema 升级为 v2，新增
 > `runtime_deferred` 无产品副作用终态和对应第三页空结果 UI；正常 Runtime provisioning 与“初次集结”路径
@@ -58,10 +59,10 @@ Rovai 私有、最小权限的 provider 配置运行 MiniMax M3，而不改写�
   completion frame 以 `best_effort` 启用，不安装 Hook 或修改用户配置。capability snapshot 保留真实
   `session.resume/load`，
   Host 停止或淘汰后由新 Host 优先精确 resume，load 只作 replay-quarantined fallback；
-- macOS arm64 声明 Built-in transport 并进入普通 discovery、检查、成员配置和执行路径；macOS x64 与
-  Windows x64 仍保持准入阻断，不从 arm64 证据外推。
-- Windows x64 的 Claude Code 使用独立 digest-bound 证据进入普通 discovery、检查、成员配置和执行路径；
-  该结论不改变 Kimi 的 Windows 阻断，也不外推到其他 Runtime。
+- Kimi 在 macOS arm64、macOS x64 与 Windows x64 声明 Built-in transport 并进入普通 discovery、检查、
+  成员配置和执行路径；macOS x64 的晋升来自维护者完成平台验收后的明确发布确认，不把 arm64 结论静默外推。
+- Windows x64 的设置页十一种 Runtime 使用独立 digest-bound 证据进入普通 discovery、检查、成员配置和
+  执行路径；该结论不外推到范围外 Cursor。
 - 首次训练扫描结束或失败后没有可直接继续的 Runtime 时，显示统一空结果页；用户可重新扫描，或在尚未
   provisioning 时结束训练并进入普通 App。该终态不创建成员配置、Camp、Run 或 onboarding restore target，
   以后从正常 Settings/成员工作区配置 Runtime。
@@ -94,20 +95,21 @@ Rovai 私有、最小权限的 provider 配置运行 MiniMax M3，而不改写�
   清除，cancelled 只清除；这些 frame 不进入 final 或 Missing-Send。PromptCompleted/Ready/detached warm Host
   保留 exact 四行 completion detector；宽泛关键词和 token-drop 不参与。确定性 Host 回归已覆盖
   started→blocked→completed、单次 observation 与公开文本隔离；真实自动/手动完整 Core smoke 尚未执行；
-- macOS x64 与 Windows x64 没有从 arm64 结论外推资格。
+- macOS x64 在维护者确认独立平台验收完成后于 2026-08-24 晋升；Windows x64 使用独立 Windows 资格证据。
+  两者都不依赖把 arm64 结果静默外推。
 
 ## 跨版本文档影响
 
 | 范围 | 结论 | 证据或理由 |
 | --- | --- | --- |
 | Version lifecycle | 已更新 | v1.26 冻结为 historical；本概览、计划、决定和版本索引建立唯一 current v1.27。 |
-| Decisions | 已更新 | [V1.27-D04](decisions.md#v1-27-d04)保留 warm Host reuse、External MCP 与 async catalog 边界；[V1.27-D05](decisions.md#v1-27-d05)记录初始 idle ACP completion frame；[V1.27-D06](decisions.md#v1-27-d06)把正式 AgentRun 切回用户原生 Home并保留 Probe 临时隔离；[V1.27-D07](decisions.md#v1-27-d07)补齐 Active Prompt lifecycle correlation；[V1.27-D08](decisions.md#v1-27-d08)允许零可用 Runtime 无副作用结束首次训练。 |
+| Decisions | 已更新 | [V1.27-D04](decisions.md#v1-27-d04)保留 warm Host reuse、External MCP 与 async catalog 边界；[V1.27-D05](decisions.md#v1-27-d05)记录初始 idle ACP completion frame；[V1.27-D06](decisions.md#v1-27-d06)把正式 AgentRun 切回用户原生 Home并保留 Probe 临时隔离；[V1.27-D07](decisions.md#v1-27-d07)补齐 Active Prompt lifecycle correlation；[V1.27-D08](decisions.md#v1-27-d08)允许零可用 Runtime 无副作用结束首次训练；[V1.27-D09](decisions.md#v1-27-d09)记录 Kimi macOS x64 的独立准入晋升。 |
 | Contracts | 已更新 | [Runtime Launch and Verification v25](../../contracts/runtime-launch-and-verification-v25.md)继承用户原生 Home、Probe 隔离、warm/cold continuation、Kimi External MCP 与十二种 Runtime 原生最高权限默认，并冻结 Cursor 隐藏边界；[First-run Onboarding v2](../../contracts/first-run-onboarding-v2.md)增加 schema 2 与 `runtime_deferred`。 |
 | User Automation | 已更新 | [User Automation v1](../../contracts/user-automation-v1.md)补齐 `runtime check/models` 与成员 create/runtime set/clear 的封闭 App CLI；所有写入复用既有 Core Domain Command、显式版本 fence 与幂等 command ID，不开放 generic invoke。 |
-| Architecture | 已更新 | [Runtime Catalog Boundaries](../../architecture/runtime-catalog-boundaries.md)扩展为十二种 identity；[Native Session Bootstrap Redelivery](../../architecture/native-session-bootstrap-redelivery.md)记录 Kimi completion frame detector；[First-run Onboarding](../../architecture/first-run-onboarding.md)增加 configured/deferred 分支。 |
-| UI | 已更新 | Settings Agent Runtime 目录继续展示已接入 Kimi并隐藏 Cursor；首次训练 Runtime 页增加零可用结果面、重新扫描和无副作用“进入 Rovai”。 |
+| Architecture | 已更新 | [Runtime Catalog Boundaries](../../architecture/runtime-catalog-boundaries.md)扩展为十二种 identity，并记录 Kimi 三个 shipped 平台的当前准入；[Native Session Bootstrap Redelivery](../../architecture/native-session-bootstrap-redelivery.md)记录 Kimi completion frame detector；[First-run Onboarding](../../architecture/first-run-onboarding.md)增加 configured/deferred 分支。 |
+| UI | 已更新 | Settings 与成员工作区继续展示已接入 Kimi并隐藏 Cursor；Kimi macOS x64 进入普通机器可用性与配置流；首次训练 Runtime 页增加零可用结果面、重新扫描和无副作用“进入 Rovai”。 |
 | Runtime Activity | 已更新 | [Mapping Registry](../../runtime-activity/registry.md)加入 Kimi ACP `run_level` baseline 与真实 Shell Evidence。 |
-| Runtime compatibility | 已更新 | [兼容性清单](../../runtime-compatibility.md)记录 `0.32.0`、MiniMax M3、用户原生 Home、Probe 隔离、warm/cold continuation、External MCP、Built-in 15/15、Kimi Compaction detector 与平台边界；另冻结 Claude Code Windows x64 独立资格 revision。 |
+| Runtime compatibility | 已更新 | [兼容性清单](../../runtime-compatibility.md)记录 `0.32.0`、MiniMax M3、用户原生 Home、Probe 隔离、warm/cold continuation、External MCP、Built-in 15/15、Kimi Compaction detector 与 macOS x64 晋升；另冻结 Windows x64 独立资格 revision。 |
 | Documentation routing | 已更新 | 文档导航、合同索引和当前决定导航路由到 Runtime Launch v25、本版本与 Kimi Research。 |
 | Root README | 已更新 | 常青能力更新为十二种 Product Runtime identity。 |
 

--- a/docs/versions/v1.27/decisions.md
+++ b/docs/versions/v1.27/decisions.md
@@ -2,7 +2,7 @@
 document_type: version-decisions
 version: v1.27
 lifecycle: current
-last_updated: 2026-08-23
+last_updated: 2026-08-24
 ---
 
 # v1.27 决策记录
@@ -386,3 +386,48 @@ First-run v1 把 Welcome、Member 与 Runtime 都定义为不可跳过的 mandat
 - **只在 React 内隐藏 onboarding：** 重启会恢复旧持久状态，不能真正解除卡死；
 - **允许 provisioning 中途延后：** 可能留下已经创建的成员或配置，却把完成态声明为无产品身份；
 - **新增独立扫描失败页：** 不改变用户可执行选择，只增加一个与零可用结果同义的产品状态。
+
+<a id="v1-27-d09"></a>
+## V1.27-D09：完成独立平台验收后准入 Kimi macOS x64
+
+### 背景
+
+D03 正确地拒绝把 Kimi macOS arm64 的资格自动外推到 macOS x64；当时没有 x86_64 平台自己的验收结论，
+所以 `kimi-code-cli × macos-x64` 保持 `runtime_platform.qualification_evidence_missing`。随后 Windows x64
+也通过独立 Windows 资格证据准入，进一步确认同一 Adapter 的平台状态必须分别建立，而不是按协议形态或共享
+实现批量推导。
+
+2026-08-24，维护者确认 Kimi Code 的 x86_64 macOS 平台验收已经完成，并明确批准开放。继续保留 x64 特例
+阻断会让 Registry、Settings 与 AgentRun preflight 拒绝一个已经通过发布裁决的平台，并使常青文档继续显示
+过期状态。本提交所在主机是 macOS arm64，因此本提交可以复核确定性准入链路和闭合矩阵，但不能冒充在本次
+提交内重新执行 x86_64 真实模型 Smoke。
+
+### 决定
+
+1. D03 第 2 项、后果和 D04 第 5 项中关于 macOS x64 继续未准入的结论由本决定替代；
+2. `kimi-code-cli × macos-x64` 晋升为 `qualified`，使用更新后的
+   `docs/runtime-compatibility.md` SHA-256 digest 作为 macOS evidence revision；
+3. Kimi macOS x64 进入与 arm64 相同的普通 discovery、检查、Installation、成员配置、诊断和 AgentRun
+   preflight 路径；机器缺少 executable、认证或 Ready evidence 时仍按既有 Machine Availability 合同阻断；
+4. 该晋升不改变 Adapter、provider allowlist、权限默认、用户原生 Home、warm/cold continuation、External MCP、
+   Usage/Cost、Compaction 或 Renderer 信息架构；
+5. Windows x64 的现有 Kimi 资格继续由独立 Windows evidence revision 拥有。Cursor 三个平台仍保持
+   `not_qualified`，本决定不能外推到其他 Adapter 或未来平台。
+
+当前规范见 [Runtime Catalog Boundaries](../../architecture/runtime-catalog-boundaries.md)、
+[Runtime Platform Admission v1](../../contracts/runtime-platform-admission-v1.md)与
+[Runtime 兼容性清单](../../runtime-compatibility.md)。
+
+### 后果
+
+- Intel Mac 用户可以在普通 Settings 与成员工作区选择、检查并执行 Kimi；
+- macOS Kimi 不再需要架构特例，Registry 的唯一未准入 Runtime 继续是 Cursor；
+- macOS evidence revision 随兼容性清单更新，旧 Snapshot 能通过 revision 漂移诚实失效并重新检查；
+- 当前提交的自动验证只证明准入代码、投影和文档一致，不被描述为新的 x86_64 实机资格运行。
+
+### 被拒绝方案
+
+- **继续阻断 macOS x64：** 与维护者已经完成验收并明确批准发布的当前裁决冲突；
+- **把 arm64 digest 直接套到 x64 而不记录平台晋升：** 会掩盖 D03 的独立取证边界与本次发布来源；
+- **新增第二个 Kimi AdapterKind：** CPU 架构是 HostPlatformKey，不是新的 Runtime 产品身份；
+- **同时修改 Runtime 能力或权限：** 平台准入不提供这些独立语义变化的证据。

--- a/docs/versions/v1.27/implementation-plan.md
+++ b/docs/versions/v1.27/implementation-plan.md
@@ -3,7 +3,7 @@ document_type: implementation-plan
 version: v1.27
 authority: implementation-and-acceptance-status
 status: in_progress
-last_updated: 2026-08-23
+last_updated: 2026-08-24
 ---
 
 # v1.27 Kimi Code + MiniMax M3 实施验收计划
@@ -81,9 +81,12 @@ last_updated: 2026-08-23
   十一种 Runtime；范围外 `cursor-agent` 保持 `not_qualified`。
 - [x] 修复 Windows titlebar overlay 的未缩放 `env(titlebar-area-width)` 在 200% zoom 下撑大根 grid；packaged
   planned-shutdown 的 1040×700 Day/Night 与 200% zoom 对话框、文档尺寸、自然退出和恢复矩阵通过。
+- [x] 维护者确认 Kimi x86_64 macOS 平台验收完成并明确批准发布；`kimi-code-cli × macos-x64` 使用更新后的
+  macOS digest-bound evidence revision 晋升为 `qualified`，Core closed matrix、Renderer fixture 与当前文档
+  同步；本提交在 arm64 主机完成确定性回归，不冒充在本提交内重跑 x86_64 真实模型 Smoke。
 
-Kimi 验收不包含 macOS x64、Windows x64 的平台资格，也没有开启 Usage/Cost；Claude Code 的 Windows x64
-资格使用独立 Adapter 证据，不改变 Kimi 或其他 Runtime 的平台状态。Kimi Compaction compatibility
+Kimi 当前在 macOS arm64、macOS x64 与 Windows x64 三个平台均已准入，但仍没有开启 Usage/Cost；Windows x64
+与 macOS x64 使用各自的平台准入来源，不把 arm64 结果静默外推。Kimi Compaction compatibility
 detector 已进入代码和定向 Rust 验证，真实自动/手动完整 Core smoke 仍待执行。warm Host、External MCP 与
 native resume 已进入产品，History Restore 只在 load-only 时作为既有 quarantine fallback。
-十五项 Built-in CLI matrix 已在 macOS arm64 完整通过，该平台已准入；其他平台仍需独立完成同等级证据。
+十五项 Built-in CLI matrix 已在 macOS arm64 完整通过；x86_64 macOS 平台验收由维护者确认完成并批准开放。


### PR DESCRIPTION
## Summary

- qualify Kimi Code on macOS x64 in the Core platform admission matrix
- update the digest-bound macOS compatibility evidence and existing regression fixtures
- synchronize current architecture, UI briefs, research, and v1.27 decision/status documentation

## Validation

- cargo test -p rovai-core --lib runtime_platform_admission::tests::
- cargo check -p rovai-core
- cargo clippy -p rovai-core --lib -- -D warnings
- pnpm typecheck
- pnpm test (522 Vitest + 193 Node tests)
- pnpm docs:test
- pnpm docs:check
- DOCS_BASE_REF=9811ff03 pnpm docs:check:ci

## Known unrelated baseline

The full 304-test Rust library run passed 303 tests; the unchanged macOS sandbox-exec test failed on macOS 26.3 with exit status 71 and also failed when rerun alone.