### PR TITLE
feat: ship Rovai AI 0.0.2 app updates

### DIFF
--- a/.github/workflows/macos-signed-build.yml
+++ b/.github/workflows/macos-signed-build.yml
@@ -135,10 +135,10 @@ jobs:
           printf 'CSC_NAME=%s\n' 'Rovai Release Signing' >> "$GITHUB_ENV"
           printf 'CSC_KEYCHAIN=%s\n' "$KEYCHAIN_PATH" >> "$GITHUB_ENV"
 
-      - name: Build signed DMG
+      - name: Build signed release artifacts
         run: ${{ matrix.build-command }}
 
-      - name: Verify signed DMG
+      - name: Verify signed release artifacts
         run: node scripts/verify-macos-release.mjs ${{ matrix.arch }}
 
       - name: Clean sensitive signing material
@@ -183,6 +183,66 @@ jobs:
           name: ${{ matrix.artifact-name }}
           path: |
             dist/*.dmg
+            dist/*.zip
+            dist/latest-mac.yml
             dist/signing-report-*.txt
+          if-no-files-found: error
+          retention-days: 14
+
+  assemble:
+    needs: build
+    name: Assemble macOS release bundle
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 26
+
+      - name: Install pnpm
+        run: npm install --global pnpm@11.20.0
+
+      - name: Install manifest dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Download arm64 artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: rovai-macos-arm64-signed
+          path: dist/intermediate/arm64
+
+      - name: Download x64 artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: rovai-macos-x64-signed
+          path: dist/intermediate/x64
+
+      - name: Assemble architecture-complete update manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist/release
+          cp dist/intermediate/arm64/*.dmg dist/release/
+          cp dist/intermediate/arm64/*.zip dist/release/
+          cp dist/intermediate/arm64/signing-report-*.txt dist/release/
+          cp dist/intermediate/x64/*.dmg dist/release/
+          cp dist/intermediate/x64/*.zip dist/release/
+          cp dist/intermediate/x64/signing-report-*.txt dist/release/
+          node scripts/merge-macos-update-info.mjs \
+            dist/release/latest-mac.yml \
+            dist/intermediate/arm64/latest-mac.yml \
+            dist/intermediate/x64/latest-mac.yml
+
+      - name: Upload complete signed macOS release
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: rovai-macos-signed
+          path: dist/release/*
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -73,8 +73,9 @@ jobs:
         with:
           name: rovai-windows-x64-unsigned-${{ github.sha }}
           path: |
-            dist/Rovai-ai-*-x64.exe
-            dist/Rovai-ai-*-x64.exe.blockmap
+            dist/Rovai-AI-*-x64.exe
+            dist/Rovai-AI-*-x64.exe.blockmap
+            dist/latest.yml
             dist/windows-release-manifest.json
             dist/windows-verification-report.txt
             dist/win-unpacked/**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "rovai-core"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/rovai-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -49,9 +49,10 @@ coordinates them while preserving which facts came from Rovai Core and which cam
 
 ## Brand Commitments
 
-The product name is “Rovai AI” in application UI and “Rovai-ai” where existing package/repository
-naming requires it. Copy is calm, direct and evidence-first. Uncertainty, partial coverage and the
-next available action are stated plainly rather than hidden behind optimistic status language.
+The product name, macOS application bundle, macOS executable and Helper names are “Rovai AI”.
+“Rovai-ai” remains only where legacy data, the Windows executable or the repository slug requires it.
+Copy is calm, direct and evidence-first. Uncertainty, partial coverage and the next available action
+are stated plainly rather than hidden behind optimistic status language.
 
 ## Evidence on Hand
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,11 @@ Download the installer for your device from
 The Windows x64 installer is currently unsigned. Windows SmartScreen may show an unknown publisher
 warning. Download the installer only from the official Rovai AI GitHub Release.
 
+Rovai AI v0.0.2 adds manual “检查更新” in Settings → About & Updates. A found update downloads
+immediately, shows progress, and installs only after “安装并重启” is selected. The published v0.0.1
+does not contain the updater metadata or install flow, so moving from v0.0.1 to v0.0.2 remains a
+one-time manual installer upgrade; in-app upgrading starts with releases after v0.0.2.
+
 #### Run from source (for developers)
 
 For source installation, environment setup, isolated data directories, and build instructions,

--- a/apps/desktop/.impeccable/surfaces/settings-workspace.md
+++ b/apps/desktop/.impeccable/surfaces/settings-workspace.md
@@ -162,19 +162,21 @@ Coverage, clean-break and freshness semantics local to that page.
 
 About & Updates belongs to the Support group and extends the same borderless `1040px` settings track,
 two-column section rhythm and quiet raised rows used by reviewed settings pages. The first viewport
-shows the installed Rovai AI version and one primary “检查更新” action. It is an inspect-and-handoff
-surface, not an updater dashboard or installation wizard.
+shows the installed Rovai AI version and one primary action. It is a compact one-click updater surface,
+not an updater dashboard or installation wizard.
 
-Checking is always a user action. One click requests the latest published full release from the public
-official `murray17/rovai-ai` GitHub Releases API, compares its semantic version with the packaged App
-version and presents a bounded plain-text Release Notes summary. When a trusted release page is
-available, a secondary action opens that exact page in the system browser. The Renderer never accepts
-or renders remote HTML and never receives an arbitrary URL.
+Checking is always a user action. One click asks the packaged Main-process updater for the latest stable
+release from the public official `murray17/rovai-ai` GitHub release channel. When a newer release exists,
+download begins immediately and the same bounded row shows determinate percent, transferred/total bytes
+and speed without blocking navigation or ordinary App use. Renderer receives only the typed update
+snapshot; it never receives a remote URL, HTML, local installer path or updater credential.
 
-The page keeps the installed version visible through idle, checking, up-to-date, update-available,
-no-release, network failure, GitHub unavailable, rate-limited and invalid-release states. A failure
-keeps the manual action recoverable and never retries automatically. This first version has no
-background request, timer, GitHub token, automatic download, overwrite, restart or `electron-updater`.
+The page keeps the installed version visible through idle, checking, downloading, up-to-date,
+ready-to-install, installing and recoverable check/download/install failure states. Download completion
+changes the primary action to “安装并重启”; installation is never triggered by checking alone. There is
+no background request, timer, GitHub token, pause queue, release-notes reader or automatic retry. Main
+uses the existing controlled-shutdown boundary before the updater-owned restart; Renderer does not add
+task waiting, hash, signature or shutdown controls to this surface.
 
 ## Inheritance and hard boundaries
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rovai/desktop",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "license": "MIT",
   "type": "module"

--- a/apps/desktop/src/main/app-updates.test.ts
+++ b/apps/desktop/src/main/app-updates.test.ts
@@ -1,164 +1,200 @@
+import { EventEmitter } from 'node:events'
 import { describe, expect, it, vi } from 'vitest'
 import {
   AppUpdatesService,
-  compareVersions,
-  parseVersion,
-  summarizeReleaseNotes
+  type DesktopAutoUpdater
 } from './app-updates'
 
-const RELEASE_URL = 'https://github.com/murray17/rovai-ai/releases/tag/v1.3.0'
-const NOW = new Date('2026-08-23T08:00:00.000Z')
+const NOW = new Date('2026-08-24T08:00:00.000Z')
 
-function release(overrides: Record<string, unknown> = {}): Record<string, unknown> {
-  return {
-    tag_name: 'v1.3.0',
-    name: 'Rovai AI 1.3.0',
-    body: '## 新功能\n- 增加关于与更新页面\n- 改善启动体验',
-    html_url: RELEASE_URL,
-    published_at: '2026-08-22T09:30:00Z',
-    draft: false,
-    prerelease: false,
-    ...overrides
-  }
+class FakeUpdater extends EventEmitter {
+  autoDownload = false
+  autoInstallOnAppQuit = true
+  autoRunAppAfterInstall = false
+  allowPrerelease = true
+  checkForUpdates = vi.fn<() => Promise<unknown>>(async () => ({}))
+  quitAndInstall = vi.fn<(isSilent?: boolean, isForceRunAfter?: boolean) => void>()
 }
 
-describe('app update version comparison', () => {
-  it('compares normalized stable and prerelease versions', () => {
-    expect(parseVersion('v1.2')).toMatchObject({ normalized: '1.2.0', core: [1, 2, 0] })
-    expect(compareVersions(parseVersion('1.2.1')!, parseVersion('1.2.0')!)).toBeGreaterThan(0)
-    expect(compareVersions(parseVersion('1.2.0')!, parseVersion('1.2.0-rc.2')!)).toBeGreaterThan(0)
-    expect(compareVersions(parseVersion('1.2.0-rc.10')!, parseVersion('1.2.0-rc.2')!)).toBeGreaterThan(0)
-    expect(parseVersion('1.2.3.4')).toBeNull()
+function service(updater: FakeUpdater, isPackaged = true): AppUpdatesService {
+  return new AppUpdatesService({
+    currentVersion: () => '0.0.2',
+    isPackaged: () => isPackaged,
+    updater: updater as unknown as DesktopAutoUpdater,
+    now: () => NOW
   })
-
-  it('turns markdown release notes into a bounded plain-text summary', () => {
-    expect(summarizeReleaseNotes(
-      '## 更新内容\n- [查看详情](https://example.com)\n![截图](https://example.com/a.png)\n```sh\nrm -rf /\n```'
-    )).toBe('更新内容\n查看详情\n截图')
-    expect(summarizeReleaseNotes(' '.repeat(20))).toBeNull()
-  })
-})
+}
 
 describe('AppUpdatesService', () => {
-  it('starts idle and checks the unauthenticated official latest-release endpoint only on demand', async () => {
-    const openExternal = vi.fn(async () => undefined)
-    const fetchImpl = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
-      const headers = new Headers(init?.headers)
-      expect(headers.get('accept')).toBe('application/vnd.github+json')
-      expect(headers.get('x-github-api-version')).toBe('2026-03-10')
-      expect(headers.get('user-agent')).toBe('Rovai-AI/1.2.0')
-      expect(headers.has('authorization')).toBe(false)
-      return new Response(JSON.stringify(release()), {
-        status: 200,
-        headers: { etag: '"release-v1.3.0"' }
-      })
-    })
-    const service = new AppUpdatesService({
-      currentVersion: () => '1.2.0',
-      fetchImpl,
-      openExternal,
-      now: () => NOW
-    })
+  it('keeps checks manual while configuring found updates to download immediately', () => {
+    const updater = new FakeUpdater()
+    const updates = service(updater)
 
-    expect(service.get()).toMatchObject({ status: 'idle', currentVersion: '1.2.0' })
-    expect(fetchImpl).not.toHaveBeenCalled()
-
-    await expect(service.check()).resolves.toEqual({
-      currentVersion: '1.2.0',
-      status: 'update_available',
-      latestVersion: '1.3.0',
-      releaseName: 'Rovai AI 1.3.0',
-      releaseNotesSummary: '新功能\n增加关于与更新页面\n改善启动体验',
-      publishedAt: '2026-08-22T09:30:00.000Z',
-      releasePageAvailable: true,
-      checkedAt: NOW.toISOString(),
-      failureReason: null,
-      retryAt: null
+    expect(updates.get()).toEqual({
+      currentVersion: '0.0.2',
+      status: 'idle',
+      latestVersion: null,
+      checkedAt: null,
+      downloadPercent: null,
+      transferredBytes: null,
+      totalBytes: null,
+      bytesPerSecond: null,
+      failureReason: null
     })
-    expect(fetchImpl).toHaveBeenCalledWith(
-      'https://api.github.com/repos/murray17/rovai-ai/releases/latest',
-      expect.objectContaining({ method: 'GET' })
-    )
-    await expect(service.openReleasePage()).resolves.toBe(true)
-    expect(openExternal).toHaveBeenCalledWith(RELEASE_URL)
+    expect(updater.checkForUpdates).not.toHaveBeenCalled()
+    expect(updater.autoDownload).toBe(true)
+    expect(updater.autoInstallOnAppQuit).toBe(false)
+    expect(updater.autoRunAppAfterInstall).toBe(true)
+    expect(updater.allowPrerelease).toBe(false)
   })
 
-  it('reports up-to-date, no-release, and rate-limit outcomes without retrying', async () => {
-    const upToDate = new AppUpdatesService({
-      currentVersion: () => '1.3.0',
-      fetchImpl: async () => new Response(JSON.stringify(release()), { status: 200 }),
-      openExternal: async () => undefined,
-      now: () => NOW
+  it('publishes checking, download progress, and ready-to-install snapshots', async () => {
+    const updater = new FakeUpdater()
+    const updates = service(updater)
+    const observed: string[] = []
+    updates.onChanged((snapshot) => observed.push(snapshot.status))
+    updater.checkForUpdates.mockImplementation(async () => {
+      updater.emit('checking-for-update')
+      updater.emit('update-available', { version: '0.0.3' })
+      return {}
     })
-    await expect(upToDate.check()).resolves.toMatchObject({ status: 'up_to_date' })
 
-    const noReleaseFetch = vi.fn(async () => new Response('', { status: 404 }))
-    const noRelease = new AppUpdatesService({
-      currentVersion: () => '1.2.0',
-      fetchImpl: noReleaseFetch,
-      openExternal: async () => undefined,
-      now: () => NOW
+    await expect(updates.check()).resolves.toMatchObject({
+      status: 'downloading',
+      latestVersion: '0.0.3',
+      downloadPercent: 0
     })
-    await expect(noRelease.check()).resolves.toMatchObject({
-      status: 'no_release',
-      releasePageAvailable: false
+    updater.emit('download-progress', {
+      percent: 42.34,
+      transferred: 42_340_000,
+      total: 100_000_000,
+      bytesPerSecond: 5_000_000
     })
-    expect(noReleaseFetch).toHaveBeenCalledTimes(1)
+    expect(updates.get()).toMatchObject({
+      status: 'downloading',
+      downloadPercent: 42.3,
+      transferredBytes: 42_340_000,
+      totalBytes: 100_000_000,
+      bytesPerSecond: 5_000_000
+    })
+    updater.emit('update-downloaded', { version: '0.0.3' })
+    expect(updates.get()).toMatchObject({
+      status: 'ready_to_install',
+      latestVersion: '0.0.3',
+      downloadPercent: 100,
+      transferredBytes: 100_000_000
+    })
+    expect(observed).toEqual([
+      'checking',
+      'downloading',
+      'downloading',
+      'ready_to_install'
+    ])
+  })
 
-    const rateLimitedFetch = vi.fn(async () => new Response('', {
-      status: 429,
-      headers: { 'retry-after': '90' }
+  it('reports the current version as up to date without starting a download', async () => {
+    const updater = new FakeUpdater()
+    const updates = service(updater)
+    updater.checkForUpdates.mockImplementation(async () => {
+      updater.emit('update-not-available', { version: '0.0.2' })
+      return {}
+    })
+
+    await expect(updates.check()).resolves.toMatchObject({
+      status: 'up_to_date',
+      latestVersion: '0.0.2',
+      downloadPercent: null
+    })
+  })
+
+  it('keeps unpackaged, network, invalid-release, and download failures recoverable', async () => {
+    const unpackagedUpdater = new FakeUpdater()
+    await expect(service(unpackagedUpdater, false).check()).resolves.toMatchObject({
+      status: 'check_failed',
+      failureReason: 'updater_unavailable'
+    })
+    expect(unpackagedUpdater.checkForUpdates).not.toHaveBeenCalled()
+
+    const networkUpdater = new FakeUpdater()
+    networkUpdater.checkForUpdates.mockRejectedValue(new Error('connect ETIMEDOUT'))
+    await expect(service(networkUpdater).check()).resolves.toMatchObject({
+      status: 'check_failed',
+      failureReason: 'network'
+    })
+
+    const invalidUpdater = new FakeUpdater()
+    invalidUpdater.checkForUpdates.mockImplementation(async () => {
+      invalidUpdater.emit('update-available', { version: '<script>' })
+      return {}
+    })
+    await expect(service(invalidUpdater).check()).resolves.toMatchObject({
+      status: 'check_failed',
+      failureReason: 'invalid_release'
+    })
+
+    const downloadUpdater = new FakeUpdater()
+    downloadUpdater.checkForUpdates.mockImplementation(async () => {
+      downloadUpdater.emit('update-available', { version: '0.0.3' })
+      return {}
+    })
+    const downloading = service(downloadUpdater)
+    await downloading.check()
+    downloadUpdater.emit('error', new Error('download connection reset'))
+    expect(downloading.get()).toMatchObject({
+      status: 'download_failed',
+      failureReason: 'download_failed',
+      latestVersion: '0.0.3'
+    })
+  })
+
+  it('coalesces simultaneous checks', async () => {
+    const updater = new FakeUpdater()
+    let resolveCheck!: (value: unknown) => void
+    updater.checkForUpdates.mockImplementation(() => new Promise((resolve) => {
+      resolveCheck = resolve
     }))
-    const rateLimited = new AppUpdatesService({
-      currentVersion: () => '1.2.0',
-      fetchImpl: rateLimitedFetch,
-      openExternal: async () => undefined,
-      now: () => NOW
-    })
-    await expect(rateLimited.check()).resolves.toMatchObject({
-      status: 'check_failed',
-      failureReason: 'rate_limited',
-      retryAt: '2026-08-23T08:01:30.000Z'
-    })
-    expect(rateLimitedFetch).toHaveBeenCalledTimes(1)
-  })
+    const updates = service(updater)
 
-  it('rejects untrusted release pages and never opens them', async () => {
-    const openExternal = vi.fn(async () => undefined)
-    const service = new AppUpdatesService({
-      currentVersion: () => '1.2.0',
-      fetchImpl: async () => new Response(JSON.stringify(release({
-        html_url: 'https://example.com/murray17/rovai-ai/releases/tag/v1.3.0'
-      })), { status: 200 }),
-      openExternal,
-      now: () => NOW
-    })
-
-    await expect(service.check()).resolves.toMatchObject({
-      status: 'check_failed',
-      failureReason: 'invalid_release',
-      releasePageAvailable: false
-    })
-    await expect(service.openReleasePage()).resolves.toBe(false)
-    expect(openExternal).not.toHaveBeenCalled()
-  })
-
-  it('coalesces simultaneous manual checks into one GitHub request', async () => {
-    let resolveResponse!: (response: Response) => void
-    const pending = new Promise<Response>((resolve) => { resolveResponse = resolve })
-    const fetchImpl = vi.fn(() => pending)
-    const service = new AppUpdatesService({
-      currentVersion: () => '1.2.0',
-      fetchImpl,
-      openExternal: async () => undefined,
-      now: () => NOW
-    })
-
-    const first = service.check()
-    const second = service.check()
-    expect(fetchImpl).toHaveBeenCalledTimes(1)
-    resolveResponse(new Response(JSON.stringify(release()), { status: 200 }))
+    const first = updates.check()
+    const second = updates.check()
+    expect(updater.checkForUpdates).toHaveBeenCalledTimes(1)
+    updater.emit('update-not-available', { version: '0.0.2' })
+    resolveCheck({})
     await expect(Promise.all([first, second])).resolves.toHaveLength(2)
-    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(updater.checkForUpdates).toHaveBeenCalledTimes(1)
+  })
+
+  it('only installs a fully downloaded update and keeps installation retryable', async () => {
+    const updater = new FakeUpdater()
+    const updates = service(updater)
+    expect(updates.install()).toBe(false)
+
+    updater.checkForUpdates.mockImplementation(async () => {
+      updater.emit('update-available', { version: '0.0.3' })
+      return {}
+    })
+    await updates.check()
+    updater.emit('update-downloaded', { version: '0.0.3' })
+    expect(updates.install()).toBe(true)
+    expect(updater.quitAndInstall).toHaveBeenCalledWith(true, true)
+    expect(updates.get().status).toBe('installing')
+    updater.emit('error', new Error('native installer failed'))
+    expect(updates.get()).toMatchObject({
+      status: 'install_failed',
+      failureReason: 'install_failed'
+    })
+
+    const failingUpdater = new FakeUpdater()
+    failingUpdater.quitAndInstall.mockImplementation(() => {
+      throw new Error('installer unavailable')
+    })
+    const failing = service(failingUpdater)
+    failingUpdater.emit('update-available', { version: '0.0.3' })
+    failingUpdater.emit('update-downloaded', { version: '0.0.3' })
+    expect(failing.install()).toBe(false)
+    expect(failing.get()).toMatchObject({
+      status: 'install_failed',
+      failureReason: 'install_failed'
+    })
   })
 })

--- a/apps/desktop/src/main/app-updates.ts
+++ b/apps/desktop/src/main/app-updates.ts
@@ -3,258 +3,216 @@ import type {
   AppUpdateSnapshot
 } from '@contracts'
 
-const GITHUB_API_VERSION = '2026-03-10'
-const LATEST_RELEASE_ENDPOINT = 'https://api.github.com/repos/murray17/rovai-ai/releases/latest'
-const RELEASE_PAGE_PREFIX = '/murray17/rovai-ai/releases/tag/'
-const MAX_RESPONSE_CHARACTERS = 512 * 1024
-const MAX_RELEASE_NAME_CHARACTERS = 160
-const MAX_RELEASE_NOTES_CHARACTERS = 720
-const DEFAULT_TIMEOUT_MS = 12_000
-
-type FetchImplementation = (input: string | URL | Request, init?: RequestInit) => Promise<Response>
-
-interface ParsedVersion {
-  normalized: string
-  core: [number, number, number]
-  prerelease: Array<number | string>
+interface DesktopUpdateInfo {
+  version: string
 }
 
-interface GitHubReleasePayload {
-  tagName: string
-  name: string | null
-  body: string | null
-  htmlUrl: string
-  publishedAt: string | null
-  draft: boolean
-  prerelease: boolean
+interface DesktopDownloadProgress {
+  percent: number
+  transferred: number
+  total: number
+  bytesPerSecond: number
+}
+
+export interface DesktopAutoUpdater {
+  autoDownload: boolean
+  autoInstallOnAppQuit: boolean
+  autoRunAppAfterInstall: boolean
+  allowPrerelease: boolean
+  on(event: 'checking-for-update', listener: () => void): this
+  on(event: 'update-available', listener: (info: DesktopUpdateInfo) => void): this
+  on(event: 'update-not-available', listener: (info: DesktopUpdateInfo) => void): this
+  on(event: 'download-progress', listener: (progress: DesktopDownloadProgress) => void): this
+  on(event: 'update-downloaded', listener: (info: DesktopUpdateInfo) => void): this
+  on(event: 'update-cancelled', listener: (info: DesktopUpdateInfo) => void): this
+  on(event: 'error', listener: (error: Error) => void): this
+  checkForUpdates(): Promise<unknown>
+  quitAndInstall(isSilent?: boolean, isForceRunAfter?: boolean): void
 }
 
 interface AppUpdatesServiceOptions {
   currentVersion(): string
-  openExternal(url: string): Promise<void>
-  fetchImpl?: FetchImplementation
+  isPackaged(): boolean
+  updater: DesktopAutoUpdater
   now?: () => Date
-  timeoutMs?: number
 }
+
+type SnapshotListener = (snapshot: AppUpdateSnapshot) => void
 
 export class AppUpdatesService {
   readonly #currentVersion: () => string
-  readonly #openExternal: (url: string) => Promise<void>
-  readonly #fetch: FetchImplementation
+  readonly #isPackaged: () => boolean
+  readonly #updater: DesktopAutoUpdater
   readonly #now: () => Date
-  readonly #timeoutMs: number
+  readonly #listeners = new Set<SnapshotListener>()
   #snapshot: AppUpdateSnapshot
-  #releasePageUrl: string | null = null
-  #etag: string | null = null
-  #inFlight: Promise<AppUpdateSnapshot> | null = null
+  #checkInFlight: Promise<AppUpdateSnapshot> | null = null
 
   constructor(options: AppUpdatesServiceOptions) {
     this.#currentVersion = options.currentVersion
-    this.#openExternal = options.openExternal
-    this.#fetch = options.fetchImpl ?? globalThis.fetch
+    this.#isPackaged = options.isPackaged
+    this.#updater = options.updater
     this.#now = options.now ?? (() => new Date())
-    this.#timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
     this.#snapshot = idleSnapshot(this.#currentVersion())
+
+    this.#updater.autoDownload = true
+    this.#updater.autoInstallOnAppQuit = false
+    this.#updater.autoRunAppAfterInstall = true
+    this.#updater.allowPrerelease = false
+
+    this.#updater.on('checking-for-update', () => {
+      if (this.#snapshot.status === 'checking') return
+      this.#replace({
+        ...idleSnapshot(this.#currentVersion()),
+        status: 'checking',
+        checkedAt: this.#now().toISOString()
+      })
+    })
+    this.#updater.on('update-available', (info) => {
+      const latestVersion = safeVersion(info.version)
+      if (!latestVersion) {
+        this.#acceptFailure('invalid_release')
+        return
+      }
+      this.#replace({
+        ...this.#snapshot,
+        currentVersion: this.#currentVersion(),
+        status: 'downloading',
+        latestVersion,
+        checkedAt: this.#snapshot.checkedAt ?? this.#now().toISOString(),
+        downloadPercent: 0,
+        transferredBytes: 0,
+        totalBytes: null,
+        bytesPerSecond: null,
+        failureReason: null
+      })
+    })
+    this.#updater.on('update-not-available', (info) => {
+      this.#replace({
+        ...idleSnapshot(this.#currentVersion()),
+        status: 'up_to_date',
+        latestVersion: safeVersion(info.version) ?? safeVersion(this.#currentVersion()),
+        checkedAt: this.#snapshot.checkedAt ?? this.#now().toISOString()
+      })
+    })
+    this.#updater.on('download-progress', (progress) => {
+      if (this.#snapshot.status !== 'downloading') return
+      this.#replace({
+        ...this.#snapshot,
+        downloadPercent: boundedPercent(progress.percent),
+        transferredBytes: boundedBytes(progress.transferred),
+        totalBytes: boundedBytes(progress.total),
+        bytesPerSecond: boundedBytes(progress.bytesPerSecond)
+      })
+    })
+    this.#updater.on('update-downloaded', (info) => {
+      const latestVersion = safeVersion(info.version) ?? this.#snapshot.latestVersion
+      if (!latestVersion) {
+        this.#acceptFailure('invalid_release')
+        return
+      }
+      this.#replace({
+        ...this.#snapshot,
+        status: 'ready_to_install',
+        latestVersion,
+        downloadPercent: 100,
+        transferredBytes: this.#snapshot.totalBytes ?? this.#snapshot.transferredBytes,
+        failureReason: null
+      })
+    })
+    this.#updater.on('update-cancelled', () => {
+      this.#acceptFailure('download_failed')
+    })
+    this.#updater.on('error', (error) => {
+      this.#acceptFailure(failureReason(error, this.#snapshot.status))
+    })
   }
 
   get(): AppUpdateSnapshot {
     return structuredClone(this.#snapshot)
   }
 
-  check(): Promise<AppUpdateSnapshot> {
-    if (this.#inFlight) return this.#inFlight.then((snapshot) => structuredClone(snapshot))
-    const request = this.#performCheck().finally(() => {
-      this.#inFlight = null
-    })
-    this.#inFlight = request
-    return request.then((snapshot) => structuredClone(snapshot))
+  onChanged(listener: SnapshotListener): () => void {
+    this.#listeners.add(listener)
+    return () => this.#listeners.delete(listener)
   }
 
-  async openReleasePage(): Promise<boolean> {
-    if (!this.#releasePageUrl) return false
-    await this.#openExternal(this.#releasePageUrl)
-    return true
+  check(): Promise<AppUpdateSnapshot> {
+    if (this.#checkInFlight) {
+      return this.#checkInFlight.then(() => this.get())
+    }
+    if (this.#snapshot.status === 'downloading'
+        || this.#snapshot.status === 'ready_to_install'
+        || this.#snapshot.status === 'installing') {
+      return Promise.resolve(this.get())
+    }
+    const request = this.#performCheck().finally(() => {
+      this.#checkInFlight = null
+    })
+    this.#checkInFlight = request
+    return request.then(() => this.get())
+  }
+
+  install(): boolean {
+    if (this.#snapshot.status !== 'ready_to_install'
+        && this.#snapshot.status !== 'install_failed') return false
+    this.#replace({
+      ...this.#snapshot,
+      status: 'installing',
+      failureReason: null
+    })
+    try {
+      this.#updater.quitAndInstall(true, true)
+      return true
+    } catch {
+      this.#replace({
+        ...this.#snapshot,
+        status: 'install_failed',
+        failureReason: 'install_failed'
+      })
+      return false
+    }
   }
 
   async #performCheck(): Promise<AppUpdateSnapshot> {
-    const currentVersion = this.#currentVersion()
-    const checkedAt = this.#now().toISOString()
-    const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), this.#timeoutMs)
-    timeout.unref?.()
-
-    let response: Response
+    this.#replace({
+      ...idleSnapshot(this.#currentVersion()),
+      status: 'checking',
+      checkedAt: this.#now().toISOString()
+    })
+    if (!this.#isPackaged()) {
+      this.#acceptFailure('updater_unavailable')
+      return this.get()
+    }
     try {
-      response = await this.#fetch(LATEST_RELEASE_ENDPOINT, {
-        method: 'GET',
-        headers: {
-          Accept: 'application/vnd.github+json',
-          'User-Agent': `Rovai-AI/${safeUserAgentVersion(currentVersion)}`,
-          'X-GitHub-Api-Version': GITHUB_API_VERSION,
-          ...(this.#etag ? { 'If-None-Match': this.#etag } : {})
-        },
-        redirect: 'follow',
-        signal: controller.signal
-      })
-    } catch {
-      return this.#acceptFailure(currentVersion, 'network', checkedAt)
-    } finally {
-      clearTimeout(timeout)
-    }
-
-    if (response.status === 304 && this.#releasePageUrl && hasRelease(this.#snapshot)) {
-      this.#snapshot = { ...this.#snapshot, checkedAt }
-      return this.#snapshot
-    }
-    if (response.status === 404) {
-      this.#releasePageUrl = null
-      this.#etag = null
-      this.#snapshot = {
-        ...idleSnapshot(currentVersion),
-        status: 'no_release',
-        checkedAt
+      const result = await this.#updater.checkForUpdates()
+      if (result === null && this.#snapshot.status === 'checking') {
+        this.#acceptFailure('updater_unavailable')
       }
-      return this.#snapshot
+    } catch (error) {
+      if (!isFailureStatus(this.#snapshot.status)) {
+        this.#acceptFailure(failureReason(error, this.#snapshot.status))
+      }
     }
-    if (response.status === 403 || response.status === 429) {
-      return this.#acceptFailure(
-        currentVersion,
-        'rate_limited',
-        checkedAt,
-        rateLimitRetryAt(response.headers, this.#now())
-      )
-    }
-    if (!response.ok) {
-      return this.#acceptFailure(currentVersion, 'github_unavailable', checkedAt)
-    }
-
-    const declaredLength = Number(response.headers.get('content-length'))
-    if (Number.isFinite(declaredLength) && declaredLength > MAX_RESPONSE_CHARACTERS) {
-      return this.#acceptFailure(currentVersion, 'invalid_release', checkedAt)
-    }
-
-    let raw: string
-    try {
-      raw = await response.text()
-    } catch {
-      return this.#acceptFailure(currentVersion, 'network', checkedAt)
-    }
-    if (raw.length > MAX_RESPONSE_CHARACTERS) {
-      return this.#acceptFailure(currentVersion, 'invalid_release', checkedAt)
-    }
-
-    let release: GitHubReleasePayload | null = null
-    try {
-      release = parseGitHubRelease(JSON.parse(raw) as unknown)
-    } catch {
-      release = null
-    }
-    const current = parseVersion(currentVersion)
-    const latest = release ? parseVersion(release.tagName) : null
-    const releasePageUrl = release ? trustedReleasePageUrl(release.htmlUrl) : null
-    if (!release || release.draft || release.prerelease || !current || !latest || !releasePageUrl) {
-      return this.#acceptFailure(currentVersion, 'invalid_release', checkedAt)
-    }
-
-    this.#etag = response.headers.get('etag')
-    this.#releasePageUrl = releasePageUrl
-    this.#snapshot = {
-      currentVersion,
-      status: compareVersions(latest, current) > 0 ? 'update_available' : 'up_to_date',
-      latestVersion: latest.normalized,
-      releaseName: boundedSingleLine(release.name ?? release.tagName, MAX_RELEASE_NAME_CHARACTERS),
-      releaseNotesSummary: summarizeReleaseNotes(release.body),
-      publishedAt: validIsoDate(release.publishedAt),
-      releasePageAvailable: true,
-      checkedAt,
-      failureReason: null,
-      retryAt: null
-    }
-    return this.#snapshot
+    return this.get()
   }
 
-  #acceptFailure(
-    currentVersion: string,
-    reason: AppUpdateFailureReason,
-    checkedAt: string,
-    retryAt: string | null = null
-  ): AppUpdateSnapshot {
-    this.#releasePageUrl = null
-    this.#etag = null
-    this.#snapshot = {
-      ...idleSnapshot(currentVersion),
-      status: 'check_failed',
-      checkedAt,
-      failureReason: reason,
-      retryAt
-    }
-    return this.#snapshot
+  #acceptFailure(reason: AppUpdateFailureReason): void {
+    const downloadFailure = reason === 'download_failed'
+    const installFailure = reason === 'install_failed'
+    this.#replace({
+      ...this.#snapshot,
+      currentVersion: this.#currentVersion(),
+      status: installFailure ? 'install_failed' : downloadFailure ? 'download_failed' : 'check_failed',
+      checkedAt: this.#snapshot.checkedAt ?? this.#now().toISOString(),
+      failureReason: reason
+    })
   }
-}
 
-export function parseVersion(value: string): ParsedVersion | null {
-  const match = value.trim().match(
-    /^v?(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?(?:\.(0|[1-9]\d*))?(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/
-  )
-  if (!match) return null
-  const core = [match[1], match[2] ?? '0', match[3] ?? '0'].map(Number)
-  if (core.some((part) => !Number.isSafeInteger(part))) return null
-  const prerelease = match[4]
-    ? match[4].split('.').map((identifier) => /^(0|[1-9]\d*)$/.test(identifier)
-        ? Number(identifier)
-        : identifier)
-    : []
-  return {
-    normalized: `${core.join('.')}${match[4] ? `-${match[4]}` : ''}`,
-    core: core as [number, number, number],
-    prerelease
+  #replace(snapshot: AppUpdateSnapshot): void {
+    this.#snapshot = snapshot
+    for (const listener of this.#listeners) listener(structuredClone(snapshot))
   }
-}
-
-export function compareVersions(left: ParsedVersion, right: ParsedVersion): number {
-  for (let index = 0; index < left.core.length; index += 1) {
-    if (left.core[index] !== right.core[index]) return left.core[index] - right.core[index]
-  }
-  if (left.prerelease.length === 0 || right.prerelease.length === 0) {
-    return left.prerelease.length === right.prerelease.length
-      ? 0
-      : left.prerelease.length === 0 ? 1 : -1
-  }
-  const length = Math.max(left.prerelease.length, right.prerelease.length)
-  for (let index = 0; index < length; index += 1) {
-    const leftPart = left.prerelease[index]
-    const rightPart = right.prerelease[index]
-    if (leftPart === undefined || rightPart === undefined) {
-      return leftPart === rightPart ? 0 : leftPart === undefined ? -1 : 1
-    }
-    if (leftPart === rightPart) continue
-    if (typeof leftPart === 'number' && typeof rightPart === 'number') return leftPart - rightPart
-    if (typeof leftPart === 'number') return -1
-    if (typeof rightPart === 'number') return 1
-    return leftPart.localeCompare(rightPart)
-  }
-  return 0
-}
-
-export function summarizeReleaseNotes(body: string | null): string | null {
-  if (!body?.trim()) return null
-  const lines = body
-    .replace(/<!--[\s\S]*?-->/g, ' ')
-    .replace(/```[\s\S]*?```/g, ' ')
-    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
-    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
-    .replace(/<[^>]{1,240}>/g, ' ')
-    .split(/\r?\n/)
-    .map((line) => line
-      .replace(/^\s{0,3}(?:#{1,6}|>|[-*+] |\d+[.)] )\s*/, '')
-      .replace(/^\s*\[[ xX]\]\s*/, '')
-      .replace(/[*_~`]/g, '')
-      .replace(/\s+/g, ' ')
-      .trim())
-    .filter(Boolean)
-    .slice(0, 6)
-  if (lines.length === 0) return null
-  return boundedMultiline(lines.join('\n'), MAX_RELEASE_NOTES_CHARACTERS)
 }
 
 function idleSnapshot(currentVersion: string): AppUpdateSnapshot {
@@ -262,95 +220,53 @@ function idleSnapshot(currentVersion: string): AppUpdateSnapshot {
     currentVersion,
     status: 'idle',
     latestVersion: null,
-    releaseName: null,
-    releaseNotesSummary: null,
-    publishedAt: null,
-    releasePageAvailable: false,
     checkedAt: null,
-    failureReason: null,
-    retryAt: null
+    downloadPercent: null,
+    transferredBytes: null,
+    totalBytes: null,
+    bytesPerSecond: null,
+    failureReason: null
   }
 }
 
-function hasRelease(snapshot: AppUpdateSnapshot): boolean {
-  return snapshot.releasePageAvailable
-    && snapshot.latestVersion !== null
-    && (snapshot.status === 'up_to_date' || snapshot.status === 'update_available')
+function safeVersion(value: string): string | null {
+  const match = value.trim().match(
+    /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/
+  )
+  if (!match) return null
+  return `${match[1]}.${match[2]}.${match[3]}${match[4] ?? ''}`
 }
 
-function parseGitHubRelease(value: unknown): GitHubReleasePayload | null {
-  if (!isRecord(value)) return null
-  if (typeof value.tag_name !== 'string'
-      || (typeof value.name !== 'string' && value.name !== null)
-      || (typeof value.body !== 'string' && value.body !== null)
-      || typeof value.html_url !== 'string'
-      || (typeof value.published_at !== 'string' && value.published_at !== null)
-      || typeof value.draft !== 'boolean'
-      || typeof value.prerelease !== 'boolean') return null
-  return {
-    tagName: value.tag_name,
-    name: value.name,
-    body: value.body,
-    htmlUrl: value.html_url,
-    publishedAt: value.published_at,
-    draft: value.draft,
-    prerelease: value.prerelease
+function boundedPercent(value: number): number {
+  if (!Number.isFinite(value)) return 0
+  return Math.min(100, Math.max(0, Math.round(value * 10) / 10))
+}
+
+function boundedBytes(value: number): number | null {
+  if (!Number.isFinite(value) || value < 0) return null
+  return Math.round(value)
+}
+
+function failureReason(
+  error: unknown,
+  status: AppUpdateSnapshot['status']
+): AppUpdateFailureReason {
+  if (status === 'downloading') return 'download_failed'
+  if (status === 'installing' || status === 'ready_to_install' || status === 'install_failed') {
+    return 'install_failed'
   }
-}
-
-function trustedReleasePageUrl(value: string): string | null {
-  try {
-    const url = new URL(value)
-    if (url.protocol !== 'https:'
-        || url.hostname.toLowerCase() !== 'github.com'
-        || url.port
-        || url.username
-        || url.password
-        || url.search
-        || url.hash
-        || !url.pathname.startsWith(RELEASE_PAGE_PREFIX)
-        || url.pathname.length <= RELEASE_PAGE_PREFIX.length) return null
-    return url.toString()
-  } catch {
-    return null
+  const message = error instanceof Error
+    ? `${error.name} ${error.message}`.toLowerCase()
+    : String(error).toLowerCase()
+  if (/enet|econn|etimedout|network|timeout|timed out|dns|socket|http status (?:408|429|5\d\d)/.test(message)) {
+    return 'network'
   }
-}
-
-function rateLimitRetryAt(headers: Headers, now: Date): string | null {
-  const retryAfter = headers.get('retry-after')
-  const retryAfterSeconds = retryAfter === null ? Number.NaN : Number(retryAfter)
-  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0) {
-    return new Date(now.getTime() + retryAfterSeconds * 1000).toISOString()
+  if (/latest-mac|ya?ml|sha512|checksum|signature|semver|release|provider|update info/.test(message)) {
+    return 'invalid_release'
   }
-  const resetSeconds = Number(headers.get('x-ratelimit-reset'))
-  if (Number.isFinite(resetSeconds) && resetSeconds > 0) {
-    return new Date(resetSeconds * 1000).toISOString()
-  }
-  return null
+  return 'updater_unavailable'
 }
 
-function validIsoDate(value: string | null): string | null {
-  if (!value) return null
-  const parsed = new Date(value)
-  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString()
-}
-
-function boundedSingleLine(value: string, maximum: number): string {
-  const normalized = value.replace(/\s+/g, ' ').trim()
-  return normalized.length <= maximum ? normalized : `${normalized.slice(0, maximum - 1).trimEnd()}…`
-}
-
-function boundedMultiline(value: string, maximum: number): string {
-  if (value.length <= maximum) return value
-  const candidate = value.slice(0, maximum - 1)
-  const boundary = Math.max(candidate.lastIndexOf(' '), candidate.lastIndexOf('\n'))
-  return `${candidate.slice(0, boundary > maximum * 0.72 ? boundary : candidate.length).trimEnd()}…`
-}
-
-function safeUserAgentVersion(value: string): string {
-  return value.replace(/[^0-9A-Za-z.+-]/g, '_').slice(0, 80) || 'unknown'
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+function isFailureStatus(status: AppUpdateSnapshot['status']): boolean {
+  return status === 'check_failed' || status === 'download_failed' || status === 'install_failed'
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -76,7 +76,7 @@ import {
   prepareWindowsDataRoot,
   resolveWindowsDataRoot
 } from './windows-data-root'
-import { AppUpdatesService } from './app-updates'
+import { AppUpdatesService, type DesktopAutoUpdater } from './app-updates'
 
 const mainStartupStartedAt = performance.now()
 console.info('[startup] stage=main_module_loaded elapsed_ms=0.0')
@@ -219,10 +219,7 @@ const isolatedAcceptanceInstance =
 const primaryInstance = isolatedAcceptanceInstance || app.requestSingleInstanceLock()
 if (!primaryInstance) app.quit()
 const core = new CoreClient(coreDataPath)
-const appUpdates = new AppUpdatesService({
-  currentVersion: () => app.getVersion(),
-  openExternal: (url) => shell.openExternal(url)
-})
+let appUpdates: AppUpdatesService | null = null
 let mainWindow: BrowserWindow | null = null
 let themePreference: ThemePreference = 'system'
 let appearanceFilePath = ''
@@ -238,6 +235,31 @@ let quitDrainStarted = false
 let quitDrainCompleted = false
 const desktopSessions = new DesktopSessionRegistry()
 const memberAvatars = new MemberAvatarAssetService(coreDataPath)
+
+async function initializeAppUpdates(): Promise<void> {
+  // electron-updater eagerly touches Electron's native autoUpdater while the
+  // module is evaluated. Loading it before app.whenReady() can stall packaged
+  // macOS startup before our main module runs, so keep it on the ready path.
+  const updaterModule = await import('electron-updater')
+  const autoUpdater = updaterModule.autoUpdater
+    ?? (updaterModule.default as { autoUpdater?: DesktopAutoUpdater } | undefined)?.autoUpdater
+  if (!autoUpdater) throw new Error('electron-updater did not expose autoUpdater')
+  const service = new AppUpdatesService({
+    currentVersion: () => app.getVersion(),
+    isPackaged: () => app.isPackaged,
+    updater: autoUpdater as unknown as DesktopAutoUpdater
+  })
+  service.onChanged((snapshot) => {
+    if (!mainWindow || mainWindow.isDestroyed() || mainWindow.webContents.isDestroyed()) return
+    mainWindow.webContents.send('rovai:app-updates-changed', snapshot)
+  })
+  appUpdates = service
+}
+
+function requireAppUpdates(): AppUpdatesService {
+  if (!appUpdates) throw new Error('Application updates are not ready')
+  return appUpdates
+}
 
 function removeRetiredLoginItemRegistration(): void {
   if (process.platform !== 'darwin' || !app.isPackaged) return
@@ -434,6 +456,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
   console.info(
     `[startup] stage=electron_ready elapsed_ms=${(performance.now() - mainStartupStartedAt).toFixed(1)}`
   )
+  await initializeAppUpdates()
   removeRetiredLoginItemRegistration()
   await deleteRetiredManagedDirectory(coreDataPath)
   const userDataPath = app.getPath('userData')
@@ -532,17 +555,17 @@ ipcMain.handle('rovai:appearance-set', async (_event, preference: unknown) => {
 
 ipcMain.handle('rovai:app-updates-get', (event) => {
   requireMainWindow(event.sender)
-  return appUpdates.get()
+  return requireAppUpdates().get()
 })
 
 ipcMain.handle('rovai:app-updates-check', (event) => {
   requireMainWindow(event.sender)
-  return appUpdates.check()
+  return requireAppUpdates().check()
 })
 
-ipcMain.handle('rovai:app-updates-open-release', (event) => {
+ipcMain.handle('rovai:app-updates-install', (event) => {
   requireMainWindow(event.sender)
-  return appUpdates.openReleasePage()
+  return requireAppUpdates().install()
 })
 
 ipcMain.handle('rovai:window-application-menu-popup', (event, input: unknown) => {

--- a/apps/desktop/src/main/package-metadata.test.ts
+++ b/apps/desktop/src/main/package-metadata.test.ts
@@ -8,9 +8,27 @@ const packageMetadata = JSON.parse(readFileSync(
 
 describe('desktop package metadata', () => {
   it('keeps the visible brand separate from Electron helper bundle identity', () => {
-    expect(packageMetadata.productName).toBe('Rovai-ai')
+    expect(packageMetadata.productName).toBe('Rovai AI')
+    expect(packageMetadata.version).toBe('0.0.2')
+    expect(packageMetadata.build.productName).toBe('Rovai AI')
+    expect(packageMetadata.build.mac.executableName).toBeUndefined()
+    expect(packageMetadata.build.win.executableName).toBe('Rovai-ai')
+    expect(packageMetadata.build.mac.artifactName).toBe('Rovai-AI-${version}-${arch}.${ext}')
+    expect(packageMetadata.build.win.artifactName).toBe('Rovai-AI-${version}-${arch}.${ext}')
     expect(packageMetadata.build.mac.extendInfo.CFBundleDisplayName).toBe('Rovai AI')
     expect(packageMetadata.build.mac.extendInfo.CFBundleName).toBeUndefined()
+  })
+
+  it('packages GitHub update metadata and a macOS zip beside the install DMG', () => {
+    expect(packageMetadata.build.publish).toEqual([{
+      provider: 'github',
+      owner: 'murray17',
+      repo: 'rovai-ai',
+      releaseType: 'release'
+    }])
+    expect(packageMetadata.build.mac.target).toEqual(['dir', 'dmg', 'zip'])
+    expect(packageMetadata.scripts['dist:mac:release:arm64']).toContain('--mac dmg zip')
+    expect(packageMetadata.scripts['dist:mac:release:x64']).toContain('--mac dmg zip')
   })
 
   it('does not build or package a native open-panel prewarmer', () => {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron'
 import type {
   AppearanceSnapshot,
+  AppUpdateSnapshot,
   CoreEvent,
   CoreMethod,
   ExecutionConsolePlacement,
@@ -55,8 +56,16 @@ const api: RovaiApi = {
     check() {
       return ipcRenderer.invoke('rovai:app-updates-check')
     },
-    openReleasePage() {
-      return ipcRenderer.invoke('rovai:app-updates-open-release')
+    install() {
+      return ipcRenderer.invoke('rovai:app-updates-install')
+    },
+    onChanged(listener: (snapshot: AppUpdateSnapshot) => void): () => void {
+      const handler = (
+        _event: Electron.IpcRendererEvent,
+        value: AppUpdateSnapshot
+      ): void => listener(value)
+      ipcRenderer.on('rovai:app-updates-changed', handler)
+      return () => ipcRenderer.removeListener('rovai:app-updates-changed', handler)
     }
   },
   desktopSession: {

--- a/apps/desktop/src/renderer/src/AboutUpdatesSettings.test.ts
+++ b/apps/desktop/src/renderer/src/AboutUpdatesSettings.test.ts
@@ -6,92 +6,121 @@ import { AboutUpdatesSettingsView } from './AboutUpdatesSettings'
 
 function snapshot(overrides: Partial<AppUpdateSnapshot> = {}): AppUpdateSnapshot {
   return {
-    currentVersion: '0.0.1',
+    currentVersion: '0.0.2',
     status: 'idle',
     latestVersion: null,
-    releaseName: null,
-    releaseNotesSummary: null,
-    publishedAt: null,
-    releasePageAvailable: false,
     checkedAt: null,
+    downloadPercent: null,
+    transferredBytes: null,
+    totalBytes: null,
+    bytesPerSecond: null,
     failureReason: null,
-    retryAt: null,
     ...overrides
   }
 }
 
 function render(value: AppUpdateSnapshot | null, options: {
   loading?: boolean
-  checking?: boolean
   loadError?: boolean
+  actionError?: boolean
 } = {}): string {
   return renderToStaticMarkup(createElement(AboutUpdatesSettingsView, {
     snapshot: value,
-    canCheck: true,
+    canUpdate: true,
     loading: options.loading ?? false,
-    checking: options.checking ?? false,
-    openingRelease: false,
     loadError: options.loadError ?? false,
-    openError: false,
+    actionError: options.actionError ?? false,
     onCheck: () => undefined,
-    onOpenRelease: () => undefined
+    onInstall: () => undefined
   }))
 }
 
 describe('AboutUpdatesSettingsView', () => {
-  it('shows the installed version and a manual-only check action', () => {
+  it('shows the installed 0.0.2 version and the one-click update path', () => {
     const markup = render(snapshot())
     expect(markup).toContain('<h1>关于与更新</h1>')
-    expect(markup).toContain('<code>v0.0.1</code>')
+    expect(markup).toContain('<code>v0.0.2</code>')
     expect(markup).toContain('>检查更新</button>')
-    expect(markup).toContain('点击“检查更新”后才会连接 GitHub')
-    expect(markup).toContain('不会下载或安装内容')
+    expect(markup).toContain('检查到新版本后会立即下载')
+    expect(markup).toContain('正式更新来自 Rovai AI 的 GitHub Release')
     expect(markup).not.toContain('Release Notes 摘要')
+    expect(markup).not.toContain('在 GitHub 查看')
   })
 
-  it('presents an available release summary and its GitHub handoff', () => {
+  it('keeps the check action visibly busy while checking', () => {
     const markup = render(snapshot({
-      status: 'update_available',
-      latestVersion: '0.2.0',
-      releaseName: 'Rovai AI 0.2.0',
-      releaseNotesSummary: '新增轻量更新入口。',
-      publishedAt: '2026-08-22T09:30:00.000Z',
-      releasePageAvailable: true,
-      checkedAt: '2026-08-23T08:00:00.000Z'
+      status: 'checking',
+      checkedAt: '2026-08-24T08:00:00.000Z'
     }))
-    expect(markup).toContain('发现新版本 v0.2.0')
-    expect(markup).toContain('Release Notes 摘要')
-    expect(markup).toContain('新增轻量更新入口。')
-    expect(markup).toContain('在 GitHub 查看此 Release')
-    expect(markup).toContain('>重新检查</button>')
-  })
-
-  it('keeps no-release and rate-limit failures recoverable', () => {
-    expect(render(snapshot({ status: 'no_release', checkedAt: '2026-08-23T08:00:00.000Z' })))
-      .toContain('暂未找到正式 Release')
-    const limited = render(snapshot({
-      status: 'check_failed',
-      checkedAt: '2026-08-23T08:00:00.000Z',
-      failureReason: 'rate_limited',
-      retryAt: '2026-08-23T09:00:00.000Z'
-    }))
-    expect(limited).toContain('GitHub 请求暂时受限')
-    expect(limited).toContain('role="alert"')
-    expect(limited).not.toContain('在 GitHub 查看此 Release')
-  })
-
-  it('disables duplicate checks while a request is running', () => {
-    const markup = render(snapshot(), { checking: true })
-    expect(markup).toContain('aria-disabled="true" aria-busy="true"')
-    expect(markup).not.toContain('disabled=""')
+    expect(markup).toContain('disabled="" aria-busy="true"')
     expect(markup).toContain('正在检查…')
-    expect(markup).toContain('正在检查官方 Release')
-    expect(markup).not.toContain('尚未检查更新')
+    expect(markup).toContain('正在确认是否有可用的新版本')
   })
 
-  it('allows an in-page retry when the initial version read fails', () => {
+  it('shows stable download progress and transfer detail', () => {
+    const markup = render(snapshot({
+      status: 'downloading',
+      latestVersion: '0.0.3',
+      checkedAt: '2026-08-24T08:00:00.000Z',
+      downloadPercent: 42.3,
+      transferredBytes: 42_340_000,
+      totalBytes: 100_000_000,
+      bytesPerSecond: 5_000_000
+    }))
+    expect(markup).toContain('正在下载 42%')
+    expect(markup).toContain('<progress max="100" value="42.3"')
+    expect(markup).toContain('40.4 MB / 95.4 MB')
+    expect(markup).toContain('4.8 MB/s')
+    expect(markup).toContain('下载期间可以继续使用 Rovai AI')
+  })
+
+  it('offers installation only after the update is downloaded', () => {
+    const markup = render(snapshot({
+      status: 'ready_to_install',
+      latestVersion: '0.0.3',
+      checkedAt: '2026-08-24T08:00:00.000Z',
+      downloadPercent: 100,
+      transferredBytes: 100_000_000,
+      totalBytes: 100_000_000
+    }))
+    expect(markup).toContain('>安装并重启</button>')
+    expect(markup).toContain('v0.0.3 已准备好')
+    expect(markup).toContain('安装后 Rovai AI 会自动重新打开')
+    expect(markup).not.toContain('<progress')
+  })
+
+  it('keeps current and failure outcomes recoverable', () => {
+    const current = render(snapshot({
+      status: 'up_to_date',
+      latestVersion: '0.0.2',
+      checkedAt: '2026-08-24T08:00:00.000Z'
+    }))
+    expect(current).toContain('当前已是最新版本')
+    expect(current).toContain('>重新检查</button>')
+
+    const failed = render(snapshot({
+      status: 'download_failed',
+      latestVersion: '0.0.3',
+      checkedAt: '2026-08-24T08:00:00.000Z',
+      failureReason: 'download_failed'
+    }))
+    expect(failed).toContain('更新下载中断')
+    expect(failed).toContain('role="alert"')
+    expect(failed).toContain('>重试</button>')
+
+    const installFailed = render(snapshot({
+      status: 'install_failed',
+      latestVersion: '0.0.3',
+      checkedAt: '2026-08-24T08:00:00.000Z',
+      failureReason: 'install_failed'
+    }))
+    expect(installFailed).toContain('>重试安装</button>')
+    expect(installFailed).toContain('已下载的更新仍然保留')
+  })
+
+  it('allows an in-page retry when the initial snapshot read fails', () => {
     const markup = render(null, { loadError: true })
-    expect(markup).toContain('可直接点击“检查更新”重试')
-    expect(markup).not.toContain('disabled=""')
+    expect(markup).toContain('可以直接重试检查')
+    expect(markup).toContain('>重试</button>')
   })
 })

--- a/apps/desktop/src/renderer/src/AboutUpdatesSettings.tsx
+++ b/apps/desktop/src/renderer/src/AboutUpdatesSettings.tsx
@@ -1,14 +1,11 @@
 /*
- * THESIS: One quiet, inspectable release check; no updater dashboard or installation wizard.
- * OWN-WORLD: Rovai's open Porcelain/Graphite settings plane, Steel action, aligned evidence rows.
- * STORY: Read the installed version, check once on demand, review the latest notes, open GitHub.
- * FIRST VIEWPORT: Borderless settings header, version row, then one update row with the sole primary action.
- * FORM: Established settings-surface extension; no concept seed. Key: about-updates-lightweight-release-check.
- * FINISH: unreviewed and undocumented is unfinished; this build ends with the finish review and surface brief.
+ * THESIS: One calm update surface: check once, download immediately, install when ready.
+ * OWN-WORLD: Rovai's open Porcelain/Graphite settings plane, Steel action, aligned status rows.
+ * STORY: Read the installed version, check on demand, keep progress visible, then install and restart.
+ * FIRST VIEWPORT: Borderless settings header, installed version, update action, progress and recovery.
  */
 import { useEffect, useState } from 'react'
 import type {
-  AppUpdateFailureReason,
   AppUpdateSnapshot,
   AppUpdatesApi
 } from '@contracts'
@@ -22,21 +19,27 @@ export function AboutUpdatesSettings({
   const resolvedApi = api ?? (typeof window === 'undefined' ? null : window.rovai.appUpdates)
   const [snapshot, setSnapshot] = useState<AppUpdateSnapshot | null>(null)
   const [loading, setLoading] = useState(true)
-  const [checking, setChecking] = useState(false)
-  const [openingRelease, setOpeningRelease] = useState(false)
   const [loadError, setLoadError] = useState(false)
-  const [openError, setOpenError] = useState(false)
+  const [actionError, setActionError] = useState(false)
 
   useEffect(() => {
     let active = true
+    let receivedChange = false
     if (!resolvedApi) {
       setLoading(false)
       setLoadError(true)
       return () => { active = false }
     }
+    const unsubscribe = resolvedApi.onChanged((next) => {
+      if (!active) return
+      receivedChange = true
+      setSnapshot(next)
+      setLoadError(false)
+      setActionError(false)
+    })
     void resolvedApi.get()
       .then((next) => {
-        if (!active) return
+        if (!active || receivedChange) return
         setSnapshot(next)
         setLoadError(false)
       })
@@ -46,96 +49,74 @@ export function AboutUpdatesSettings({
       .finally(() => {
         if (active) setLoading(false)
       })
-    return () => { active = false }
+    return () => {
+      active = false
+      unsubscribe()
+    }
   }, [resolvedApi])
 
   const checkForUpdates = async (): Promise<void> => {
-    if (!resolvedApi || checking) return
-    setChecking(true)
-    setOpenError(false)
+    if (!resolvedApi || isBusy(snapshot?.status)) return
+    setActionError(false)
     try {
       setSnapshot(await resolvedApi.check())
       setLoadError(false)
     } catch {
-      if (snapshot) {
-        setSnapshot({
-          ...snapshot,
-          status: 'check_failed',
-          checkedAt: new Date().toISOString(),
-          failureReason: 'network',
-          retryAt: null
-        })
-        setLoadError(false)
-      } else {
-        setLoadError(true)
-      }
-    } finally {
-      setChecking(false)
+      setActionError(true)
     }
   }
 
-  const openReleasePage = async (): Promise<void> => {
-    if (!resolvedApi || openingRelease) return
-    setOpeningRelease(true)
-    setOpenError(false)
+  const installUpdate = async (): Promise<void> => {
+    if (!resolvedApi || !snapshot || !canInstall(snapshot.status)) return
+    setActionError(false)
     try {
-      if (!await resolvedApi.openReleasePage()) setOpenError(true)
+      if (!await resolvedApi.install()) setActionError(true)
     } catch {
-      setOpenError(true)
-    } finally {
-      setOpeningRelease(false)
+      setActionError(true)
     }
   }
 
   return (
     <AboutUpdatesSettingsView
       snapshot={snapshot}
-      canCheck={Boolean(resolvedApi)}
+      canUpdate={Boolean(resolvedApi)}
       loading={loading}
-      checking={checking}
-      openingRelease={openingRelease}
       loadError={loadError}
-      openError={openError}
+      actionError={actionError}
       onCheck={() => void checkForUpdates()}
-      onOpenRelease={() => void openReleasePage()}
+      onInstall={() => void installUpdate()}
     />
   )
 }
 
 export function AboutUpdatesSettingsView({
   snapshot,
-  canCheck,
+  canUpdate,
   loading,
-  checking,
-  openingRelease,
   loadError,
-  openError,
+  actionError,
   onCheck,
-  onOpenRelease
+  onInstall
 }: {
   snapshot: AppUpdateSnapshot | null
-  canCheck: boolean
+  canUpdate: boolean
   loading: boolean
-  checking: boolean
-  openingRelease: boolean
   loadError: boolean
-  openError: boolean
+  actionError: boolean
   onCheck(): void
-  onOpenRelease(): void
+  onInstall(): void
 }): React.JSX.Element {
-  const status = updateStatus(snapshot, loading, loadError, checking, canCheck)
-  const releaseVisible = Boolean(
-    snapshot?.releasePageAvailable
-    && snapshot.latestVersion
-    && (snapshot.status === 'up_to_date' || snapshot.status === 'update_available')
-  )
+  const presentation = updatePresentation(snapshot, loading, loadError, actionError, canUpdate)
+  const action = updateAction(snapshot, loading, canUpdate)
+  const downloading = snapshot?.status === 'downloading'
+  const progress = downloading ? snapshot.downloadPercent ?? 0 : 0
 
   return (
     <div className="about-updates-settings">
       <SettingsPageHeader
         eyebrow="Settings / About & Updates"
         title="关于与更新"
-        description="查看当前版本，按需检查官方 GitHub Releases。"
+        description="查看当前版本，检查并安装 Rovai AI 更新。"
       />
 
       <div className="about-updates-body">
@@ -157,63 +138,53 @@ export function AboutUpdatesSettingsView({
 
         <section className="section-block about-updates-section" aria-labelledby="about-update-heading">
           <div className="section-heading">
-            <div><h2 id="about-update-heading">更新</h2><p>手动检查</p></div>
+            <div><h2 id="about-update-heading">更新</h2><p>一键升级</p></div>
           </div>
           <div className="about-update-body">
             <div className="about-update-control">
               <div>
-                <strong>GitHub Releases</strong>
-                <p>仅在你点击时读取一次公开 Release 信息；不会下载或安装内容。</p>
+                <strong>{controlTitle(snapshot)}</strong>
+                <p>{controlDetail(snapshot)}</p>
               </div>
               <button
                 className="primary-button"
                 type="button"
-                disabled={!canCheck || (loading && !snapshot)}
-                aria-disabled={checking || undefined}
-                aria-busy={checking || undefined}
+                disabled={action.disabled}
+                aria-busy={isBusy(snapshot?.status) || undefined}
                 aria-describedby="about-update-status"
-                onClick={onCheck}
+                onClick={action.kind === 'install' ? onInstall : onCheck}
               >
-                {checking && <span className="about-update-spinner" aria-hidden="true" />}
-                {checking ? '正在检查…' : snapshot?.checkedAt ? '重新检查' : '检查更新'}
+                {(snapshot?.status === 'checking' || snapshot?.status === 'installing') && (
+                  <span className="about-update-spinner" aria-hidden="true" />
+                )}
+                {action.label}
               </button>
             </div>
 
+            {downloading && (
+              <div className="about-download-progress" aria-label="更新下载进度">
+                <div className="about-download-progress-heading">
+                  <span>下载进度</span>
+                  <strong>{formatPercent(progress)}</strong>
+                </div>
+                <progress max="100" value={progress} aria-label={`已下载 ${formatPercent(progress)}`} />
+                <div className="about-download-progress-meta">
+                  <span>{formatTransfer(snapshot.transferredBytes, snapshot.totalBytes)}</span>
+                  <span>{formatSpeed(snapshot.bytesPerSecond)}</span>
+                </div>
+              </div>
+            )}
+
             <div
               id="about-update-status"
-              className={`about-update-status is-${status.tone}`}
-              role={status.tone === 'error' ? 'alert' : 'status'}
+              className={`about-update-status is-${presentation.tone}`}
+              role={presentation.tone === 'error' ? 'alert' : 'status'}
               aria-live="polite"
             >
               <span className="about-update-status-mark" aria-hidden="true" />
-              <div><strong>{status.title}</strong><p>{status.detail}</p></div>
+              <div><strong>{presentation.title}</strong><p>{presentation.detail}</p></div>
             </div>
-
-            {releaseVisible && snapshot && (
-              <section className="about-release-notes" aria-labelledby="about-release-notes-heading">
-                <div className="about-release-notes-heading">
-                  <div>
-                    <h3 id="about-release-notes-heading">Release Notes 摘要</h3>
-                    <p>{snapshot.releaseName?.trim() || displayVersion(snapshot.latestVersion ?? '')}</p>
-                  </div>
-                  <span>{releaseMetadata(snapshot)}</span>
-                </div>
-                <p className="about-release-notes-copy">
-                  {snapshot.releaseNotesSummary ?? '此版本没有提供可显示的 Release Notes 摘要。请前往 GitHub 查看完整内容。'}
-                </p>
-                <div className="about-release-notes-action">
-                  <button
-                    className="quiet-button compact"
-                    type="button"
-                    disabled={openingRelease}
-                    onClick={onOpenRelease}
-                  >
-                    {openingRelease ? '正在打开…' : '在 GitHub 查看此 Release'}
-                  </button>
-                  {openError && <span role="alert">无法打开 GitHub Release，请稍后重试。</span>}
-                </div>
-              </section>
-            )}
+            <p className="about-update-source">正式更新来自 Rovai AI 的 GitHub Release。</p>
           </div>
         </section>
       </div>
@@ -221,111 +192,169 @@ export function AboutUpdatesSettingsView({
   )
 }
 
-function updateStatus(
+function updateAction(
+  snapshot: AppUpdateSnapshot | null,
+  loading: boolean,
+  canUpdate: boolean
+): { kind: 'check' | 'install'; label: string; disabled: boolean } {
+  if (loading) return { kind: 'check', label: '读取中…', disabled: true }
+  if (!snapshot) return { kind: 'check', label: '重试', disabled: !canUpdate }
+  switch (snapshot.status) {
+    case 'checking':
+      return { kind: 'check', label: '正在检查…', disabled: true }
+    case 'downloading':
+      return {
+        kind: 'check',
+        label: `正在下载 ${formatPercent(snapshot.downloadPercent ?? 0)}`,
+        disabled: true
+      }
+    case 'ready_to_install':
+      return { kind: 'install', label: '安装并重启', disabled: !canUpdate }
+    case 'installing':
+      return { kind: 'install', label: '正在安装…', disabled: true }
+    case 'install_failed':
+      return { kind: 'install', label: '重试安装', disabled: !canUpdate }
+    case 'up_to_date':
+      return { kind: 'check', label: '重新检查', disabled: !canUpdate }
+    case 'check_failed':
+    case 'download_failed':
+      return { kind: 'check', label: '重试', disabled: !canUpdate }
+    case 'idle':
+      return { kind: 'check', label: '检查更新', disabled: !canUpdate }
+  }
+}
+
+function updatePresentation(
   snapshot: AppUpdateSnapshot | null,
   loading: boolean,
   loadError: boolean,
-  checking: boolean,
-  canCheck: boolean
+  actionError: boolean,
+  canUpdate: boolean
 ): { tone: 'neutral' | 'success' | 'attention' | 'error'; title: string; detail: string } {
   if (loading) return { tone: 'neutral', title: '正在读取当前版本', detail: '更新检查尚未开始。' }
-  if (checking) {
-    return {
-      tone: 'neutral',
-      title: '正在检查官方 Release',
-      detail: '完成后将显示当前版本与最新正式版本的比较结果。'
-    }
-  }
   if (loadError || !snapshot) {
     return {
       tone: 'error',
-      title: '无法读取应用版本',
-      detail: canCheck ? '可直接点击“检查更新”重试。' : '请重新打开此页面后再试。'
+      title: '无法读取更新状态',
+      detail: canUpdate ? '可以直接重试检查。' : '请重新打开此页面后再试。'
     }
+  }
+  if (actionError) {
+    return { tone: 'error', title: '更新操作未完成', detail: '当前版本没有变化，请重试。' }
   }
   switch (snapshot.status) {
     case 'idle':
       return {
         tone: 'neutral',
         title: '尚未检查更新',
-        detail: '点击“检查更新”后才会连接 GitHub。'
+        detail: '点击“检查更新”后会连接正式发布通道。'
+      }
+    case 'checking':
+      return {
+        tone: 'neutral',
+        title: '正在检查更新',
+        detail: '正在确认是否有可用的新版本。'
+      }
+    case 'downloading':
+      return {
+        tone: 'neutral',
+        title: `正在下载 ${displayVersion(snapshot.latestVersion ?? '')}`,
+        detail: '下载期间可以继续使用 Rovai AI。'
+      }
+    case 'ready_to_install':
+      return {
+        tone: 'success',
+        title: `${displayVersion(snapshot.latestVersion ?? '')} 已准备好`,
+        detail: '点击“安装并重启”即可完成更新。'
+      }
+    case 'installing':
+      return {
+        tone: 'neutral',
+        title: '正在安装更新',
+        detail: 'Rovai AI 将关闭并自动重新打开。'
       }
     case 'up_to_date':
       return {
         tone: 'success',
-        title: '当前已是最新正式版本',
-        detail: `已与官方 GitHub Releases 中的 ${displayVersion(snapshot.latestVersion ?? snapshot.currentVersion)} 完成比较。`
-      }
-    case 'update_available':
-      return {
-        tone: 'attention',
-        title: `发现新版本 ${displayVersion(snapshot.latestVersion ?? '')}`,
-        detail: '可先阅读下方摘要，再前往 GitHub Release 页面选择安装包。'
-      }
-    case 'no_release':
-      return {
-        tone: 'neutral',
-        title: '暂未找到正式 Release',
-        detail: '官方 GitHub Releases 目前没有可用于比较的正式版本。'
+        title: '当前已是最新版本',
+        detail: `${displayVersion(snapshot.currentVersion)} 已安装。`
       }
     case 'check_failed':
-      return failureStatus(snapshot.failureReason, snapshot.retryAt)
+      return checkFailure(snapshot.failureReason)
+    case 'download_failed':
+      return {
+        tone: 'error',
+        title: '更新下载中断',
+        detail: '当前版本没有变化，请检查网络后重试。'
+      }
+    case 'install_failed':
+      return {
+        tone: 'error',
+        title: '更新未能开始安装',
+        detail: '已下载的更新仍然保留，可以重试安装。'
+      }
   }
 }
 
-function failureStatus(
-  reason: AppUpdateFailureReason | null,
-  retryAt: string | null
-): { tone: 'error'; title: string; detail: string } {
-  if (reason === 'rate_limited') {
-    return {
-      tone: 'error',
-      title: 'GitHub 请求暂时受限',
-      detail: retryAt
-        ? `未使用 Token 的公开请求已达到限制，请在 ${formatTime(retryAt)} 后重试。`
-        : '未使用 Token 的公开请求已达到限制，请稍后重试。'
-    }
+function checkFailure(reason: AppUpdateSnapshot['failureReason']): {
+  tone: 'error'
+  title: string
+  detail: string
+} {
+  if (reason === 'network') {
+    return { tone: 'error', title: '无法连接更新服务', detail: '请检查网络连接后重试。' }
   }
   if (reason === 'invalid_release') {
-    return {
-      tone: 'error',
-      title: 'Release 信息无法验证',
-      detail: '返回的版本或下载页信息不符合 Rovai 的公开 Release 规则。'
-    }
+    return { tone: 'error', title: '更新信息暂不可用', detail: '正式发布文件尚未准备完整，请稍后重试。' }
   }
-  if (reason === 'github_unavailable') {
-    return { tone: 'error', title: 'GitHub 暂时不可用', detail: '本次检查没有完成，请稍后重试。' }
+  return { tone: 'error', title: '当前无法检查更新', detail: '请稍后重试。' }
+}
+
+function controlTitle(snapshot: AppUpdateSnapshot | null): string {
+  if (!snapshot?.latestVersion) return 'Rovai AI 更新'
+  if (snapshot.status === 'up_to_date') return 'Rovai AI 已是最新版本'
+  return `Rovai AI ${displayVersion(snapshot.latestVersion)}`
+}
+
+function controlDetail(snapshot: AppUpdateSnapshot | null): string {
+  if (snapshot?.status === 'ready_to_install' || snapshot?.status === 'install_failed') {
+    return '更新已下载完成，安装后 Rovai AI 会自动重新打开。'
   }
-  return { tone: 'error', title: '无法连接 GitHub', detail: '请检查网络连接后重试。' }
+  if (snapshot?.status === 'up_to_date') return '需要时可以重新检查正式发布通道。'
+  return '检查到新版本后会立即下载，并持续显示下载进度。'
 }
 
 function displayVersion(value: string): string {
   const trimmed = value.trim().replace(/^v/i, '')
-  return trimmed ? `v${trimmed}` : '版本未知'
+  return trimmed ? `v${trimmed}` : '新版本'
 }
 
-function releaseMetadata(snapshot: AppUpdateSnapshot): string {
-  const version = displayVersion(snapshot.latestVersion ?? '')
-  if (!snapshot.publishedAt) return version
-  try {
-    const date = new Intl.DateTimeFormat('zh-CN', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric'
-    }).format(new Date(snapshot.publishedAt))
-    return `${version} · ${date}`
-  } catch {
-    return version
-  }
+function formatPercent(value: number): string {
+  return `${Math.round(Math.min(100, Math.max(0, value)))}%`
 }
 
-function formatTime(value: string): string {
-  try {
-    return new Intl.DateTimeFormat('zh-CN', {
-      hour: '2-digit',
-      minute: '2-digit'
-    }).format(new Date(value))
-  } catch {
-    return '限制解除'
-  }
+function formatTransfer(transferred: number | null, total: number | null): string {
+  if (transferred === null && total === null) return '正在准备下载…'
+  if (total === null) return `已下载 ${formatBytes(transferred ?? 0)}`
+  return `${formatBytes(transferred ?? 0)} / ${formatBytes(total)}`
+}
+
+function formatSpeed(bytesPerSecond: number | null): string {
+  return bytesPerSecond === null ? '速度计算中' : `${formatBytes(bytesPerSecond)}/s`
+}
+
+function formatBytes(bytes: number): string {
+  const value = Math.max(0, bytes)
+  if (value < 1024) return `${Math.round(value)} B`
+  if (value < 1024 ** 2) return `${(value / 1024).toFixed(1)} KB`
+  if (value < 1024 ** 3) return `${(value / 1024 ** 2).toFixed(1)} MB`
+  return `${(value / 1024 ** 3).toFixed(1)} GB`
+}
+
+function isBusy(status: AppUpdateSnapshot['status'] | undefined): boolean {
+  return status === 'checking' || status === 'downloading' || status === 'installing'
+}
+
+function canInstall(status: AppUpdateSnapshot['status']): boolean {
+  return status === 'ready_to_install' || status === 'install_failed'
 }

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -3109,9 +3109,18 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
 .about-update-control strong { color: var(--ink); font-size: 12.5px; font-weight: 650; }
 .about-update-control p { max-width: 560px; margin: 0; color: var(--muted); font-size: 10.5px; line-height: 1.55; }
 .about-update-control > button { display: inline-flex; flex: 0 0 auto; align-items: center; gap: 7px; justify-content: center; }
-.about-update-control > .primary-button[aria-disabled="true"],
-.about-update-control > .primary-button[aria-disabled="true"]:hover { border-color: var(--brand); background: var(--brand); cursor: wait; opacity: .76; }
-.about-update-control > .primary-button[aria-disabled="true"]:active { transform: none; }
+.about-update-control > .primary-button[aria-busy="true"]:disabled,
+.about-update-control > .primary-button[aria-busy="true"]:disabled:hover { border-color: var(--brand); background: var(--brand); cursor: wait; opacity: .76; }
+.about-update-control > .primary-button[aria-busy="true"]:disabled:active { transform: none; }
+.about-download-progress { display: grid; gap: 8px; padding: 12px 13px; border-radius: 9px; background: var(--workspace-surface-subtle); }
+.about-download-progress-heading,
+.about-download-progress-meta { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+.about-download-progress-heading span { color: var(--muted); font-size: 10.5px; }
+.about-download-progress-heading strong { color: var(--ink); font: 650 10.5px/1.25 ui-monospace, SFMono-Regular, Menlo, monospace; font-variant-numeric: tabular-nums; }
+.about-download-progress progress { display: block; width: 100%; height: 6px; overflow: hidden; appearance: none; border: 0; border-radius: 999px; background: var(--surface-muted); }
+.about-download-progress progress::-webkit-progress-bar { border-radius: inherit; background: var(--surface-muted); }
+.about-download-progress progress::-webkit-progress-value { border-radius: inherit; background: var(--brand); }
+.about-download-progress-meta { color: var(--faint); font: 500 9.5px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; font-variant-numeric: tabular-nums; }
 .about-update-status { display: grid; min-height: 54px; grid-template-columns: 8px minmax(0, 1fr); align-items: start; gap: 10px; padding: 11px 13px; border-radius: 9px; color: var(--muted); background: var(--workspace-surface-subtle); }
 .about-update-status-mark { width: 7px; height: 7px; margin-top: 4px; border-radius: 50%; color: var(--neutral); background: currentColor; }
 .about-update-status > div { display: grid; min-width: 0; gap: 3px; }
@@ -3123,15 +3132,7 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
 .about-update-status.is-error .about-update-status-mark,
 .about-update-status.is-error strong,
 .about-update-status.is-error p { color: var(--danger); }
-.about-release-notes { display: grid; gap: 12px; margin-top: 3px; padding: 16px 17px; border-radius: 10px; background: var(--workspace-surface-subtle); }
-.about-release-notes-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; }
-.about-release-notes-heading > div { display: grid; min-width: 0; gap: 4px; }
-.about-release-notes-heading h3 { margin: 0; color: var(--ink); font-size: 12px; font-weight: 650; }
-.about-release-notes-heading p { overflow: hidden; margin: 0; color: var(--muted); font-size: 10.5px; text-overflow: ellipsis; white-space: nowrap; }
-.about-release-notes-heading > span { flex: 0 0 auto; color: var(--faint); font: 550 9.5px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace; font-variant-numeric: tabular-nums; white-space: nowrap; }
-.about-release-notes-copy { max-width: 76ch; margin: 0; white-space: pre-line; overflow-wrap: anywhere; color: var(--muted); font-size: 10.5px; line-height: 1.65; }
-.about-release-notes-action { display: flex; align-items: center; flex-wrap: wrap; gap: 9px; padding-top: 1px; }
-.about-release-notes-action > span { color: var(--danger); font-size: 10.5px; line-height: 1.45; }
+.about-update-source { margin: 0 2px; color: var(--faint); font-size: 9.5px; line-height: 1.45; }
 .about-update-spinner { width: 11px; height: 11px; border: 1.5px solid color-mix(in srgb, currentColor 36%, transparent); border-top-color: currentColor; border-radius: 50%; animation: about-update-spin 650ms linear infinite; }
 @keyframes about-update-spin { to { transform: rotate(360deg); } }
 .general-section-body { min-width: 0; }
@@ -6281,7 +6282,6 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
   .about-update-control { align-items: flex-start; flex-direction: column; gap: 13px; }
   .about-version-value { justify-items: start; }
   .about-update-control > button { width: fit-content; }
-  .about-release-notes-heading { flex-direction: column; gap: 7px; }
   .startup-location-options { grid-template-columns: minmax(0, 1fr); }
   .general-default-member-list { grid-template-columns: minmax(0, 1fr); }
   .general-default-lead { grid-template-columns: minmax(0, 1fr); gap: 8px; }

--- a/docs/development/local-workflow.md
+++ b/docs/development/local-workflow.md
@@ -16,7 +16,7 @@ last_updated: 2026-08-24
 | --- | --- | --- | --- |
 | 日常安装版 | 仓库外的已安装 `.app`，通常位于 `/Applications` 或 `~/Applications` | Electron 日常数据目录 | 用户真实 Camp 和 Runtime 工作；开发任务默认只读 |
 | 开发版 | `pnpm dev` 使用 `resources/bin/` 与 Electron Vite | 启动器生成的逐仓库隔离目录 | HMR、功能开发、手工调试 |
-| 打包产物 | `dist/mac-arm64/Rovai-ai.app` | 每次验收显式创建的隔离目录 | 签名、打包和一次性 App 验收 |
+| 打包产物 | `dist/mac-arm64/Rovai AI.app` | 每次验收显式创建的隔离目录 | 签名、打包和一次性 App 验收 |
 | 自动验收 | 脚本声明的 App/Core 与 fixture | 脚本创建的临时目录 | Smoke、截图和回归测试 |
 
 `dist/` 是可被 `pnpm package:mac` 覆盖的生成目录，不是安装位置。日常 App 不得从仓库的
@@ -54,7 +54,7 @@ Windows 的 `--user-data-dir=<root>` 是隔离 data-root 开关，不直接等�
    “打包到 Applications”不构成退出、终止或重启该宿主的授权；用户已经明确要求安装或升级时，优先按
    [非终止安装交接](#当前会话中的非终止安装交接)保留当前进程并替换磁盘上的日常安装版。前置条件不满足时
    停在安装边界，交由用户手动处理，或先取得针对本次退出的明确即时授权；
-7. 不得为了方便直接调用 `electron-vite dev`、直接打开 `dist/.../Rovai-ai.app`，或让
+7. 不得为了方便直接调用 `electron-vite dev`、直接打开 `dist/.../Rovai AI.app`，或让
    `rovai-core --data-dir` 指向日常目录；
 8. 测试结束后只清理本次命令创建且路径已经确认的临时目录，不推测或递归删除日常目录。
 
@@ -118,10 +118,10 @@ pnpm package:mac
 需要运行刚生成的 App 时，必须显式使用隔离目录：
 
 ```bash
-ROVAI_APP="$(pwd)/dist/mac-arm64/Rovai-ai.app"
+ROVAI_APP="$(pwd)/dist/mac-arm64/Rovai AI.app"
 FIXTURE_ROOT="$(mktemp -d)"
 ROVAI_ALLOW_ISOLATED_INSTANCE=1 \
-"$ROVAI_APP/Contents/MacOS/Rovai-ai" \
+"$ROVAI_APP/Contents/MacOS/Rovai AI" \
   --user-data-dir="$FIXTURE_ROOT/user-data"
 ```
 
@@ -129,7 +129,7 @@ Desktop 检测到这组显式隔离标记后，会以
 `--skill-library-root "$FIXTURE_ROOT/user-data/managed-skill-library"` 启动 Core；验收脚本不得绕过
 Desktop 另起一个仍指向日常全局 Skill Library 的 Core。
 
-AI Agent 不得把 `open "$(pwd)/dist/mac-arm64/Rovai-ai.app"` 当作打包验证，因为该命令没有证明
+AI Agent 不得把 `open "$(pwd)/dist/mac-arm64/Rovai AI.app"` 当作打包验证，因为该命令没有证明
 `userData` 隔离。签名和二进制检查不需要启动 App，优先使用
 [macOS 构建与打包](packaging.md)中的只读命令。
 

--- a/docs/development/packaging-windows.md
+++ b/docs/development/packaging-windows.md
@@ -3,7 +3,7 @@ document_type: development-guide
 authority: windows-desktop-build-packaging-routing
 status: implemented-pending-release-qualification
 source_version: v1.15
-last_updated: 2026-08-23
+last_updated: 2026-08-24
 ---
 
 # Windows x64 构建、打包与发布
@@ -36,13 +36,20 @@ pnpm accept:planned-shutdown
 pnpm accept:windows:installer
 ```
 
-`package:windows:x64` 生成 unpacked App 并执行 verifier；`dist:windows:x64` 生成 unsigned NSIS installer。两条命令都验证
+`package:windows:x64` 生成 unpacked App 并执行 verifier；`dist:windows:x64` 生成 unsigned NSIS installer。外层产品名和安装目录为
+`Rovai AI`，内部兼容可执行文件继续是 `Rovai-ai.exe`，发布 artifact 使用 URL 安全的
+`Rovai-AI-<version>-x64.exe`。两条命令都验证
 App/Core/CLI 的 PE32+ 架构、icon/version/manifest、hash、CLI contract 与隔离 Core health。`accept:windows:installer`
 执行 per-user clean install、已安装 App Onboarding、同版本 upgrade、默认卸载和数据保留，并把报告与截图写入
 `dist/windows-installation-acceptance/`。`accept:planned-shutdown` 默认使用 `dist/win-unpacked/Rovai-ai.exe`，
 在隔离 `userData` 中验证真实 Runtime 运行期间的受控退出、子进程回收和重启恢复。正式签名构建使用
 `dist:windows:release:x64`，且必须提供签名材料和
 `ROVAI_WINDOWS_SIGNER_SHA256` allowlist；缺少任一发布条件时 verifier 必须失败。
+
+NSIS Release 还必须同版本上传 installer、`.exe.blockmap` 与 `latest.yml`。verifier 会检查 packaged
+`app-update.yml` 指向官方 GitHub 通道，并核对 `latest.yml` 中 installer 的版本、sha512 和大小；缺少
+任一更新文件时不得发布应用内升级。初始安装仍使用 assisted installer，应用内“安装并重启”使用
+silent upgrade，不再次展示安装向导。
 
 ## Target-isolated staging
 

--- a/docs/development/packaging.md
+++ b/docs/development/packaging.md
@@ -1,13 +1,13 @@
 ---
 document_type: development-guide
 authority: macos-build-and-packaging
-last_updated: 2026-08-23
+last_updated: 2026-08-24
 ---
 
 # macOS 构建、签名与打包
 
-当前仓库记录的桌面交付目标是 macOS 14+ Apple Silicon。`package:mac` 和 `dist:mac`
-固定生成 arm64 产物。
+当前本地桌面交付目标是 macOS 14+ Apple Silicon。`package:mac` 和 `dist:mac` 固定生成
+arm64 产物；正式签名 workflow 另外生成 x64 产物并组合两种架构的更新清单。
 
 ## 构建
 
@@ -69,8 +69,11 @@ CSC_IDENTITY_AUTO_DISCOVERY=false pnpm exec electron-builder \
 产物：
 
 ```text
-dist/mac-arm64/Rovai-ai.app
+dist/mac-arm64/Rovai AI.app
 ```
+
+外层产品名、App bundle、主可执行文件与 Helper 名统一为 `Rovai AI` / `Rovai AI.app`。Bundle ID
+继续使用 `ai.rovai.desktop`，旧的 `Rovai-ai` userData 由启动兼容层继续采用，不因产品名改动而丢失。
 
 生成 DMG：
 
@@ -78,38 +81,66 @@ dist/mac-arm64/Rovai-ai.app
 pnpm dist:mac
 ```
 
-DMG 文件位于 `dist/`，文件名由 `package.json#build.mac.artifactName` 决定。
+该命令同时生成安装用 DMG、自动更新用 ZIP 和 `latest-mac.yml`。DMG/ZIP 使用 URL 安全的
+`Rovai-AI-<version>-<arch>` 文件名；文件名由 `package.json#build.mac.artifactName` 决定，DMG
+内部仍是 `Rovai AI.app`。
+
+## 一键更新发布集合
+
+应用内“检查更新”只由用户触发。Main 通过打包进 App 的 `app-update.yml` 读取官方
+`murray17/rovai-ai` GitHub Release 通道；发现新版本后自动下载 ZIP，Renderer 显示进度，用户点击
+“安装并重启”后才进入受控关闭与安装。
+
+macOS 正式 Release 必须在同一个版本标签中上传以下完整集合：
+
+```text
+Rovai-AI-<version>-arm64.dmg
+Rovai-AI-<version>-arm64.zip
+Rovai-AI-<version>-x64.dmg
+Rovai-AI-<version>-x64.zip
+latest-mac.yml
+```
+
+`.github/workflows/macos-signed-build.yml` 分架构构建并验证后，生成一个名为
+`rovai-macos-signed` 的组合 artifact。它的 `latest-mac.yml` 由
+`scripts/merge-macos-update-info.mjs` 合并，必须同时包含 arm64 与 x64 ZIP；发布者只能上传这份
+组合清单，不能任选一个架构构建出的单架构 `latest-mac.yml`。少任一 ZIP 或清单时，另一架构可能
+拿到错误更新包，因此发布必须 fail closed。
+
+已发布的 v0.0.1 没有 ZIP/`latest-mac.yml`，旧 App 也没有自动安装能力，所以
+`v0.0.1 → v0.0.2` 是一次性手动迁移；从 v0.0.2 安装完成后，后续完整 Release 才能使用应用内升级。
 
 ## 本地签名
 
-当前本地脚本关闭自动证书发现，`package.json#build.mac.identity` 使用 `-`，因此生成
-ad-hoc 签名产物。它适合本机开发验收，不代表可以对外发布。
+当前普通本地脚本关闭自动证书发现并显式使用 `identity=-`，因此生成 ad-hoc 签名产物。它适合
+本机开发验收，不代表可以对外发布，也不能作为自动升级签名连续性的证据。
 
 检查签名：
 
 ```bash
-codesign --verify --deep --strict "dist/mac-arm64/Rovai-ai.app"
+codesign --verify --deep --strict "dist/mac-arm64/Rovai AI.app"
 codesign --verify --strict \
-  "dist/mac-arm64/Rovai-ai.app/Contents/Resources/bin/rovai-core"
+  "dist/mac-arm64/Rovai AI.app/Contents/Resources/bin/rovai-core"
 codesign --verify --strict \
-  "dist/mac-arm64/Rovai-ai.app/Contents/Resources/bin/rovai"
+  "dist/mac-arm64/Rovai AI.app/Contents/Resources/bin/rovai"
 ```
 
-正式分发需要独立配置 Developer ID、Hardened Runtime entitlement 和 Apple
-Notarization 凭据，并验证公证结果。不要把证书、密码或 notarization 凭据写入仓库。
+仓库签名 workflow 使用固定 `Rovai Release Signing` 身份并校验其证书指纹，使相邻版本具备同一
+designated-requirement 根。正式公共分发仍需要独立配置 Developer ID、Hardened Runtime entitlement
+和 Apple Notarization 凭据，并验证公证结果。不要把证书、密码或 notarization 凭据写入仓库。
 
 ## 隔离运行打包 App
 
-`dist/mac-arm64/Rovai-ai.app` 是可被下次打包覆盖的生成产物，不得作为日常安装版运行。日常 App
+`dist/mac-arm64/Rovai AI.app` 是可被下次打包覆盖的生成产物，不得作为日常安装版运行。日常 App
 必须位于仓库外；完整边界见[本地开发与 App 隔离流程](local-workflow.md)。
 
 从仓库根目录运行刚生成的 App 时，显式创建隔离 `userData`：
 
 ```bash
-ROVAI_APP="$(pwd)/dist/mac-arm64/Rovai-ai.app"
+ROVAI_APP="$(pwd)/dist/mac-arm64/Rovai AI.app"
 FIXTURE_ROOT="$(mktemp -d)"
 ROVAI_ALLOW_ISOLATED_INSTANCE=1 \
-"$ROVAI_APP/Contents/MacOS/Rovai-ai" \
+"$ROVAI_APP/Contents/MacOS/Rovai AI" \
   --user-data-dir="$FIXTURE_ROOT/user-data"
 ```
 
@@ -128,9 +159,9 @@ Ready。
 确认架构和内置 Core/CLI：
 
 ```bash
-file "dist/mac-arm64/Rovai-ai.app/Contents/MacOS/Rovai-ai"
-file "dist/mac-arm64/Rovai-ai.app/Contents/Resources/bin/rovai-core"
-file "dist/mac-arm64/Rovai-ai.app/Contents/Resources/bin/rovai"
+file "dist/mac-arm64/Rovai AI.app/Contents/MacOS/Rovai AI"
+file "dist/mac-arm64/Rovai AI.app/Contents/Resources/bin/rovai-core"
+file "dist/mac-arm64/Rovai AI.app/Contents/Resources/bin/rovai"
 ```
 
 需要确认本次 release Core 已进入 App 时，可比较 Mach-O UUID：
@@ -138,10 +169,10 @@ file "dist/mac-arm64/Rovai-ai.app/Contents/Resources/bin/rovai"
 ```bash
 dwarfdump --uuid resources/bin/rovai-core
 dwarfdump --uuid \
-  "dist/mac-arm64/Rovai-ai.app/Contents/Resources/bin/rovai-core"
+  "dist/mac-arm64/Rovai AI.app/Contents/Resources/bin/rovai-core"
 dwarfdump --uuid resources/bin/rovai
 dwarfdump --uuid \
-  "dist/mac-arm64/Rovai-ai.app/Contents/Resources/bin/rovai"
+  "dist/mac-arm64/Rovai AI.app/Contents/Resources/bin/rovai"
 ```
 
 codesign 会修改签名相关字节，因此不要把签名后文件的逐字节 `cmp` 当作唯一一致性

--- a/docs/development/troubleshooting.md
+++ b/docs/development/troubleshooting.md
@@ -88,10 +88,10 @@ startup recovery 前退出，因此不要删除 `.rovai-core-instance.lock`，�
 
 ```bash
 pnpm package:mac
-ROVAI_APP="$(pwd)/dist/mac-arm64/Rovai-ai.app"
+ROVAI_APP="$(pwd)/dist/mac-arm64/Rovai AI.app"
 FIXTURE_ROOT="$(mktemp -d)"
 ROVAI_ALLOW_ISOLATED_INSTANCE=1 \
-"$ROVAI_APP/Contents/MacOS/Rovai-ai" \
+"$ROVAI_APP/Contents/MacOS/Rovai AI" \
   --user-data-dir="$FIXTURE_ROOT/user-data"
 ```
 
@@ -151,11 +151,11 @@ App/Core 是否为旧构建，以及冲突 Core 是否曾在升级前打开过�
 
 ## `codesign` 校验失败
 
-先确认目标是本次生成的 `dist/mac-arm64/Rovai-ai.app`，再运行：
+先确认目标是本次生成的 `dist/mac-arm64/Rovai AI.app`，再运行：
 
 ```bash
-codesign --verify --deep --strict "dist/mac-arm64/Rovai-ai.app"
-codesign -dv --verbose=4 "dist/mac-arm64/Rovai-ai.app"
+codesign --verify --deep --strict "dist/mac-arm64/Rovai AI.app"
+codesign -dv --verbose=4 "dist/mac-arm64/Rovai AI.app"
 ```
 
 本地 `package:mac` 是 ad-hoc 签名，不会产生 Notarization 票据。正式证书或公证问题按

--- a/docs/development/ui-acceptance.md
+++ b/docs/development/ui-acceptance.md
@@ -1,7 +1,7 @@
 ---
 document_type: development-guide
 authority: desktop-ui-acceptance-infrastructure
-last_updated: 2026-08-23
+last_updated: 2026-08-24
 ---
 
 # 桌面 UI 验收与隔离数据
@@ -18,7 +18,7 @@ pnpm package:mac
 后续示例都从仓库根目录执行：
 
 ```bash
-ROVAI_APP="$(pwd)/dist/mac-arm64/Rovai-ai.app"
+ROVAI_APP="$(pwd)/dist/mac-arm64/Rovai AI.app"
 ```
 
 ## 隔离 `userData`
@@ -43,7 +43,7 @@ node scripts/capture-desktop.mjs "$ROVAI_APP" "$FIXTURE_ROOT/capture"
 
 ```bash
 ROVAI_ALLOW_ISOLATED_INSTANCE=1 \
-"$ROVAI_APP/Contents/MacOS/Rovai-ai" \
+"$ROVAI_APP/Contents/MacOS/Rovai AI" \
   --user-data-dir="$FIXTURE_ROOT/user-data"
 ```
 
@@ -101,6 +101,7 @@ pnpm accept:structured-mentions-ui
 pnpm accept:task-card-ui
 pnpm accept:runtime-activity-ui
 pnpm accept:diagnostics-ui
+pnpm accept:app-updates-ui
 pnpm accept:onboarding-ui
 ```
 
@@ -108,7 +109,8 @@ pnpm accept:onboarding-ui
 可恢复 Project 移除、跨重启隐藏、Quick Chat 焦点回退与 Core 数据保留）、结构化提及和
 当前会话完整正文查找（含地图快捷返回、非 Camp 边界、旧消息 anchored 定位与双主题双尺寸）、
 Task 创建操作行、完整表单聚焦、取消恢复与单卡原地更新、十 Runtime Canonical Activity 工具名称与 Agent 级连续执行过程、A2A 消息
-Scheme C 转交 footer，以及诊断中心双尺寸、只读自检、MCP 权限修复复检与 v5 脱敏的桌面回归。
+Scheme C 转交 footer，诊断中心双尺寸、只读自检、MCP 权限修复复检与 v5 脱敏，以及“关于与更新”
+的真实 packaged 0.0.2 版本、Day/Night、1040×700、200% 等效布局、键盘焦点和无竖线回归。
 当前 Neutral Porcelain + Steel 视觉迁移还必须按当前版本实施计划覆盖 2K Composer、八个设置页、
 队员半身照与 Runtime 入口、记忆 Workbench、New Conversation 和各类 Dialog/Drawer。
 具体 Schema/Migration 编号属于测试 fixture 和版本证据，不是本文的常青要求。
@@ -385,7 +387,7 @@ Skill 短标签显示“GitHub”；主行不存在来源明细，`DonkeyKing01/
 
 ## 从明确来源创建只读隔离副本
 
-需要复现已有 Camp 时，先彻底退出 Rovai-ai。v0.51 起诊断中心和 v5 导出故意不显示绝对
+需要复现已有 Camp 时，先彻底退出 Rovai AI。v0.51 起诊断中心和 v5 导出故意不显示绝对
 SQLite 路径；只使用用户明确提供、Electron 开发日志记录或隔离启动参数已证明的来源路径。然后使用 SQLite
 Backup API 创建副本：
 

--- a/docs/prototypes/one-click-app-update-v002/README.md
+++ b/docs/prototypes/one-click-app-update-v002/README.md
@@ -31,6 +31,14 @@
 
 原型示例版本、大小和速度仅用于交互评审，不是正式 Release 事实。
 
+## 对应生产实现
+
+- Renderer：`apps/desktop/src/renderer/src/AboutUpdatesSettings.tsx`；
+- Main 更新状态机：`apps/desktop/src/main/app-updates.ts`；
+- Preload/typed contract：`apps/desktop/src/preload/index.ts` 与 `packages/contracts/src/index.ts`；
+- Release 产物与双架构清单：`package.json`、`.github/workflows/macos-signed-build.yml` 与
+  `scripts/merge-macos-update-info.mjs`。
+
 ## 正式实现的发布前置条件
 
 - 把 macOS 产品展示名与产物名统一为 `Rovai AI`，但保持既有 `ai.rovai.desktop` 应用身份与数据迁移兼容；

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rovai-ai",
-  "productName": "Rovai-ai",
-  "version": "0.0.1",
+  "productName": "Rovai AI",
+  "version": "0.0.2",
   "private": true,
   "type": "module",
   "description": "A desktop workspace for long-lived agent teams, shared Camps, visible execution, and collaborative memory.",
@@ -41,7 +41,7 @@
     "build:macos:x64": "pnpm core:build:macos:x64 && pnpm build:desktop",
     "build:windows:x64": "pnpm core:build:windows:x64 && pnpm build:desktop",
     "typecheck": "tsc --noEmit",
-    "test": "pnpm docs:test && pnpm docs:check && pnpm skills:test && pnpm skills:check && vitest run && node --test scripts/lib/check-rust-staged.test.mjs scripts/lib/copilot-native-turn-reconciliation-evidence.test.mjs scripts/lib/dev-desktop.test.mjs scripts/lib/missing-send-recovery-protocol.test.mjs scripts/lib/planned-shutdown-app-quit.test.mjs scripts/lib/sidecar-targets.test.mjs scripts/lib/qualification-acceptance-v034.test.mjs scripts/lib/qualification-acceptance-v036.test.mjs scripts/lib/qualification-artifacts.test.mjs scripts/lib/qualification-bundle.test.mjs scripts/lib/qualification-case-v3.test.mjs scripts/lib/qualification-collaboration.test.mjs scripts/lib/qualification-collaboration-ledger.test.mjs scripts/lib/qualification-core.test.mjs scripts/lib/qualification-demo-cases.test.mjs scripts/lib/qualification-diagnostic-portfolio.test.mjs scripts/lib/qualification-evaluation.test.mjs scripts/lib/qualification-evidence-index.test.mjs scripts/lib/qualification-isolation.test.mjs scripts/lib/qualification-judge-views.test.mjs scripts/lib/qualification-observation.test.mjs scripts/lib/qualification-public-report.test.mjs scripts/lib/qualification-recovery.test.mjs scripts/lib/qualification-schema-validation.test.mjs scripts/lib/qualification-semantic-evidence.test.mjs scripts/lib/qualification-semantic-judge.test.mjs scripts/lib/qualification-tool-evidence.test.mjs scripts/lib/qualification-tool-ledger.test.mjs scripts/lib/qualification-tool-use-judge.test.mjs scripts/lib/qualification-workspace-mutation-ledger.test.mjs scripts/lib/tool-interaction-measurement/index.test.mjs scripts/lib/qualification-tool-measurement-spec.test.mjs scripts/benchmark-paired-collaboration.test.mjs scripts/benchmark/*.test.mjs scripts/benchmark/**/*.test.mjs",
+    "test": "pnpm docs:test && pnpm docs:check && pnpm skills:test && pnpm skills:check && vitest run && node --test scripts/lib/check-rust-staged.test.mjs scripts/lib/copilot-native-turn-reconciliation-evidence.test.mjs scripts/lib/dev-desktop.test.mjs scripts/lib/macos-update-info.test.mjs scripts/lib/missing-send-recovery-protocol.test.mjs scripts/lib/planned-shutdown-app-quit.test.mjs scripts/lib/sidecar-targets.test.mjs scripts/lib/qualification-acceptance-v034.test.mjs scripts/lib/qualification-acceptance-v036.test.mjs scripts/lib/qualification-artifacts.test.mjs scripts/lib/qualification-bundle.test.mjs scripts/lib/qualification-case-v3.test.mjs scripts/lib/qualification-collaboration.test.mjs scripts/lib/qualification-collaboration-ledger.test.mjs scripts/lib/qualification-core.test.mjs scripts/lib/qualification-demo-cases.test.mjs scripts/lib/qualification-diagnostic-portfolio.test.mjs scripts/lib/qualification-evaluation.test.mjs scripts/lib/qualification-evidence-index.test.mjs scripts/lib/qualification-isolation.test.mjs scripts/lib/qualification-judge-views.test.mjs scripts/lib/qualification-observation.test.mjs scripts/lib/qualification-public-report.test.mjs scripts/lib/qualification-recovery.test.mjs scripts/lib/qualification-schema-validation.test.mjs scripts/lib/qualification-semantic-evidence.test.mjs scripts/lib/qualification-semantic-judge.test.mjs scripts/lib/qualification-tool-evidence.test.mjs scripts/lib/qualification-tool-ledger.test.mjs scripts/lib/qualification-tool-use-judge.test.mjs scripts/lib/qualification-workspace-mutation-ledger.test.mjs scripts/lib/tool-interaction-measurement/index.test.mjs scripts/lib/qualification-tool-measurement-spec.test.mjs scripts/benchmark-paired-collaboration.test.mjs scripts/benchmark/*.test.mjs scripts/benchmark/**/*.test.mjs",
     "smoke:core": "pnpm core:build:debug && node scripts/smoke-core.mjs",
     "smoke:member-config": "pnpm core:build:debug && node scripts/smoke-member-config.mjs",
     "smoke:intake": "pnpm core:build:debug && node scripts/smoke-intake.mjs",
@@ -97,6 +97,7 @@
     "accept:planned-shutdown": "node scripts/accept-planned-shutdown.mjs",
     "accept:windows:installer": "node scripts/accept-windows-installation.mjs",
     "accept:diagnostics-ui": "node scripts/accept-diagnostics-ui.mjs",
+    "accept:app-updates-ui": "node scripts/accept-app-updates-ui.mjs",
     "accept:runtime-monitoring-ui": "node scripts/accept-runtime-monitoring-ui.mjs",
     "accept:onboarding-ui": "node scripts/accept-onboarding-ui.mjs",
     "smoke:recovery": "pnpm core:build:debug && node scripts/smoke-recovery.mjs",
@@ -105,9 +106,9 @@
     "test:p1:copilot-native-turn-evidence": "node --test scripts/lib/copilot-native-turn-reconciliation-evidence.test.mjs",
     "package:mac:unsigned": "pnpm build:macos:arm64 && CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --mac dir --arm64 -c.mac.identity=-",
     "package:mac": "pnpm build:macos:arm64 && CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --mac dir --arm64 -c.mac.identity=-",
-    "dist:mac": "pnpm build:macos:arm64 && CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --mac dmg --arm64 -c.mac.identity=-",
-    "dist:mac:release:arm64": "pnpm build:macos:arm64 && electron-builder --mac dmg --arm64 --publish never -c.mac.identity=\"Rovai Release Signing\" -c.forceCodeSigning=true",
-    "dist:mac:release:x64": "pnpm build:macos:x64 && electron-builder --mac dmg --x64 --publish never -c.mac.identity=\"Rovai Release Signing\" -c.forceCodeSigning=true",
+    "dist:mac": "pnpm build:macos:arm64 && CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --mac dmg zip --arm64 --publish never -c.mac.identity=-",
+    "dist:mac:release:arm64": "pnpm build:macos:arm64 && electron-builder --mac dmg zip --arm64 --publish never -c.mac.identity=\"Rovai Release Signing\" -c.forceCodeSigning=true",
+    "dist:mac:release:x64": "pnpm build:macos:x64 && electron-builder --mac dmg zip --x64 --publish never -c.mac.identity=\"Rovai Release Signing\" -c.forceCodeSigning=true",
     "package:windows:x64": "pnpm build:windows:x64 && node scripts/package-windows.mjs dir && node scripts/verify-windows-release.mjs --unpacked-only",
     "dist:windows:x64": "pnpm build:windows:x64 && node scripts/package-windows.mjs nsis && node scripts/verify-windows-release.mjs",
     "dist:windows:release:x64": "pnpm build:windows:x64 && node scripts/package-windows.mjs nsis && node scripts/verify-windows-release.mjs --require-signed",
@@ -117,6 +118,7 @@
     "@radix-ui/react-dialog": "1.1.19",
     "@radix-ui/react-dropdown-menu": "2.1.20",
     "@radix-ui/react-tabs": "1.1.17",
+    "electron-updater": "6.8.9",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-markdown": "^10.1.0",
@@ -141,7 +143,7 @@
   },
   "build": {
     "appId": "ai.rovai.desktop",
-    "productName": "Rovai-ai",
+    "productName": "Rovai AI",
     "asar": true,
     "directories": {
       "output": "dist",
@@ -152,6 +154,14 @@
       "package.json"
     ],
     "afterPack": "scripts/after-pack.cjs",
+    "publish": [
+      {
+        "provider": "github",
+        "owner": "murray17",
+        "repo": "rovai-ai",
+        "releaseType": "release"
+      }
+    ],
     "mac": {
       "icon": "build/icon.png",
       "extraResources": [
@@ -182,12 +192,14 @@
       "minimumSystemVersion": "14.0",
       "target": [
         "dir",
-        "dmg"
+        "dmg",
+        "zip"
       ],
-      "artifactName": "Rovai-ai-${version}-${arch}.${ext}"
+      "artifactName": "Rovai-AI-${version}-${arch}.${ext}"
     },
     "win": {
       "icon": "build/icon.png",
+      "executableName": "Rovai-ai",
       "target": [
         {
           "target": "nsis",
@@ -210,7 +222,7 @@
           "to": "bin/rovai.exe"
         }
       ],
-      "artifactName": "Rovai-ai-${version}-${arch}.${ext}"
+      "artifactName": "Rovai-AI-${version}-${arch}.${ext}"
     },
     "nsis": {
       "oneClick": false,
@@ -224,7 +236,7 @@
       "warningsAsErrors": true
     },
     "dmg": {
-      "title": "Rovai-ai ${version}",
+      "title": "Rovai AI ${version}",
       "window": {
         "width": 540,
         "height": 380

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rovai/contracts",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1791,34 +1791,39 @@ export interface AppearanceApi {
 
 export type AppUpdateStatus =
   | 'idle'
+  | 'checking'
   | 'up_to_date'
-  | 'update_available'
-  | 'no_release'
+  | 'downloading'
+  | 'ready_to_install'
+  | 'installing'
   | 'check_failed'
+  | 'download_failed'
+  | 'install_failed'
 
 export type AppUpdateFailureReason =
   | 'network'
-  | 'rate_limited'
-  | 'github_unavailable'
+  | 'updater_unavailable'
   | 'invalid_release'
+  | 'download_failed'
+  | 'install_failed'
 
 export interface AppUpdateSnapshot {
   currentVersion: string
   status: AppUpdateStatus
   latestVersion: string | null
-  releaseName: string | null
-  releaseNotesSummary: string | null
-  publishedAt: string | null
-  releasePageAvailable: boolean
   checkedAt: string | null
+  downloadPercent: number | null
+  transferredBytes: number | null
+  totalBytes: number | null
+  bytesPerSecond: number | null
   failureReason: AppUpdateFailureReason | null
-  retryAt: string | null
 }
 
 export interface AppUpdatesApi {
   get(): Promise<AppUpdateSnapshot>
   check(): Promise<AppUpdateSnapshot>
-  openReleasePage(): Promise<boolean>
+  install(): Promise<boolean>
+  onChanged(listener: (snapshot: AppUpdateSnapshot) => void): () => void
 }
 
 export type StartupLocationMode = 'last_location' | 'quick_chat'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@radix-ui/react-tabs':
         specifier: 1.1.17
         version: 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      electron-updater:
+        specifier: 6.8.9
+        version: 6.8.9(supports-color@7.2.0)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -1465,6 +1468,9 @@ packages:
   electron-to-chromium@1.5.392:
     resolution: {integrity: sha512-1yQq3VQCZRwsnYc67Oc+1fge6Lwtn0hzi6zmEVkB61Zx21kTbwJAW4dFLadl5Rc1tKhG/kSpYXnfiAhu0f0a1g==}
 
+  electron-updater@6.8.9:
+    resolution: {integrity: sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==}
+
   electron-vite@5.0.0:
     resolution: {integrity: sha512-OHp/vjdlubNlhNkPkL/+3JD34ii5ov7M0GpuXEVdQeqdQ3ulvVR7Dg/rNBLfS5XPIFwgoBLDf9sjjrL+CuDyRQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1820,6 +1826,13 @@ packages:
 
   lazy-val@1.0.5:
     resolution: {integrity: sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==}
+
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -2397,6 +2410,9 @@ packages:
 
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
+
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -4004,6 +4020,19 @@ snapshots:
 
   electron-to-chromium@1.5.392: {}
 
+  electron-updater@6.8.9(supports-color@7.2.0):
+    dependencies:
+      builder-util-runtime: 9.7.0(supports-color@7.2.0)
+      fs-extra: 10.1.0
+      js-yaml: 4.3.0
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.4
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   electron-vite@5.0.0(supports-color@7.2.0)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@babel/core': 7.29.7(supports-color@7.2.0)
@@ -4430,6 +4459,10 @@ snapshots:
       json-buffer: 3.0.1
 
   lazy-val@1.0.5: {}
+
+  lodash.escaperegexp@4.1.2: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash@4.18.1: {}
 
@@ -5259,6 +5292,8 @@ snapshots:
   tiny-async-pool@1.3.0:
     dependencies:
       semver: 5.7.2
+
+  tiny-typed-emitter@2.1.0: {}
 
   tinybench@2.9.0: {}
 

--- a/scripts/accept-app-updates-ui.mjs
+++ b/scripts/accept-app-updates-ui.mjs
@@ -1,0 +1,319 @@
+import { mkdir, mkdtemp, realpath, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, join, resolve } from 'node:path'
+import { spawn } from 'node:child_process'
+import { seedCompletedOnboardingForAcceptance } from './lib/dev-desktop.mjs'
+
+const root = resolve(import.meta.dirname, '..')
+const appPath = resolve(process.argv[2] ?? join(root, 'dist', 'mac-arm64', 'Rovai AI.app'))
+const fixtureRoot = process.env.ROVAI_APP_UPDATES_ACCEPT_FIXTURE_ROOT
+  ?? await mkdtemp(join(tmpdir(), 'rovai-app-updates-ui-accept-'))
+const dataDir = join(fixtureRoot, 'user-data')
+const outputDir = process.env.ROVAI_APP_UPDATES_ACCEPT_OUTPUT_DIR
+  ?? await mkdtemp(join(tmpdir(), 'rovai-app-updates-ui-captures-'))
+const port = Number(process.env.ROVAI_APP_UPDATES_ACCEPT_DEBUG_PORT ?? 9521)
+
+await mkdir(dataDir, { recursive: true })
+await mkdir(outputDir, { recursive: true })
+seedCompletedOnboardingForAcceptance(dataDir)
+
+let isolatedApp = null
+try {
+  isolatedApp = await launchApp(1440, 920)
+  await setTheme(isolatedApp.cdp, 'day')
+  await openAboutUpdates(isolatedApp.cdp)
+  await assertAboutUpdates(isolatedApp.cdp, 'day desktop')
+  const dayCapture = join(outputDir, 'about-updates-idle-day-1440x920.png')
+  await capture(isolatedApp.cdp, dayCapture)
+
+  await isolatedApp.cdp.send('Emulation.setDeviceMetricsOverride', {
+    width: 1040,
+    height: 700,
+    deviceScaleFactor: 1,
+    mobile: false
+  })
+  await isolatedApp.cdp.send('Emulation.setEmulatedMedia', {
+    features: [{ name: 'prefers-reduced-motion', value: 'reduce' }]
+  })
+  await setTheme(isolatedApp.cdp, 'night')
+  await assertAboutUpdates(isolatedApp.cdp, 'night compact')
+  const nightCapture = join(outputDir, 'about-updates-idle-night-1040x700.png')
+  await capture(isolatedApp.cdp, nightCapture)
+
+  await isolatedApp.cdp.send('Emulation.setDeviceMetricsOverride', {
+    width: 720,
+    height: 460,
+    deviceScaleFactor: 1,
+    mobile: false
+  })
+  await wait(100)
+  await assertNoHorizontalOverflow(isolatedApp.cdp, '200% layout equivalent')
+
+  console.log(JSON.stringify({
+    ok: true,
+    app: basename(appPath),
+    fixtureRoot,
+    outputDir,
+    verified: {
+      isolatedPackagedApplication: true,
+      packagedVersion: '0.0.2',
+      typedIdleUpdaterSnapshot: true,
+      productAndBundleName: 'Rovai AI',
+      existingSettingsVisualWorld: true,
+      noVerticalHeadingRules: true,
+      noReleaseNotesOrExternalHandoff: true,
+      keyboardFocus: true,
+      dayAndNightLayouts: true,
+      compactReducedMotionLayout: true,
+      twoHundredPercentLayout: true,
+      horizontalOverflow: false
+    },
+    captures: { day: dayCapture, night: nightCapture }
+  }, null, 2))
+} finally {
+  if (isolatedApp) await closeApp(isolatedApp)
+}
+
+async function openAboutUpdates(cdp) {
+  const opened = await evaluate(cdp, `(() => {
+    const button = document.querySelector('.unified-sidebar-footer button[aria-label="设置"]')
+    button?.click()
+    return Boolean(button)
+  })()`)
+  assert(opened, 'Could not open Settings')
+  await waitForSelector(cdp, '.settings-sidebar-menu')
+  const selected = await evaluate(cdp, `(() => {
+    const button = [...document.querySelectorAll('.settings-sidebar-menu button')]
+      .find((candidate) => candidate.textContent?.includes('关于与更新'))
+    button?.click()
+    return Boolean(button)
+  })()`)
+  assert(selected, 'About & Updates Settings entry was unavailable')
+  await waitForSelector(cdp, '.about-updates-settings')
+  await waitForExpression(cdp,
+    `document.querySelector('.about-version-value code')?.textContent === 'v0.0.2'`)
+}
+
+async function assertAboutUpdates(cdp, context) {
+  const updaterSnapshot = await evaluate(cdp, 'window.rovai.appUpdates.get()', true)
+  assert(updaterSnapshot?.currentVersion === '0.0.2' && updaterSnapshot.status === 'idle',
+    `${context} returned the wrong updater snapshot: ${JSON.stringify(updaterSnapshot)}`)
+
+  const state = await evaluate(cdp, `(() => {
+    const surface = document.querySelector('.about-updates-settings')
+    const action = document.querySelector('.about-update-control > button')
+    const headingCopy = document.querySelector('.about-updates-settings .settings-page-heading-copy')
+    const sectionHeading = document.querySelector('.about-updates-settings .section-heading')
+    action?.focus()
+    return {
+      heading: surface?.querySelector('h1')?.textContent ?? '',
+      description: surface?.querySelector('.settings-page-heading-copy > p:last-child')?.textContent ?? '',
+      product: surface?.querySelector('.about-product-name strong')?.textContent ?? '',
+      version: surface?.querySelector('.about-version-value code')?.textContent ?? '',
+      action: action?.textContent?.trim() ?? '',
+      actionTag: action?.tagName ?? '',
+      actionFocused: document.activeElement === action,
+      statusRole: surface?.querySelector('.about-update-status')?.getAttribute('role'),
+      source: surface?.querySelector('.about-update-source')?.textContent ?? '',
+      progressVisible: Boolean(surface?.querySelector('progress')),
+      forbiddenCopy: /Release Notes 摘要|在 GitHub 查看|校验 hash|等待当前任务/.test(surface?.textContent ?? ''),
+      headingRule: headingCopy ? getComputedStyle(headingCopy, '::before').content : 'missing',
+      sectionRule: sectionHeading ? getComputedStyle(sectionHeading, '::before').content : 'missing',
+      documentOverflow: document.documentElement.scrollWidth > window.innerWidth + 1,
+      surfaceOverflow: surface ? surface.scrollWidth > surface.clientWidth + 1 : true
+    }
+  })()`)
+  assert(state.heading === '关于与更新', `${context} omitted the page heading`)
+  assert(state.description === '查看当前版本，检查并安装 Rovai AI 更新。',
+    `${context} used the wrong description`)
+  assert(state.product === 'Rovai AI' && state.version === 'v0.0.2',
+    `${context} used the wrong product/version: ${JSON.stringify(state)}`)
+  assert(state.action === '检查更新' && state.actionTag === 'BUTTON' && state.actionFocused,
+    `${context} did not expose a keyboard-focusable check action`)
+  assert(state.statusRole === 'status' && state.source.includes('GitHub Release'),
+    `${context} omitted updater status/source evidence`)
+  assert(!state.progressVisible && !state.forbiddenCopy,
+    `${context} rendered download or removed handoff controls while idle`)
+  assert(state.headingRule === 'none' && state.sectionRule === 'none',
+    `${context} restored vertical heading rules: ${JSON.stringify(state)}`)
+  assert(!state.documentOverflow && !state.surfaceOverflow,
+    `${context} overflowed horizontally: ${JSON.stringify(state)}`)
+}
+
+async function assertNoHorizontalOverflow(cdp, context) {
+  const state = await evaluate(cdp, `({
+    documentOverflow: document.documentElement.scrollWidth > window.innerWidth + 1,
+    surfaceOverflow: (() => {
+      const node = document.querySelector('.about-updates-settings')
+      return node ? node.scrollWidth > node.clientWidth + 1 : true
+    })()
+  })`)
+  assert(!state.documentOverflow && !state.surfaceOverflow,
+    `${context} overflowed horizontally: ${JSON.stringify(state)}`)
+}
+
+async function setTheme(cdp, preference) {
+  await evaluate(cdp, `window.rovai.appearance.setPreference(${JSON.stringify(preference)})`, true)
+  const expected = preference === 'night' ? 'night' : 'day'
+  await waitForExpression(cdp,
+    `document.documentElement.dataset.theme === ${JSON.stringify(expected)}`)
+}
+
+async function launchApp(width, height) {
+  const executable = join(appPath, 'Contents', 'MacOS', 'Rovai AI')
+  const stderr = []
+  const child = spawn(executable, [
+    `--remote-debugging-port=${port}`,
+    `--user-data-dir=${dataDir}`
+  ], {
+    cwd: root,
+    stdio: ['ignore', 'ignore', 'pipe'],
+    env: {
+      ...process.env,
+      ROVAI_ALLOW_ISOLATED_INSTANCE: '1'
+    }
+  })
+  child.stderr.on('data', (chunk) => stderr.push(String(chunk)))
+  let cdp = null
+  try {
+    const target = await waitForTarget(stderr)
+    cdp = await connectCdp(target.webSocketDebuggerUrl)
+    await cdp.send('Page.enable')
+    await cdp.send('Page.bringToFront')
+    await cdp.send('Emulation.setDeviceMetricsOverride', {
+      width,
+      height,
+      deviceScaleFactor: 1,
+      mobile: false
+    })
+    await waitForExpression(cdp,
+      `Boolean(window.rovai && document.querySelector('.app-shell'))`, 45_000)
+    const health = await evaluate(cdp, "window.rovai.request('health.check', {})", true)
+    assert(await realpath(health.database.path) === await realpath(join(dataDir, 'rovai.sqlite')),
+      `Isolated App opened the wrong database: ${JSON.stringify(health.database.path)}`)
+    return { cdp, child }
+  } catch (error) {
+    cdp?.close()
+    await terminateChild(child)
+    throw error
+  }
+}
+
+async function closeApp(app) {
+  try {
+    await Promise.race([app.cdp.send('Browser.close'), wait(1_000)])
+  } catch {
+    // The isolated App may already have exited.
+  }
+  app.cdp.close()
+  await terminateChild(app.child)
+}
+
+async function terminateChild(child) {
+  if (!child || child.exitCode !== null || child.signalCode !== null) return
+  await Promise.race([
+    new Promise((resolveExit) => child.once('exit', resolveExit)),
+    wait(15_000)
+  ])
+  if (child.exitCode !== null || child.signalCode !== null) return
+  child.kill('SIGTERM')
+  await Promise.race([
+    new Promise((resolveExit) => child.once('exit', resolveExit)),
+    wait(3_000)
+  ])
+  if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL')
+}
+
+async function capture(cdp, path) {
+  const result = await cdp.send('Page.captureScreenshot', {
+    format: 'png',
+    captureBeyondViewport: false,
+    fromSurface: true
+  })
+  await writeFile(path, Buffer.from(result.result.data, 'base64'))
+}
+
+async function evaluate(cdp, expression, awaitPromise = false) {
+  const response = await cdp.send('Runtime.evaluate', {
+    expression,
+    awaitPromise,
+    returnByValue: true
+  })
+  if (response.result?.exceptionDetails) {
+    throw new Error(response.result.exceptionDetails.exception?.description
+      ?? response.result.exceptionDetails.text
+      ?? `Evaluation failed: ${expression}`)
+  }
+  return response.result?.result?.value
+}
+
+async function waitForSelector(cdp, selector, timeoutMs = 10_000) {
+  await waitForExpression(cdp, `Boolean(document.querySelector(${JSON.stringify(selector)}))`, timeoutMs)
+}
+
+async function waitForExpression(cdp, expression, timeoutMs = 10_000) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (await evaluate(cdp, expression)) return
+    await wait(100)
+  }
+  throw new Error(`Expression did not become true within ${timeoutMs}ms: ${expression}`)
+}
+
+async function waitForTarget(stderr) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < 20_000) {
+    try {
+      const targets = await fetch(`http://127.0.0.1:${port}/json`).then((response) => response.json())
+      const target = targets.find((candidate) => candidate.type === 'page')
+      if (target) return target
+    } catch {
+      // Electron is still starting.
+    }
+    await wait(150)
+  }
+  throw new Error(`Electron DevTools target did not appear. ${stderr.join('')}`)
+}
+
+async function connectCdp(url) {
+  const socket = new WebSocket(url)
+  const pending = new Map()
+  let nextId = 1
+  await new Promise((resolveOpen, rejectOpen) => {
+    socket.addEventListener('open', resolveOpen, { once: true })
+    socket.addEventListener('error', rejectOpen, { once: true })
+  })
+  socket.addEventListener('message', (event) => {
+    const message = JSON.parse(String(event.data))
+    if (!message.id) return
+    const request = pending.get(message.id)
+    if (!request) return
+    pending.delete(message.id)
+    if (message.error) request.reject(new Error(message.error.message))
+    else request.resolve(message)
+  })
+  socket.addEventListener('close', () => {
+    for (const request of pending.values()) request.reject(new Error('CDP connection closed'))
+    pending.clear()
+  })
+  return {
+    send(method, params = {}) {
+      return new Promise((resolveSend, rejectSend) => {
+        const id = nextId++
+        pending.set(id, { resolve: resolveSend, reject: rejectSend })
+        socket.send(JSON.stringify({ id, method, params }))
+      })
+    },
+    close() {
+      socket.close()
+    }
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function wait(milliseconds) {
+  return new Promise((resolveWait) => setTimeout(resolveWait, milliseconds))
+}

--- a/scripts/accept-conversation-find-ui.mjs
+++ b/scripts/accept-conversation-find-ui.mjs
@@ -10,7 +10,7 @@ import { stagedSidecarPath } from './lib/sidecar-targets.mjs'
 import { coreDataDirectoryArguments } from './lib/runtime-camp-files-root.mjs'
 
 const root = resolve(import.meta.dirname, '..')
-const appPath = resolve(process.argv[2] ?? join(root, 'dist', 'mac-arm64', 'Rovai-ai.app'))
+const appPath = resolve(process.argv[2] ?? join(root, 'dist', 'mac-arm64', 'Rovai AI.app'))
 const fixtureRoot = process.env.ROVAI_CONVERSATION_FIND_ACCEPT_FIXTURE_ROOT
   ?? await mkdtemp(join(tmpdir(), 'rovai-conversation-find-ui-accept-'))
 const dataDir = join(fixtureRoot, 'user-data')
@@ -525,7 +525,7 @@ async function setTheme(cdp, preference) {
 }
 
 async function launchApp(port, width, height, reducedMotion) {
-  const executable = join(appPath, 'Contents', 'MacOS', 'Rovai-ai')
+  const executable = join(appPath, 'Contents', 'MacOS', 'Rovai AI')
   const stderr = []
   const child = spawn(executable, [
     `--remote-debugging-port=${port}`,

--- a/scripts/accept-diagnostics-ui.mjs
+++ b/scripts/accept-diagnostics-ui.mjs
@@ -5,7 +5,7 @@ import { spawn } from 'node:child_process'
 import { seedCompletedOnboardingForAcceptance } from './lib/dev-desktop.mjs'
 
 const root = resolve(import.meta.dirname, '..')
-const appPath = resolve(process.argv[2] ?? join(root, 'dist', 'mac-arm64', 'Rovai-ai.app'))
+const appPath = resolve(process.argv[2] ?? join(root, 'dist', 'mac-arm64', 'Rovai AI.app'))
 const fixtureRoot = process.env.ROVAI_DIAGNOSTICS_ACCEPT_FIXTURE_ROOT
   ?? await mkdtemp(join(tmpdir(), 'rovai-diagnostics-ui-accept-'))
 const outputDir = process.env.ROVAI_DIAGNOSTICS_ACCEPT_OUTPUT_DIR
@@ -298,7 +298,7 @@ async function setTheme(cdp, preference) {
 }
 
 async function launchApp(port, width, height, reducedMotion, fixture) {
-  const executable = join(appPath, 'Contents', 'MacOS', 'Rovai-ai')
+  const executable = join(appPath, 'Contents', 'MacOS', 'Rovai AI')
   const stderr = []
   const child = spawn(executable, [
     `--remote-debugging-port=${port}`,

--- a/scripts/accept-member-avatar-ui.mjs
+++ b/scripts/accept-member-avatar-ui.mjs
@@ -15,7 +15,7 @@ import { seedCompletedOnboardingForAcceptance } from './lib/dev-desktop.mjs'
 
 const root = resolve(import.meta.dirname, '..')
 const appPath = resolve(
-  process.argv[2] ?? join(root, 'dist', 'mac-arm64', 'Rovai-ai.app')
+  process.argv[2] ?? join(root, 'dist', 'mac-arm64', 'Rovai AI.app')
 )
 const dataDir = process.env.ROVAI_MEMBER_AVATAR_ACCEPT_DATA_DIR
   ?? await mkdtemp(join(tmpdir(), 'rovai-member-avatar-ui-accept-'))

--- a/scripts/accept-member-lifecycle-ui.mjs
+++ b/scripts/accept-member-lifecycle-ui.mjs
@@ -7,7 +7,7 @@ import { seedCompletedOnboardingForAcceptance } from './lib/dev-desktop.mjs'
 
 const root = resolve(import.meta.dirname, '..')
 const appPath = resolve(
-  process.argv[2] ?? join(root, 'dist', 'mac-arm64', 'Rovai-ai.app')
+  process.argv[2] ?? join(root, 'dist', 'mac-arm64', 'Rovai AI.app')
 )
 const fixtureRoot = process.env.ROVAI_MEMBER_LIFECYCLE_ACCEPT_DATA_DIR
   ?? await mkdtemp(join(tmpdir(), 'rovai-member-lifecycle-ui-accept-'))
@@ -1781,7 +1781,7 @@ async function reloadRenderer(cdp) {
 
 async function launchApp(dataDir, port, width, height) {
   const stderr = []
-  const child = spawn(join(appPath, 'Contents', 'MacOS', 'Rovai-ai'), [
+  const child = spawn(join(appPath, 'Contents', 'MacOS', 'Rovai AI'), [
     `--remote-debugging-port=${port}`,
     `--user-data-dir=${dataDir}`
   ], {

--- a/scripts/accept-memory-ui.mjs
+++ b/scripts/accept-memory-ui.mjs
@@ -5,7 +5,7 @@ import { spawn } from 'node:child_process'
 import { seedCompletedOnboardingForAcceptance } from './lib/dev-desktop.mjs'
 
 const root = resolve(import.meta.dirname, '..')
-const appPath = resolve(process.argv[2] ?? join(root, 'dist', 'mac-arm64', 'Rovai-ai.app'))
+const appPath = resolve(process.argv[2] ?? join(root, 'dist', 'mac-arm64', 'Rovai AI.app'))
 const dataDir = process.env.ROVAI_MEMORY_ACCEPT_DATA_DIR
   ?? await mkdtemp(join(tmpdir(), 'rovai-memory-ui-accept-'))
 const outputDir = process.env.ROVAI_MEMORY_ACCEPT_OUTPUT_DIR
@@ -647,7 +647,7 @@ async function assertNoHorizontalOverflow(cdp, context) {
 }
 
 async function launchApp(port, width, height) {
-  const executable = join(appPath, 'Contents', 'MacOS', 'Rovai-ai')
+  const executable = join(appPath, 'Contents', 'MacOS', 'Rovai AI')
   const stderr = []
   const child = spawn(executable, [
     `--remote-debugging-port=${port}`,

--- a/scripts/accept-notification-ui.mjs
+++ b/scripts/accept-notification-ui.mjs
@@ -7,7 +7,7 @@ import { stagedSidecarPath } from './lib/sidecar-targets.mjs'
 import { coreDataDirectoryArguments } from './lib/runtime-camp-files-root.mjs'
 
 const root = resolve(import.meta.dirname, '..')
-const appPath = resolve(process.argv[2] ?? join(root, 'dist', 'mac-arm64', 'Rovai-ai.app'))
+const appPath = resolve(process.argv[2] ?? join(root, 'dist', 'mac-arm64', 'Rovai AI.app'))
 const fixtureRoot = process.env.ROVAI_NOTIFICATION_ACCEPT_FIXTURE_ROOT
   ?? await mkdtemp(join(tmpdir(), 'rovai-notification-ui-accept-'))
 const dataDir = join(fixtureRoot, 'user-data')
@@ -691,7 +691,7 @@ async function emulateDesktopZoom(cdp, physicalWidth, physicalHeight, zoomFactor
 }
 
 async function launchApp(port, width, height, reducedMotion) {
-  const executable = join(appPath, 'Contents', 'MacOS', 'Rovai-ai')
+  const executable = join(appPath, 'Contents', 'MacOS', 'Rovai AI')
   const stderr = []
   const child = spawn(executable, [
     `--remote-debugging-port=${port}`,

--- a/scripts/accept-onboarding-ui.mjs
+++ b/scripts/accept-onboarding-ui.mjs
@@ -7,7 +7,7 @@ import { spawn, spawnSync } from 'node:child_process'
 import { assertUserDataIsIsolated } from './lib/dev-desktop.mjs'
 
 const root = resolve(import.meta.dirname, '..')
-const appPath = resolve(process.argv[2] ?? join(root, 'dist', 'mac-arm64', 'Rovai-ai.app'))
+const appPath = resolve(process.argv[2] ?? join(root, 'dist', 'mac-arm64', 'Rovai AI.app'))
 const fixtureRoot = resolve(process.env.ROVAI_ONBOARDING_ACCEPT_FIXTURE_ROOT
   ?? await mkdtemp(join(tmpdir(), 'rovai-onboarding-ui-accept-')))
 const dataDir = assertUserDataIsIsolated(join(fixtureRoot, 'user-data'))
@@ -337,7 +337,7 @@ async function launchApp(port) {
   const stderr = []
   const executable = process.platform === 'win32'
     ? appPath
-    : join(appPath, 'Contents', 'MacOS', 'Rovai-ai')
+    : join(appPath, 'Contents', 'MacOS', 'Rovai AI')
   if (process.platform === 'win32' && !existsSync(dataDir)) {
     const preparer = join(dirname(executable), 'resources', 'bin', 'rovai-core.exe')
     const prepared = spawnSync(preparer, ['--prepare-windows-data-root', dataDir], {

--- a/scripts/accept-planned-shutdown.mjs
+++ b/scripts/accept-planned-shutdown.mjs
@@ -12,7 +12,7 @@ import { querySqliteRows } from './lib/sqlite.mjs'
 const root = resolve(import.meta.dirname, '..')
 const defaultAppPath = process.platform === 'win32'
   ? join(root, 'dist', 'win-unpacked', 'Rovai-ai.exe')
-  : join(root, 'dist', 'mac-arm64', 'Rovai-ai.app')
+  : join(root, 'dist', 'mac-arm64', 'Rovai AI.app')
 const appPath = resolve(process.argv[2] ?? defaultAppPath)
 const fixtureRoot = process.env.ROVAI_PLANNED_SHUTDOWN_ACCEPT_FIXTURE_ROOT
   ?? await mkdtemp(join(tmpdir(), 'rovai-planned-shutdown-accept-'))
@@ -332,7 +332,7 @@ async function launchApp(port, width, height) {
 function packagedAppExecutable() {
   return process.platform === 'win32'
     ? appPath
-    : join(appPath, 'Contents', 'MacOS', 'Rovai-ai')
+    : join(appPath, 'Contents', 'MacOS', 'Rovai AI')
 }
 
 function packagedCoreExecutable() {

--- a/scripts/accept-runtime-activity-ui.mjs
+++ b/scripts/accept-runtime-activity-ui.mjs
@@ -12,7 +12,7 @@ import {
 } from './lib/runtime-camp-files-root.mjs'
 
 const root = resolve(import.meta.dirname, '..')
-const appPath = resolve(process.argv[2] ?? join(root, 'dist', 'mac-arm64', 'Rovai-ai.app'))
+const appPath = resolve(process.argv[2] ?? join(root, 'dist', 'mac-arm64', 'Rovai AI.app'))
 const fixtureRoot = process.env.ROVAI_RUNTIME_ACTIVITY_ACCEPT_FIXTURE_ROOT
   ?? await mkdtemp(join(tmpdir(), 'rovai-runtime-activity-ui-accept-'))
 const dataDir = join(fixtureRoot, 'user-data')
@@ -4031,7 +4031,7 @@ async function verifyExecutionPlacementWriteFailure(cdp) {
 }
 
 async function launchApp(port, width, height) {
-  const executable = join(appPath, 'Contents', 'MacOS', 'Rovai-ai')
+  const executable = join(appPath, 'Contents', 'MacOS', 'Rovai AI')
   const stderr = []
   const child = spawn(executable, [
     `--remote-debugging-port=${port}`,

--- a/scripts/accept-runtime-monitoring-ui.mjs
+++ b/scripts/accept-runtime-monitoring-ui.mjs
@@ -5,7 +5,7 @@ import { spawn } from 'node:child_process'
 import { seedCompletedOnboardingForAcceptance } from './lib/dev-desktop.mjs'
 
 const root = resolve(import.meta.dirname, '..')
-const appPath = resolve(process.argv[2] ?? join(root, 'dist', 'mac-arm64', 'Rovai-ai.app'))
+const appPath = resolve(process.argv[2] ?? join(root, 'dist', 'mac-arm64', 'Rovai AI.app'))
 const fixtureRoot = process.env.ROVAI_MONITORING_ACCEPT_FIXTURE_ROOT
   ?? await mkdtemp(join(tmpdir(), 'rovai-monitoring-ui-accept-'))
 const dataDir = join(fixtureRoot, 'user-data')
@@ -132,7 +132,7 @@ async function setTheme(cdp, preference) {
 }
 
 async function launchApp(width, height) {
-  const executable = join(appPath, 'Contents', 'MacOS', 'Rovai-ai')
+  const executable = join(appPath, 'Contents', 'MacOS', 'Rovai AI')
   const stderr = []
   const child = spawn(executable, [
     '--remote-debugging-port=' + port,

--- a/scripts/accept-sidebar-ui.mjs
+++ b/scripts/accept-sidebar-ui.mjs
@@ -5,7 +5,7 @@ import { execFileSync, spawn } from 'node:child_process'
 import { seedCompletedOnboardingForAcceptance } from './lib/dev-desktop.mjs'
 
 const root = resolve(import.meta.dirname, '..')
-const appPath = resolve(process.argv[2] ?? join(root, 'dist', 'mac-arm64', 'Rovai-ai.app'))
+const appPath = resolve(process.argv[2] ?? join(root, 'dist', 'mac-arm64', 'Rovai AI.app'))
 const fixtureRoot = process.env.ROVAI_SIDEBAR_ACCEPT_FIXTURE_ROOT
   ?? await mkdtemp(join(tmpdir(), 'rovai-sidebar-ui-accept-'))
 const dataDir = join(fixtureRoot, 'user-data')
@@ -1293,7 +1293,7 @@ async function setTheme(cdp, preference) {
 }
 
 async function launchApp(port, width, height, reducedMotion) {
-  const executable = join(appPath, 'Contents', 'MacOS', 'Rovai-ai')
+  const executable = join(appPath, 'Contents', 'MacOS', 'Rovai AI')
   const stderr = []
   const child = spawn(executable, [
     `--remote-debugging-port=${port}`,

--- a/scripts/accept-structured-mentions-ui.mjs
+++ b/scripts/accept-structured-mentions-ui.mjs
@@ -17,7 +17,7 @@ const root = resolve(import.meta.dirname, '..')
 const cliArguments = process.argv.slice(2)
 const suppliedAppPath = cliArguments.find((argument) => !argument.startsWith('--'))
 const appPath = resolve(
-  suppliedAppPath ?? join(root, 'dist', 'mac-arm64', 'Rovai-ai.app')
+  suppliedAppPath ?? join(root, 'dist', 'mac-arm64', 'Rovai AI.app')
 )
 const suppliedFixtureRoot = process.env.ROVAI_STRUCTURED_MENTIONS_ACCEPT_DATA_DIR
 const fixtureRoot = suppliedFixtureRoot
@@ -111,7 +111,7 @@ const acceptancePermissionOptions = JSON.stringify([
   }
 ])
 
-await access(join(appPath, 'Contents', 'MacOS', 'Rovai-ai'))
+await access(join(appPath, 'Contents', 'MacOS', 'Rovai AI'))
 await mkdir(dataDir, { recursive: true })
 seedCompletedOnboardingForAcceptance(dataDir)
 await mkdir(acceptanceHome, { recursive: true })
@@ -1781,7 +1781,7 @@ async function removeDirectoryWithRetry(path) {
 
 async function launchApp(userDataDir, port, width, height) {
   const stderr = []
-  const child = spawn(join(appPath, 'Contents', 'MacOS', 'Rovai-ai'), [
+  const child = spawn(join(appPath, 'Contents', 'MacOS', 'Rovai AI'), [
     `--remote-debugging-port=${port}`,
     `--user-data-dir=${userDataDir}`
   ], {

--- a/scripts/accept-task-card-ui.mjs
+++ b/scripts/accept-task-card-ui.mjs
@@ -7,7 +7,7 @@ import { stagedSidecarPath } from './lib/sidecar-targets.mjs'
 import { coreDataDirectoryArguments } from './lib/runtime-camp-files-root.mjs'
 
 const root = resolve(import.meta.dirname, '..')
-const appPath = resolve(process.argv[2] ?? join(root, 'dist', 'mac-arm64', 'Rovai-ai.app'))
+const appPath = resolve(process.argv[2] ?? join(root, 'dist', 'mac-arm64', 'Rovai AI.app'))
 const fixtureRoot = process.env.ROVAI_TASK_CARD_ACCEPT_FIXTURE_ROOT
   ?? await mkdtemp(join(tmpdir(), 'rovai-task-card-ui-accept-'))
 const dataDir = join(fixtureRoot, 'user-data')
@@ -663,7 +663,7 @@ async function setTheme(cdp, preference) {
 }
 
 async function launchApp(port, width, height, reducedMotion) {
-  const executable = join(appPath, 'Contents', 'MacOS', 'Rovai-ai')
+  const executable = join(appPath, 'Contents', 'MacOS', 'Rovai AI')
   const stderr = []
   const child = spawn(executable, [
     `--remote-debugging-port=${port}`,

--- a/scripts/accept-windows-installation.mjs
+++ b/scripts/accept-windows-installation.mjs
@@ -11,10 +11,16 @@ if (process.platform !== 'win32' || process.arch !== 'x64') {
 
 const root = resolve(import.meta.dirname, '..')
 const packageMetadata = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'))
+const executableName = packageMetadata.build.win.executableName ?? packageMetadata.build.productName
 const installer = join(
   root,
   'dist',
-  `${packageMetadata.build.productName}-${packageMetadata.version}-x64.exe`
+  packageMetadata.build.win.artifactName
+    .replaceAll('${productName}', packageMetadata.build.productName)
+    .replaceAll('${name}', packageMetadata.name)
+    .replaceAll('${version}', packageMetadata.version)
+    .replaceAll('${arch}', 'x64')
+    .replaceAll('${ext}', 'exe')
 )
 if (!existsSync(installer)) throw new Error(`Windows installer is missing: ${installer}`)
 
@@ -105,18 +111,18 @@ async function locateInstallation() {
     .find((value) => typeof value === 'string' && value.length > 0)
   const candidates = registryDirectory ? [registryDirectory, ...installCandidates] : installCandidates
   return candidates.find((candidate) => (
-    existsSync(join(candidate, `${packageMetadata.build.productName}.exe`))
+    existsSync(join(candidate, `${executableName}.exe`))
   )) ?? null
 }
 
 async function installedFileEvidence(directory) {
   const files = {
-    app: join(directory, `${packageMetadata.build.productName}.exe`),
+    app: join(directory, `${executableName}.exe`),
     core: join(directory, 'resources', 'bin', 'rovai-core.exe'),
     cli: join(directory, 'resources', 'bin', 'rovai.exe')
   }
   const unpacked = {
-    app: join(root, 'dist', 'win-unpacked', `${packageMetadata.build.productName}.exe`),
+    app: join(root, 'dist', 'win-unpacked', `${executableName}.exe`),
     core: join(root, 'dist', 'win-unpacked', 'resources', 'bin', 'rovai-core.exe'),
     cli: join(root, 'dist', 'win-unpacked', 'resources', 'bin', 'rovai.exe')
   }
@@ -136,7 +142,7 @@ async function installedFileEvidence(directory) {
 async function waitForUninstall(directory, timeoutMs = 20_000) {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
-    if (!existsSync(join(directory, `${packageMetadata.build.productName}.exe`))
+    if (!existsSync(join(directory, `${executableName}.exe`))
         && installedRovaiEntries().length === 0) return
     await new Promise((resolveWait) => setTimeout(resolveWait, 200))
   }
@@ -152,7 +158,7 @@ try {
 
   const onboarding = spawnSync(process.execPath, [
     join(root, 'scripts', 'accept-onboarding-ui.mjs'),
-    join(installDirectory, `${packageMetadata.build.productName}.exe`)
+    join(installDirectory, `${executableName}.exe`)
   ], {
     cwd: root,
     env: {
@@ -188,7 +194,7 @@ try {
   if (uninstallers.length !== 1) throw new Error(`expected one uninstaller, found ${uninstallers.length}`)
   run(join(installDirectory, uninstallers[0]), ['/currentuser', '/S'])
   await waitForUninstall(installDirectory)
-  if (existsSync(join(installDirectory, `${packageMetadata.build.productName}.exe`))) {
+  if (existsSync(join(installDirectory, `${executableName}.exe`))) {
     throw new Error('default uninstall left the application executable installed')
   }
   if (installedRovaiEntries().length > 0) throw new Error('default uninstall left its HKCU uninstall registration')

--- a/scripts/capture-camp-inspectors.mjs
+++ b/scripts/capture-camp-inspectors.mjs
@@ -32,7 +32,7 @@ const attachmentCampId =
   process.env.ROVAI_CAPTURE_CAMP_ID ?? null
 
 if (!appPath || !userDataDir) {
-  throw new Error('Usage: ROVAI_CAPTURE_USER_DATA_DIR=<data> node scripts/capture-camp-inspectors.mjs <Rovai-ai.app> [output-prefix]')
+  throw new Error('Usage: ROVAI_CAPTURE_USER_DATA_DIR=<data> node scripts/capture-camp-inspectors.mjs <Rovai AI.app> [output-prefix]')
 }
 if (theme && !['system', 'day', 'night'].includes(theme)) {
   throw new Error(`Unknown ROVAI_CAPTURE_THEME: ${theme}`)
@@ -41,7 +41,7 @@ if (!Number.isFinite(zoomFactor) || zoomFactor <= 0) {
   throw new Error(`Invalid ROVAI_CAPTURE_ZOOM_FACTOR: ${zoomFactor}`)
 }
 
-const executable = join(appPath, 'Contents', 'MacOS', 'Rovai-ai')
+const executable = join(appPath, 'Contents', 'MacOS', 'Rovai AI')
 const app = spawn(executable, [
   `--remote-debugging-port=${port}`,
   `--user-data-dir=${userDataDir}`

--- a/scripts/capture-desktop.mjs
+++ b/scripts/capture-desktop.mjs
@@ -25,7 +25,7 @@ const targetRuntimeLabel = targetRuntimeKind && ({
   'claude-code-cli': 'Claude Code CLI',
   'antigravity-app': 'Antigravity App'
 })[targetRuntimeKind]
-if (!appPath) throw new Error('Usage: node scripts/capture-desktop.mjs <Rovai-ai.app> [output-prefix]')
+if (!appPath) throw new Error('Usage: node scripts/capture-desktop.mjs <Rovai AI.app> [output-prefix]')
 const userDataDirectory = assertUserDataIsIsolated(process.env.ROVAI_CAPTURE_USER_DATA_DIR)
 seedCompletedOnboardingForAcceptance(userDataDirectory)
 if (targetRuntimeKind && !targetRuntimeLabel) throw new Error(`Unknown ROVAI_CAPTURE_RUNTIME_KIND: ${targetRuntimeKind}`)
@@ -36,7 +36,7 @@ if (!Number.isFinite(captureScale) || captureScale < 1) {
   throw new Error(`Unknown ROVAI_CAPTURE_SCALE: ${captureScale}`)
 }
 
-const executable = join(appPath, 'Contents', 'MacOS', 'Rovai-ai')
+const executable = join(appPath, 'Contents', 'MacOS', 'Rovai AI')
 const launchArguments = [
   `--remote-debugging-port=${port}`,
   `--user-data-dir=${userDataDirectory}`

--- a/scripts/capture-mcp.mjs
+++ b/scripts/capture-mcp.mjs
@@ -16,7 +16,7 @@ const outputPrefix = process.argv[3] ?? '/tmp/rovai-mcp'
 const port = Number(process.env.ROVAI_DEBUG_PORT ?? 9451)
 
 if (!appPath) {
-  throw new Error('Usage: node scripts/capture-mcp.mjs <Rovai-ai.app> [output-prefix]')
+  throw new Error('Usage: node scripts/capture-mcp.mjs <Rovai AI.app> [output-prefix]')
 }
 
 const fixtureRoot = await mkdtemp(join(tmpdir(), 'rovai-mcp-app-'))
@@ -35,7 +35,7 @@ await writeFile(join(codexHome, 'config.toml'), [
   ''
 ].join('\n'))
 
-const executable = join(appPath, 'Contents', 'MacOS', 'Rovai-ai')
+const executable = join(appPath, 'Contents', 'MacOS', 'Rovai AI')
 const app = spawn(executable, [
   `--remote-debugging-port=${port}`,
   `--user-data-dir=${userDataDir}`

--- a/scripts/capture-skills.mjs
+++ b/scripts/capture-skills.mjs
@@ -24,7 +24,7 @@ const cssHeight = Math.round(height / zoomFactor)
 const theme = process.env.ROVAI_CAPTURE_THEME ?? 'day'
 
 if (!appPath || !userDataDir) {
-  throw new Error('Usage: ROVAI_CAPTURE_USER_DATA_DIR=<data> node scripts/capture-skills.mjs <Rovai-ai.app> [output.png]')
+  throw new Error('Usage: ROVAI_CAPTURE_USER_DATA_DIR=<data> node scripts/capture-skills.mjs <Rovai AI.app> [output.png]')
 }
 if (!['day', 'night'].includes(theme)) throw new Error(`Unknown ROVAI_CAPTURE_THEME: ${theme}`)
 if (!Number.isFinite(zoomFactor) || zoomFactor <= 0) {
@@ -32,7 +32,7 @@ if (!Number.isFinite(zoomFactor) || zoomFactor <= 0) {
 }
 seedCompletedOnboardingForAcceptance(userDataDir)
 
-const executable = join(appPath, 'Contents', 'MacOS', 'Rovai-ai')
+const executable = join(appPath, 'Contents', 'MacOS', 'Rovai AI')
 const app = spawn(executable, [
   `--remote-debugging-port=${port}`,
   `--user-data-dir=${userDataDir}`

--- a/scripts/lib/macos-update-info.mjs
+++ b/scripts/lib/macos-update-info.mjs
@@ -1,0 +1,114 @@
+import { isDeepStrictEqual } from 'node:util'
+import { parse, stringify } from 'yaml'
+
+const ARCHITECTURES = ['x64', 'arm64']
+
+export function mergeMacUpdateInfoDocuments(documents) {
+  if (!Array.isArray(documents) || documents.length < 2) {
+    throw new Error('at least two latest-mac.yml documents are required')
+  }
+
+  const updateInfos = documents.map((document, index) => {
+    const value = typeof document === 'string' ? parse(document) : document
+    if (!isPlainObject(value)) throw new Error(`update document ${index + 1} is not an object`)
+    if (typeof value.version !== 'string' || value.version.length === 0) {
+      throw new Error(`update document ${index + 1} has no version`)
+    }
+    if (!Array.isArray(value.files) || value.files.length === 0) {
+      throw new Error(`update document ${index + 1} has no files`)
+    }
+    return value
+  })
+
+  const version = updateInfos[0].version
+  for (const updateInfo of updateInfos.slice(1)) {
+    if (updateInfo.version !== version) {
+      throw new Error(`cannot merge macOS update versions ${version} and ${updateInfo.version}`)
+    }
+    if (!isDeepStrictEqual(stableReleaseFields(updateInfos[0]), stableReleaseFields(updateInfo))) {
+      throw new Error('macOS update documents disagree on release metadata')
+    }
+  }
+
+  const filesByUrl = new Map()
+  for (const [documentIndex, updateInfo] of updateInfos.entries()) {
+    for (const [fileIndex, file] of updateInfo.files.entries()) {
+      validateFile(file, documentIndex, fileIndex)
+      const existing = filesByUrl.get(file.url)
+      if (existing && !isDeepStrictEqual(existing, file)) {
+        throw new Error(`macOS update file ${file.url} has conflicting metadata`)
+      }
+      filesByUrl.set(file.url, structuredClone(file))
+    }
+  }
+
+  const files = [...filesByUrl.values()].sort(compareFiles)
+  const zipFiles = files.filter((file) => file.url.toLowerCase().endsWith('.zip'))
+  for (const architecture of ARCHITECTURES) {
+    if (!zipFiles.some((file) => file.url.includes(`-${architecture}.zip`))) {
+      throw new Error(`merged macOS update info has no ${architecture} ZIP`)
+    }
+  }
+
+  const primaryZip = zipFiles[0]
+  const releaseDates = updateInfos
+    .map((updateInfo) => updateInfo.releaseDate)
+    .filter((releaseDate) => typeof releaseDate === 'string' && releaseDate.length > 0)
+    .sort()
+  return {
+    ...structuredClone(updateInfos[0]),
+    files,
+    path: primaryZip.url,
+    sha512: primaryZip.sha512,
+    ...(releaseDates.length > 0 ? { releaseDate: releaseDates.at(-1) } : {})
+  }
+}
+
+export function mergeMacUpdateInfoYaml(documents) {
+  return stringify(mergeMacUpdateInfoDocuments(documents), {
+    lineWidth: 0,
+    minContentWidth: 0
+  })
+}
+
+function stableReleaseFields(updateInfo) {
+  const { files, path, sha512, releaseDate, ...stable } = updateInfo
+  return stable
+}
+
+function validateFile(file, documentIndex, fileIndex) {
+  const label = `update document ${documentIndex + 1} file ${fileIndex + 1}`
+  if (!isPlainObject(file)) throw new Error(`${label} is not an object`)
+  if (typeof file.url !== 'string' || file.url.length === 0) {
+    throw new Error(`${label} has no URL`)
+  }
+  if (typeof file.sha512 !== 'string' || file.sha512.length < 80) {
+    throw new Error(`${label} has no complete sha512`)
+  }
+  if (!Number.isSafeInteger(file.size) || file.size <= 0) {
+    throw new Error(`${label} has no positive integer size`)
+  }
+}
+
+function compareFiles(left, right) {
+  const extensionDifference = extensionRank(left.url) - extensionRank(right.url)
+  if (extensionDifference !== 0) return extensionDifference
+  const architectureDifference = architectureRank(left.url) - architectureRank(right.url)
+  if (architectureDifference !== 0) return architectureDifference
+  return left.url.localeCompare(right.url)
+}
+
+function extensionRank(url) {
+  if (url.toLowerCase().endsWith('.zip')) return 0
+  if (url.toLowerCase().endsWith('.dmg')) return 1
+  return 2
+}
+
+function architectureRank(url) {
+  const architecture = ARCHITECTURES.findIndex((candidate) => url.includes(`-${candidate}.`))
+  return architecture === -1 ? ARCHITECTURES.length : architecture
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}

--- a/scripts/lib/macos-update-info.test.mjs
+++ b/scripts/lib/macos-update-info.test.mjs
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { mergeMacUpdateInfoDocuments, mergeMacUpdateInfoYaml } from './macos-update-info.mjs'
+
+const SHA_X64 = 'x'.repeat(88)
+const SHA_ARM64 = 'a'.repeat(88)
+
+function updateInfo(architecture, overrides = {}) {
+  const zip = `Rovai-AI-0.0.2-${architecture}.zip`
+  const dmg = `Rovai-AI-0.0.2-${architecture}.dmg`
+  const sha512 = architecture === 'x64' ? SHA_X64 : SHA_ARM64
+  return {
+    version: '0.0.2',
+    files: [
+      { url: zip, sha512, size: architecture === 'x64' ? 120 : 140 },
+      { url: dmg, sha512: `${sha512.slice(0, 87)}d`, size: architecture === 'x64' ? 220 : 240 }
+    ],
+    path: zip,
+    sha512,
+    releaseDate: architecture === 'x64'
+      ? '2026-08-24T12:00:00.000Z'
+      : '2026-08-24T12:01:00.000Z',
+    ...overrides
+  }
+}
+
+test('merges both macOS architectures with deterministic ZIP-first ordering', () => {
+  const merged = mergeMacUpdateInfoDocuments([updateInfo('arm64'), updateInfo('x64')])
+
+  assert.equal(merged.version, '0.0.2')
+  assert.deepEqual(merged.files.map((file) => file.url), [
+    'Rovai-AI-0.0.2-x64.zip',
+    'Rovai-AI-0.0.2-arm64.zip',
+    'Rovai-AI-0.0.2-x64.dmg',
+    'Rovai-AI-0.0.2-arm64.dmg'
+  ])
+  assert.equal(merged.path, 'Rovai-AI-0.0.2-x64.zip')
+  assert.equal(merged.sha512, SHA_X64)
+  assert.equal(merged.releaseDate, '2026-08-24T12:01:00.000Z')
+  assert.match(mergeMacUpdateInfoYaml([updateInfo('arm64'), updateInfo('x64')]), /version: 0\.0\.2/)
+})
+
+test('rejects version mismatches', () => {
+  assert.throws(
+    () => mergeMacUpdateInfoDocuments([
+      updateInfo('arm64'),
+      updateInfo('x64', { version: '0.0.3' })
+    ]),
+    /cannot merge macOS update versions/
+  )
+})
+
+test('rejects a manifest without both updater ZIP architectures', () => {
+  assert.throws(
+    () => mergeMacUpdateInfoDocuments([updateInfo('arm64'), updateInfo('arm64')]),
+    /no x64 ZIP/
+  )
+})
+
+test('rejects conflicting release metadata', () => {
+  assert.throws(
+    () => mergeMacUpdateInfoDocuments([
+      updateInfo('arm64', { releaseName: 'Stable' }),
+      updateInfo('x64', { releaseName: 'Preview' })
+    ]),
+    /disagree on release metadata/
+  )
+})

--- a/scripts/lib/qualification-core.mjs
+++ b/scripts/lib/qualification-core.mjs
@@ -13,7 +13,7 @@ export async function findCompetingRovaiProcesses() {
     const command = process.command
     return /^(?:\S*\/)rovai-core(?:\s|$)/.test(command)
       || /^rovai-core(?:\s|$)/.test(command)
-      || /^\S*Rovai-ai\.app\/Contents\/MacOS\/Rovai-ai(?:\s|$)/.test(command)
+      || /^\S*Rovai(?:-ai| AI)\.app\/Contents\/MacOS\/Rovai(?:-ai| AI)(?:\s|$)/.test(command)
   })
 }
 

--- a/scripts/merge-macos-update-info.mjs
+++ b/scripts/merge-macos-update-info.mjs
@@ -1,0 +1,18 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { mergeMacUpdateInfoYaml } from './lib/macos-update-info.mjs'
+
+const [outputArgument, ...inputArguments] = process.argv.slice(2)
+if (!outputArgument || inputArguments.length < 2) {
+  console.error(
+    'Usage: node scripts/merge-macos-update-info.mjs <output.yml> <first.yml> <second.yml> [...]'
+  )
+  process.exit(2)
+}
+
+const outputPath = resolve(outputArgument)
+const inputPaths = inputArguments.map((input) => resolve(input))
+const documents = await Promise.all(inputPaths.map((input) => readFile(input, 'utf8')))
+await writeFile(outputPath, mergeMacUpdateInfoYaml(documents), { mode: 0o644 })
+
+console.log(`Merged ${inputPaths.length} macOS update manifests into ${outputPath}`)

--- a/scripts/verify-macos-release.mjs
+++ b/scripts/verify-macos-release.mjs
@@ -12,6 +12,7 @@ import {
 import { tmpdir } from 'node:os'
 import { basename, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { parse as parseYaml } from 'yaml'
 
 const EXPECTED_APP_ID = 'ai.rovai.desktop'
 const EXPECTED_AUTHORITY = 'Rovai Release Signing'
@@ -32,6 +33,7 @@ const distDir = join(root, 'dist')
 const reportPath = join(distDir, `signing-report-${arch}.txt`)
 const packageMetadata = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'))
 const productName = packageMetadata.build.productName
+const executableName = packageMetadata.build.mac.executableName ?? productName
 const appName = `${productName}.app`
 const expectedArchitecture = EXPECTED_ARCHITECTURES[arch]
 const mountPoint = mkdtempSync(join(tmpdir(), `rovai-release-${arch}-`))
@@ -60,18 +62,51 @@ function run(command, args) {
 function findDmg() {
   if (!existsSync(distDir)) throw new Error('dist directory does not exist')
 
-  const expectedName = `${productName}-${packageMetadata.version}-${arch}.dmg`
+  const expectedName = artifactName('dmg')
   const exactPath = join(distDir, expectedName)
   if (existsSync(exactPath)) return exactPath
 
   const candidates = readdirSync(distDir)
-    .filter((name) => name.startsWith(`${productName}-`) && name.endsWith(`-${arch}.dmg`))
+    .filter((name) => name.endsWith(`-${arch}.dmg`))
     .map((name) => join(distDir, name))
 
   if (candidates.length !== 1) {
     throw new Error(`expected exactly one ${arch} DMG in dist, found ${candidates.length}`)
   }
   return candidates[0]
+}
+
+function verifyUpdateArtifacts() {
+  const zipPath = join(distDir, artifactName('zip'))
+  const updateInfoPath = join(distDir, 'latest-mac.yml')
+  if (!existsSync(zipPath)) throw new Error(`macOS update ZIP is missing: ${zipPath}`)
+  if (!existsSync(updateInfoPath)) throw new Error(`latest-mac.yml is missing: ${updateInfoPath}`)
+
+  const updateInfo = parseYaml(readFileSync(updateInfoPath, 'utf8'))
+  if (!updateInfo || updateInfo.version !== packageMetadata.version) {
+    throw new Error('latest-mac.yml has the wrong version')
+  }
+  const zipName = basename(zipPath)
+  const zipEntry = Array.isArray(updateInfo.files)
+    ? updateInfo.files.find((entry) => entry?.url === zipName)
+    : null
+  if (!zipEntry || typeof zipEntry.sha512 !== 'string' || zipEntry.sha512.length < 80) {
+    throw new Error(`latest-mac.yml has no complete entry for ${zipName}`)
+  }
+  if (Number(zipEntry.size) !== statSync(zipPath).size) {
+    throw new Error(`latest-mac.yml has the wrong size for ${zipName}`)
+  }
+  report.push(`Update ZIP: ${relative(root, zipPath)}`)
+  report.push('latest-mac.yml: version, sha512 and size passed')
+}
+
+function artifactName(extension) {
+  return packageMetadata.build.mac.artifactName
+    .replaceAll('${productName}', productName)
+    .replaceAll('${name}', packageMetadata.name)
+    .replaceAll('${version}', packageMetadata.version)
+    .replaceAll('${arch}', arch)
+    .replaceAll('${ext}', extension)
 }
 
 function architectureOf(binaryPath) {
@@ -95,7 +130,7 @@ function findPackagedApp() {
     .filter((candidate) => existsSync(candidate))
 
   const matching = candidates.filter((candidate) => {
-    const executable = join(candidate, 'Contents', 'MacOS', productName)
+    const executable = join(candidate, 'Contents', 'MacOS', executableName)
     try {
       const actual = architectureOf(executable)
       return actual.length === 1 && actual[0] === expectedArchitecture
@@ -171,6 +206,17 @@ try {
   if (dmgSize <= 0) throw new Error('DMG is empty')
 
   const packagedAppPath = findPackagedApp()
+  verifyUpdateArtifacts()
+  const updateConfiguration = parseYaml(readFileSync(
+    join(packagedAppPath, 'Contents', 'Resources', 'app-update.yml'),
+    'utf8'
+  ))
+  if (updateConfiguration?.provider !== 'github'
+      || updateConfiguration.owner !== 'murray17'
+      || updateConfiguration.repo !== 'rovai-ai') {
+    throw new Error('packaged app-update.yml does not target the official GitHub release channel')
+  }
+  report.push('Packaged updater channel: github/murray17/rovai-ai')
   report.push(`DMG: ${relative(root, dmgPath)}`)
   report.push(`DMG size: ${dmgSize}`)
   report.push(`Unpacked app: ${relative(root, packagedAppPath)}`)
@@ -188,7 +234,7 @@ try {
   const appPath = join(mountPoint, appName)
   if (!existsSync(appPath)) throw new Error(`${appName} is missing from the mounted DMG`)
 
-  const appExecutable = join(appPath, 'Contents', 'MacOS', productName)
+  const appExecutable = join(appPath, 'Contents', 'MacOS', executableName)
   const corePath = join(appPath, 'Contents', 'Resources', 'bin', 'rovai-core')
   const cliPath = join(appPath, 'Contents', 'Resources', 'bin', 'rovai')
   for (const requiredPath of [appExecutable, corePath, cliPath]) {

--- a/scripts/verify-windows-release.mjs
+++ b/scripts/verify-windows-release.mjs
@@ -14,6 +14,7 @@ import {
 import { release, tmpdir } from 'node:os'
 import { basename, join, relative, resolve } from 'node:path'
 import { createInterface } from 'node:readline'
+import { parse as parseYaml } from 'yaml'
 import { inspectPortableExecutable } from './lib/windows-pe.mjs'
 import { coreDataDirectoryArguments } from './lib/runtime-camp-files-root.mjs'
 
@@ -27,18 +28,30 @@ const packageMetadata = JSON.parse(await readFile(join(root, 'package.json'), 'u
 const requireSigned = process.argv.includes('--require-signed')
 const unpackedOnly = process.argv.includes('--unpacked-only')
 const appDirectory = join(dist, 'win-unpacked')
-const appExecutable = join(appDirectory, `${packageMetadata.build.productName}.exe`)
+const executableName = packageMetadata.build.win.executableName ?? packageMetadata.build.productName
+const appExecutable = join(appDirectory, `${executableName}.exe`)
 const coreExecutable = join(appDirectory, 'resources', 'bin', 'rovai-core.exe')
 const cliExecutable = join(appDirectory, 'resources', 'bin', 'rovai.exe')
 const installer = join(
   dist,
-  `${packageMetadata.build.productName}-${packageMetadata.version}-x64.exe`
+  artifactName('exe')
 )
+const installerBlockmap = `${installer}.blockmap`
+const updateInfoPath = join(dist, 'latest.yml')
 const reportPath = join(dist, 'windows-verification-report.txt')
 const manifestPath = join(dist, 'windows-release-manifest.json')
 const report = ['Rovai AI Windows x64 verification']
 let isolatedParent = null
 let core = null
+
+function artifactName(extension) {
+  return packageMetadata.build.win.artifactName
+    .replaceAll('${productName}', packageMetadata.build.productName)
+    .replaceAll('${name}', packageMetadata.name)
+    .replaceAll('${version}', packageMetadata.version)
+    .replaceAll('${arch}', 'x64')
+    .replaceAll('${ext}', extension)
+}
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
@@ -55,14 +68,74 @@ function run(command, args, options = {}) {
 }
 
 async function sha256(path) {
-  const hash = createHash('sha256')
+  return fileHash(path, 'sha256', 'hex')
+}
+
+async function sha512(path) {
+  return fileHash(path, 'sha512', 'base64')
+}
+
+async function fileHash(path, algorithm, encoding) {
+  const hash = createHash(algorithm)
   await new Promise((resolveHash, rejectHash) => {
     createReadStream(path)
       .on('data', (chunk) => hash.update(chunk))
       .once('error', rejectHash)
       .once('end', resolveHash)
   })
-  return hash.digest('hex')
+  return hash.digest(encoding)
+}
+
+async function verifyUpdateArtifacts() {
+  const packagedUpdateInfoPath = join(appDirectory, 'resources', 'app-update.yml')
+  if (!existsSync(packagedUpdateInfoPath)) {
+    throw new Error(`packaged app-update.yml is missing: ${packagedUpdateInfoPath}`)
+  }
+  const packagedUpdateInfo = parseYaml(await readFile(packagedUpdateInfoPath, 'utf8'))
+  if (packagedUpdateInfo?.provider !== 'github'
+      || packagedUpdateInfo.owner !== 'murray17'
+      || packagedUpdateInfo.repo !== 'rovai-ai') {
+    throw new Error('packaged app-update.yml does not target the official GitHub release channel')
+  }
+  report.push('Packaged updater channel: github/murray17/rovai-ai')
+  if (unpackedOnly) return null
+
+  if (!existsSync(installerBlockmap)) {
+    throw new Error(`NSIS updater blockmap is missing: ${installerBlockmap}`)
+  }
+  if (!existsSync(updateInfoPath)) {
+    throw new Error(`Windows latest.yml is missing: ${updateInfoPath}`)
+  }
+  const updateInfo = parseYaml(await readFile(updateInfoPath, 'utf8'))
+  if (!updateInfo || updateInfo.version !== packageMetadata.version) {
+    throw new Error('latest.yml has the wrong version')
+  }
+  const installerName = basename(installer)
+  const installerEntry = Array.isArray(updateInfo.files)
+    ? updateInfo.files.find((entry) => entry?.url === installerName)
+    : null
+  if (!installerEntry || installerEntry.sha512 !== await sha512(installer)) {
+    throw new Error(`latest.yml has the wrong sha512 for ${installerName}`)
+  }
+  if (Number(installerEntry.size) !== (await stat(installer)).size) {
+    throw new Error(`latest.yml has the wrong size for ${installerName}`)
+  }
+  const blockmapSize = (await stat(installerBlockmap)).size
+  if (blockmapSize <= 0) throw new Error('NSIS updater blockmap is empty')
+  report.push('latest.yml: version, sha512 and size passed')
+  report.push(`NSIS updater blockmap: ${relative(root, installerBlockmap)}`)
+  return {
+    updateInfo: {
+      path: relative(root, updateInfoPath).replaceAll('\\', '/'),
+      bytes: (await stat(updateInfoPath)).size,
+      sha256: await sha256(updateInfoPath)
+    },
+    blockmap: {
+      path: relative(root, installerBlockmap).replaceAll('\\', '/'),
+      bytes: blockmapSize,
+      sha256: await sha256(installerBlockmap)
+    }
+  }
 }
 
 function authenticode(path) {
@@ -232,6 +305,7 @@ function startCore(executable, dataDirectory) {
 
 try {
   const installerConfiguration = verifyInstallerConfiguration()
+  const updaterArtifacts = await verifyUpdateArtifacts()
   const binaries = {
     app: await verifyBinary('App', appExecutable),
     core: await verifyBinary('rovai-core', coreExecutable),
@@ -290,7 +364,7 @@ try {
     },
     signedReleaseRequired: requireSigned,
     installerConfiguration,
-    files: { ...binaries, installer: installerFile },
+    files: { ...binaries, installer: installerFile, updater: updaterArtifacts },
     packagedCoreSmoke: {
       isolatedDataRoot: true,
       healthCheck: true,


### PR DESCRIPTION
## Summary

- rename the macOS product, bundle, main executable, and helpers to Rovai AI for 0.0.2
- add the in-app check, automatic download progress, and install/restart update flow
- publish updater-compatible macOS ZIP metadata and Windows installer metadata
- harden release verification and add packaged UI acceptance coverage

## Upgrade boundary

0.0.1 requires the documented one-time manual migration to 0.0.2. Releases after 0.0.2 can use the in-app updater when artifacts are signed with the same stable identity.

## Verification

- pnpm test
- pnpm typecheck
- pnpm check:rust
- pnpm dist:mac:release:arm64
- node scripts/verify-macos-release.mjs arm64
- node scripts/accept-app-updates-ui.mjs
- signed 0.0.2 installed at /Applications/Rovai AI.app without terminating the running 0.0.1 process