### PR TITLE
fix(renderer): soften inline code surfaces

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -153,6 +153,8 @@ only boundary of an input or control.
   accent. Semantic danger or attention may replace the accent when meaning requires it.
 - **Evidence:** uses the dedicated evidence and diff tokens, monospaced type where appropriate, and
   structural `+`/`-`, line numbers or labels in addition to color.
+- **Inline code:** narrative inline code uses its dedicated quiet canvas with `0 2px` padding and a
+  `3px` radius; fenced code and bounded evidence surfaces keep the stronger evidence canvas.
 - **Identity:** portraits and eight stable identity tokens are a narrow exception to the neutral
   workspace. Identity treatments do not spread into background decoration.
 

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -87,6 +87,7 @@
   --shadow-dialog: var(--shadow-float);
   --shadow-card: none;
   --approval-line: #d8bd87;
+  --inline-code-canvas: #eef2f5;
   --evidence-canvas: #f4f6f3;
   --evidence-surface: #ffffff;
   --evidence-ink: #252a36;
@@ -197,6 +198,7 @@
   --overlay: rgba(0, 0, 0, 0.58);
   --shadow-float: 0 22px 64px rgba(0, 0, 0, 0.42);
   --approval-line: #8f7447;
+  --inline-code-canvas: #1d252b;
   --evidence-canvas: #12191d;
   --evidence-surface: #171f24;
   --evidence-ink: #dce4e9;
@@ -2021,7 +2023,7 @@ button.camp-world-map-live-caption { cursor: pointer; font: inherit; }
 .safe-markdown li + li { margin-top: 3px; }
 .safe-markdown blockquote { margin: 8px 0; padding: 3px 10px; border-left: 3px solid var(--line-strong); color: var(--muted); }
 .safe-markdown pre { max-width: 100%; margin: 9px 0; overflow: auto; padding: 9px 10px; border: 1px solid var(--evidence-line); border-radius: 6px; color: var(--evidence-ink); background: var(--evidence-canvas); font: 11px/1.55 ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre; }
-.safe-markdown code { padding: 1px 4px; border-radius: 4px; color: var(--evidence-ink); background: var(--evidence-canvas); font: .9em/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
+.safe-markdown code { padding: 0 2px; border-radius: 3px; color: var(--evidence-ink); background: var(--inline-code-canvas); font: .9em/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
 .safe-markdown pre code { padding: 0; background: transparent; font-size: inherit; }
 .safe-markdown table { display: block; width: 100%; margin: 9px 0; overflow-x: auto; border-spacing: 0; border-collapse: collapse; font-size: 11px; }
 .safe-markdown th, .safe-markdown td { padding: 6px 8px; border: 1px solid var(--line); text-align: left; vertical-align: top; }

--- a/apps/desktop/src/renderer/src/theme-tokens.test.ts
+++ b/apps/desktop/src/renderer/src/theme-tokens.test.ts
@@ -52,6 +52,7 @@ const requiredTokens = [
   '--neutral-soft',
   '--focus',
   '--overlay',
+  '--inline-code-canvas',
   '--evidence-canvas',
   '--evidence-surface',
   '--evidence-ink',
@@ -99,6 +100,7 @@ function expectTextContrast(tokens: Record<string, string>): void {
     ['--danger', '--danger-soft'],
     ['--info', '--info-soft'],
     ['--neutral', '--neutral-soft'],
+    ['--evidence-ink', '--inline-code-canvas'],
     ['--evidence-ink', '--evidence-surface'],
     ['--evidence-muted', '--evidence-surface'],
     ['--diff-add', '--diff-add-soft'],
@@ -167,6 +169,7 @@ describe('Porcelain Day + Steel Night theme tokens', () => {
     expect(day['--rail-line']).toBe('#dadde0')
     expect(day['--rail-logo']).toBe('#526f88')
     expect(day['--mention-ink']).toBe('#2f61c8')
+    expect(day['--inline-code-canvas']).toBe('#eef2f5')
     expect(contrast(day['--mention-ink'], day['--surface'])).toBeGreaterThanOrEqual(4.5)
     expect(css).toContain('.camp-workspace { background: var(--conversation-surface); }')
     expect(css).toContain('border-left: 1px solid var(--conversation-inspector-line)')
@@ -191,6 +194,7 @@ describe('Porcelain Day + Steel Night theme tokens', () => {
     expect(night['--brand']).toBe('#7897ae')
     expect(night['--brand-soft']).toBe('#22303a')
     expect(night['--mention-ink']).toBe('#9cc7e2')
+    expect(night['--inline-code-canvas']).toBe('#1d252b')
     expect(night['--success']).not.toBe(night['--brand'])
     expect(night['--attention']).not.toBe(night['--brand'])
     expect(night['--danger']).not.toBe(night['--brand'])
@@ -268,6 +272,9 @@ describe('Porcelain Day + Steel Night theme tokens', () => {
     expect(css).toContain('.conversation-bubble:is(.user, .agent):hover::before')
     expect(css).toMatch(/\.message-body\s*\{[^}]*position: relative[^}]*padding-right: 76px/)
     expect(css).toMatch(/\.message-surface\s*\{[^}]*position: static/)
+    expect(css).toMatch(/\.safe-markdown code\s*\{[^}]*padding:\s*0 2px[^}]*border-radius:\s*3px[^}]*background:\s*var\(--inline-code-canvas\)/)
+    expect(css).toMatch(/\.safe-markdown pre\s*\{[^}]*background:\s*var\(--evidence-canvas\)/)
+    expect(css).toMatch(/\.safe-markdown pre code\s*\{[^}]*padding:\s*0[^}]*background:\s*transparent/)
     expect(css).toContain('.conversation-bubble:hover .message-copy-button')
     expect(css).toContain('.conversation-bubble:hover .message-reply-button')
     expect(css).toContain('.composer-box:focus-within')

--- a/docs/ui/themes/porcelain-day.md
+++ b/docs/ui/themes/porcelain-day.md
@@ -4,7 +4,7 @@ authority: renderer-theme
 status: accepted
 theme_id: porcelain-day
 mode: light
-last_updated: 2026-08-18
+last_updated: 2026-08-24
 ---
 
 # Porcelain Day
@@ -119,6 +119,7 @@ Light. `color-scheme: light`.
 
 | Token | Value |
 |---|---:|
+| `--inline-code-canvas` | `#eef2f5` |
 | `--evidence-canvas` | `#f4f6f3` |
 | `--evidence-surface` | `#ffffff` |
 | `--evidence-ink` | `#252a36` |
@@ -159,6 +160,8 @@ Light. `color-scheme: light`.
 - `danger` is for stop, permanent deletion, forgetting and confirmed failure—not ordinary disabled state.
 - Stable IDs map to `--identity-1..8`; identity color never signals state or permission.
 - Evidence never inherits brand gradients, identity fills or portraits.
+- Narrative inline code uses the quieter `--inline-code-canvas`; fenced code and bounded evidence
+  surfaces continue to use `--evidence-canvas`.
 
 ## Contrast requirements
 

--- a/docs/ui/themes/steel-night.md
+++ b/docs/ui/themes/steel-night.md
@@ -4,7 +4,7 @@ authority: renderer-theme
 status: accepted
 theme_id: steel-night
 mode: dark
-last_updated: 2026-08-18
+last_updated: 2026-08-24
 ---
 
 # Steel Night
@@ -119,6 +119,7 @@ Dark. `color-scheme: dark`.
 
 | Token | Value |
 |---|---:|
+| `--inline-code-canvas` | `#1d252b` |
 | `--evidence-canvas` | `#12191d` |
 | `--evidence-surface` | `#171f24` |
 | `--evidence-ink` | `#dce4e9` |
@@ -158,7 +159,9 @@ Night inherits the shared non-color structure from `:root`; aliases resolve agai
 ## Brand, semantic, identity, and evidence color rules
 
 The same semantic separation as Day applies. Brightened identity colors retain stable ID mapping;
-they do not become statuses. Evidence and diffs remain neutral and structurally labeled.
+they do not become statuses. Evidence and diffs remain neutral and structurally labeled. Narrative
+inline code uses the quieter `--inline-code-canvas`; fenced code and bounded evidence surfaces
+continue to use `--evidence-canvas`.
 
 ## Contrast requirements
 


### PR DESCRIPTION
## Summary

- give narrative inline code a dedicated Steel Mist canvas in Porcelain Day and Steel Night
- tighten inline code padding and radius while keeping fenced code on the evidence canvas
- document and contract-test the new theme token

## Verification

- pnpm exec vitest run apps/desktop/src/renderer/src/theme-tokens.test.ts
- pnpm typecheck
- pnpm test
- pnpm build:desktop
- Impeccable detector run; only pre-existing repository warnings found