### PR TITLE
docs(development): require PR-based main delivery

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,7 +1,7 @@
 ---
 document_type: development-index
 authority: development-routing
-last_updated: 2026-08-23
+last_updated: 2026-08-24
 ---
 
 # Rovai-ai 开发者指南
@@ -22,6 +22,10 @@ last_updated: 2026-08-23
 [Git Worktree 生命周期与清理](worktrees.md)。Rovai-ai 的 Rust、Electron 和打包生成物会让每个
 活跃 worktree 占用数 GiB；Task 已合入或明确放弃后，清理 worktree 是同一次任务收口的一部分，
 不能无限期留待以后处理。
+
+所有本地代码、文档和配置变更都必须从任务分支通过 PR 合入 `main`；即使交付要求写成“push 到 main”，
+也不要先尝试直接推送受保护主线，或先把本地 `main` 快进到尚未合入的任务提交。完整步骤见
+[本地开发提交与主线合入流程](local-workflow.md#代码提交与主线合入统一使用-pr)。
 
 在仓库根目录安装锁定依赖并启动开发版桌面应用：
 

--- a/docs/development/local-workflow.md
+++ b/docs/development/local-workflow.md
@@ -1,7 +1,7 @@
 ---
 document_type: development-guide
 authority: local-development-workflow
-last_updated: 2026-08-19
+last_updated: 2026-08-24
 ---
 
 # 本地开发与 App 隔离流程
@@ -57,6 +57,29 @@ Windows 的 `--user-data-dir=<root>` 是隔离 data-root 开关，不直接等�
 7. 不得为了方便直接调用 `electron-vite dev`、直接打开 `dist/.../Rovai-ai.app`，或让
    `rovai-core --data-dir` 指向日常目录；
 8. 测试结束后只清理本次命令创建且路径已经确认的临时目录，不推测或递归删除日常目录。
+
+## 代码提交与主线合入：统一使用 PR
+
+本仓库的普通代码、文档和配置变更统一通过 Pull Request 合入 `main`。开发者或 AI Agent 收到
+“提交到 main”“push 到 main”或同义交付要求时，应将其解释为“让当前改动经 PR 成为
+`origin/main` 的祖先”，不得先尝试直接执行 `git push origin main`，也不得把特性分支先快进到
+本地 `main` 后再碰撞远端保护规则。
+
+本地开发完成后的固定流程是：
+
+1. 从已同步的 `origin/main` 创建任务分支；AI Agent 默认使用 `codex/` 前缀。需要隔离目录时，按
+   [Git Worktree 生命周期与清理](worktrees.md)创建并记录分支、基线和绝对路径；
+2. 只在任务分支实施、提交并完成与改动风险相称的本地门禁，不把未通过验证的提交移入本地 `main`；
+3. 使用 `git push -u origin <任务分支>` 推送任务分支，然后创建以 `main` 为 base 的 PR，并向用户提供
+   PR 链接；
+4. 等待仓库要求的 Review 与 CI 终态，通过 PR 合并；不得以管理员绕过、force push 或临时关闭保护规则
+   代替正常合入；
+5. 合并后执行 `git fetch origin main`，确认任务提交是 `origin/main` 的祖先，再把“已推送到 main”作为
+   完成结果报告；本地主 checkout 只在此时按 fast-forward 同步到 `origin/main`；
+6. 使用 worktree 时，在远端合入和工作目录干净得到证明后，再按清理流程移除 worktree 与本地任务分支。
+
+若权限、Review、CI 或仓库规则阻止 PR 创建或合并，应保留已推送的任务分支并报告精确 blocker；直接推送
+`main` 不是回退路径。
 
 ## 开发版：只使用 `pnpm dev`
 

--- a/docs/development/worktrees.md
+++ b/docs/development/worktrees.md
@@ -1,7 +1,7 @@
 ---
 document_type: development-guide
 authority: local-worktree-lifecycle
-last_updated: 2026-08-16
+last_updated: 2026-08-24
 ---
 
 # Git Worktree 生命周期与清理
@@ -79,10 +79,12 @@ Next: <next concrete step>
 主线，则在创建编码 worktree 前完成：
 
 1. 在干净的主 checkout 确认并按仓库规则同步 `main`；不覆盖其它未提交工作；
-2. 只更新本次工作需要的治理文档并运行对应文档门禁；
-3. 把治理文档作为独立提交提交到 `main`，按当前工作要求推送；
-4. 记录该提交的不可变 SHA，并从它创建或更新编码 worktree；
-5. 在交接的 `Governance` 字段记录该 SHA。
+2. 从 `origin/main` 创建独立治理分支，只更新本次工作需要的治理文档并运行对应文档门禁；
+3. 把治理文档作为独立提交推送到治理分支，并按
+   [本地开发提交与主线合入流程](local-workflow.md#代码提交与主线合入统一使用-pr)创建 PR；不得先尝试
+   直接推送 `main`；
+4. 等待治理 PR 合入，重新获取 `origin/main`，记录合入后的不可变 SHA，并从它创建或更新编码 worktree；
+5. 在交接的 `Governance` 字段记录该 SHA 和治理 PR。
 
 编码 worktree 已创建但尚未编码时，先快进或按仓库规则更新到该治理提交。已有代码提交或未提交改动时，
 不得自动 reset、rebase 或强制移动分支；应按仓库规则合入治理提交。无权提交主线或主 checkout 无法安全


### PR DESCRIPTION
## Summary
- define PR as the only normal path for local code, documentation, and configuration changes to reach main
- interpret requests to push to main as delivery through a PR
- prohibit trying a direct main push or fast-forwarding local main before PR merge
- align governance-first worktree instructions with the same flow

## Validation
- pnpm docs:test
- pnpm docs:check
- DOCS_BASE_REF=origin/main pnpm docs:check:ci