### PR TITLE
fix(renderer): coalesce active Camp refreshes

### DIFF
--- a/apps/desktop/src/renderer/src/App.test.ts
+++ b/apps/desktop/src/renderer/src/App.test.ts
@@ -1,6 +1,6 @@
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type {
   ActionApprovalView,
   AdapterInstallation,
@@ -12,9 +12,11 @@ import type {
   CampOpenProjection,
   CampSnapshot,
   CanonicalRuntimeActivityView,
+  CoreMethod,
   HealthStatus,
   MessageDeliveryView,
-  NotificationActionView
+  NotificationActionView,
+  RovaiApi
 } from '@contracts'
 import {
   AppHeader,
@@ -36,6 +38,7 @@ import {
   campSnapshotWithCurrentAnchor,
   campSnapshotWithAnchoredMessages,
   commandFailureMessage,
+  createActiveCampRefreshCoordinator,
   effectiveCancellingRunIds,
   effectiveCancellingTurnIds,
   notificationFocusMatchesAction,
@@ -44,7 +47,9 @@ import {
   recentCampSnapshot,
   reconcileCancellingTurnIds,
   reconcileRunCancellationIds,
+  refreshActiveCampForCoreEvent,
   rememberCampSnapshot,
+  requestAuthoritativeCampOpenProjection,
   runtimeRecoveryFromCommandResult,
   selectProjectDirectory,
   SettingsView,
@@ -188,6 +193,162 @@ describe('active Camp event invalidation', () => {
       method: 'agent_run.terminal',
       params: { agentRunId: 'run-1' }
     }, null)).toBe(false)
+  })
+
+  it('coalesces an invalidation burst into one in-flight read and one trailing read', async () => {
+    let releaseFirstRead!: () => void
+    const firstRead = new Promise<void>((resolve) => {
+      releaseFirstRead = resolve
+    })
+    const refreshOnce = vi.fn()
+      .mockImplementationOnce(() => firstRead)
+      .mockResolvedValue(undefined)
+    const coordinator = createActiveCampRefreshCoordinator(refreshOnce)
+
+    const first = coordinator.refresh('camp-1')
+    await Promise.resolve()
+    expect(refreshOnce).toHaveBeenCalledTimes(1)
+
+    const joinedSecond = coordinator.refresh('camp-1')
+    const joinedThird = coordinator.refresh('camp-1')
+    expect(joinedSecond).toBe(first)
+    expect(joinedThird).toBe(first)
+    expect(refreshOnce).toHaveBeenCalledTimes(1)
+
+    releaseFirstRead()
+    await first
+
+    expect(refreshOnce).toHaveBeenCalledTimes(2)
+    expect(refreshOnce).toHaveBeenNthCalledWith(1, 'camp-1')
+    expect(refreshOnce).toHaveBeenNthCalledWith(2, 'camp-1')
+  })
+
+  it('refreshes terminal state from camps.open and replaces the running Camp surface', async () => {
+    const projection = (status: AgentRunView['status']): CampOpenProjection => {
+      const terminal = status === 'succeeded'
+      const complete = {
+        loadedCount: 0,
+        totalCount: 0,
+        omittedCount: 0,
+        complete: true
+      }
+      return {
+        schemaVersion: 3,
+        throughGlobalSequence: terminal ? 12 : 10,
+        camp: {
+          id: 'camp-terminal-refresh', title: '终态刷新', activationState: 'active',
+          projectBindingKind: 'quick_chat', projectPath: '/quick-chat',
+          defaultLeadAgentId: 'agent_2', version: 1,
+          createdAt: '2026-08-25T00:00:00Z', updatedAt: '2026-08-25T00:00:02Z'
+        },
+        members: [{
+          agentId: 'agent_2', displayName: '沐瓦', teamRole: '验收员', avatarRef: null,
+          accent: '#39777a', membershipStatus: 'active', leaveRequestedAt: null,
+          profilePresence: 'present', memberOrder: 0, isDefaultLead: true, version: 1
+        }],
+        tasks: [],
+        messages: [{
+          id: 'message-terminal-refresh', sequence: 1, timelineGlobalSequence: 1,
+          authorType: 'user', authorId: 'local_user', sourceAgentRunId: null,
+          body: '完成验收', content: [{ kind: 'text', text: '完成验收' }], attachments: [],
+          addressMode: 'default', addressedAgentIds: [], replyToCampMessageId: null,
+          campTurnId: 'turn-terminal-refresh', presentation: null,
+          createdAt: '2026-08-25T00:00:00Z'
+        }],
+        messageDeliveries: [],
+        turns: [{
+          id: 'turn-terminal-refresh', triggerType: 'camp_message',
+          triggerId: 'message-terminal-refresh', status: terminal ? 'completed' : 'running',
+          cancelRequestedAt: null, aggregateReasonCode: null,
+          executionBudget: TEST_EXECUTION_BUDGET, version: terminal ? 2 : 1,
+          createdAt: '2026-08-25T00:00:00Z', updatedAt: '2026-08-25T00:00:02Z',
+          endedAt: terminal ? '2026-08-25T00:00:02Z' : null
+        }],
+        agentRuns: [{
+          id: 'run-terminal-refresh', campTurnId: 'turn-terminal-refresh',
+          conversationId: 'conversation-terminal-refresh', agentId: 'agent_2', taskId: null,
+          responsibilityKey: 'direct:agent_2', responsibilityGeneration: 0,
+          purpose: '完成验收', completionRole: 'required', status,
+          waitReason: null, cancelRequestedAt: null, cancelReasonCode: null,
+          cancelAcknowledgedAt: null, terminalResolutionSource: null, terminalReasonCode: null,
+          failure: null, runtimeModel: null, executionEpoch: 1,
+          permissionSemantics: 'runtime_managed_v2', invocationKind: 'direct',
+          triggerDeliveryGeneration: 0, a2aParentAgentRunId: null,
+          a2aRootAgentRunId: null, a2aDepth: 0, executionEvidenceCount: 0,
+          hasUnsettledExternalEffects: false, workspace: { path: '/quick-chat' },
+          startingGitObservation: null, endingGitObservation: null,
+          version: terminal ? 2 : 1, createdAt: '2026-08-25T00:00:00Z',
+          startedAt: '2026-08-25T00:00:00Z',
+          endedAt: terminal ? '2026-08-25T00:00:02Z' : null,
+          updatedAt: '2026-08-25T00:00:02Z'
+        }],
+        executionEvidence: [], approvals: [], timeline: [],
+        coverage: {
+          tasks: complete,
+          messages: {
+            loadedCount: 1, totalCount: 1, omittedCount: 0, complete: true,
+            oldestLoadedSequence: 1, newestLoadedSequence: 1, hasEarlier: false
+          },
+          messageDeliveries: complete,
+          turns: { ...complete, loadedCount: 1, totalCount: 1 },
+          agentRuns: { ...complete, loadedCount: 1, totalCount: 1 },
+          executionEvidence: complete,
+          approvals: complete,
+          timeline: complete
+        }
+      }
+    }
+
+    let snapshot = campOpenProjectionAsSnapshot(projection('running'), null)
+    const renderCamp = (): string => renderToStaticMarkup(createElement(CampWorkspace, {
+      snapshot,
+      projectName: null,
+      agents: [agentProfile()],
+      busy: false,
+      onSend: async () => undefined,
+      onChangeLead: async () => undefined,
+      onTasksChanged: async () => undefined,
+      onResolveApproval: () => undefined,
+      stopping: false,
+      onStop: () => undefined
+    }))
+    const runningMarkup = renderCamp()
+    expect(runningMarkup).toContain('执行中')
+    expect(runningMarkup).toContain('status-running')
+
+    const request = vi.fn()
+    const api: Pick<RovaiApi, 'request'> = {
+      async request<T>(method: CoreMethod, params?: unknown): Promise<T> {
+        request(method, params)
+        return projection('succeeded') as T
+      }
+    }
+    const coordinator = createActiveCampRefreshCoordinator(async (campId) => {
+      const refreshed = await requestAuthoritativeCampOpenProjection(
+        api,
+        campId,
+        'trace-terminal-refresh'
+      )
+      snapshot = campOpenProjectionAsSnapshot(refreshed, snapshot)
+    })
+    const refresh = refreshActiveCampForCoreEvent({
+      method: 'agent_run.terminal',
+      params: { agentRunId: 'run-terminal-refresh' }
+    }, 'camp-terminal-refresh', coordinator)
+
+    expect(refresh).not.toBeNull()
+    await refresh
+
+    expect(request).toHaveBeenCalledWith('camps.open', {
+      traceId: 'trace-terminal-refresh',
+      campId: 'camp-terminal-refresh'
+    })
+    const refreshedMarkup = renderCamp()
+    expect(refreshedMarkup).toContain('已完成')
+    expect(refreshedMarkup).toContain('state-completed')
+    expect(refreshedMarkup).not.toContain('state-running')
+    expect(refreshedMarkup).not.toContain('execution-disclosure is-running')
+    expect(snapshot.agentRuns[0]?.status).toBe('succeeded')
   })
 })
 

--- a/apps/desktop/src/renderer/src/App.test.ts
+++ b/apps/desktop/src/renderer/src/App.test.ts
@@ -223,6 +223,26 @@ describe('active Camp event invalidation', () => {
     expect(refreshOnce).toHaveBeenNthCalledWith(2, 'camp-1')
   })
 
+  it('does not lose an invalidation at the refresh completion boundary', async () => {
+    let releaseFirstRead!: () => void
+    const firstRead = new Promise<void>((resolve) => {
+      releaseFirstRead = resolve
+    })
+    const refreshOnce = vi.fn()
+      .mockImplementationOnce(() => firstRead)
+      .mockResolvedValue(undefined)
+    const coordinator = createActiveCampRefreshCoordinator(refreshOnce)
+
+    const first = coordinator.refresh('camp-1')
+    await Promise.resolve()
+    const boundaryRefresh = firstRead.then(() => coordinator.refresh('camp-1'))
+
+    releaseFirstRead()
+    await Promise.all([first, boundaryRefresh])
+
+    expect(refreshOnce).toHaveBeenCalledTimes(2)
+  })
+
   it('refreshes terminal state from camps.open and replaces the running Camp surface', async () => {
     const projection = (status: AgentRunView['status']): CampOpenProjection => {
       const terminal = status === 'succeeded'

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -32,6 +32,7 @@ import type {
   NavigationSnapshot,
   ProjectNavigationGroup,
   RestorableLocation,
+  RovaiApi,
   HearthReviewItem,
   SendCampMessageResult,
   StoredCommandResult,
@@ -140,6 +141,71 @@ export function shouldRefreshActiveCampForCoreEvent(
     return eventCampId === activeCampId
   }
   return !eventCampId || eventCampId === activeCampId
+}
+
+export interface ActiveCampRefreshCoordinator {
+  refresh(campId: string): Promise<void>
+}
+
+export function createActiveCampRefreshCoordinator(
+  refreshOnce: (campId: string) => Promise<void>
+): ActiveCampRefreshCoordinator {
+  const activeRefreshes = new Map<string, {
+    dirty: boolean
+    completion: Promise<void>
+  }>()
+
+  return {
+    refresh(campId: string): Promise<void> {
+      const active = activeRefreshes.get(campId)
+      if (active) {
+        active.dirty = true
+        return active.completion
+      }
+
+      const entry = {
+        dirty: false,
+        completion: Promise.resolve()
+      }
+      activeRefreshes.set(campId, entry)
+      entry.completion = Promise.resolve()
+        .then(async () => {
+          let lastError: unknown = null
+          do {
+            entry.dirty = false
+            try {
+              await refreshOnce(campId)
+              lastError = null
+            } catch (nextError) {
+              lastError = nextError
+            }
+          } while (entry.dirty)
+          if (lastError !== null) throw lastError
+        })
+        .finally(() => {
+          if (activeRefreshes.get(campId) === entry) activeRefreshes.delete(campId)
+        })
+      return entry.completion
+    }
+  }
+}
+
+export function refreshActiveCampForCoreEvent(
+  event: CoreEvent,
+  activeCampId: string | null,
+  coordinator: ActiveCampRefreshCoordinator
+): Promise<void> | null {
+  return shouldRefreshActiveCampForCoreEvent(event, activeCampId) && activeCampId
+    ? coordinator.refresh(activeCampId)
+    : null
+}
+
+export function requestAuthoritativeCampOpenProjection(
+  api: Pick<RovaiApi, 'request'>,
+  campId: string,
+  traceId: string
+): Promise<CampOpenProjection> {
+  return api.request<CampOpenProjection>('camps.open', { traceId, campId })
 }
 
 type LoadState = 'loading' | 'ready' | 'error'
@@ -595,7 +661,7 @@ export function App(): React.JSX.Element {
           commandId: crypto.randomUUID(),
           command: { campId }
         })
-      : await window.rovai.request<CampOpenProjection>('camps.open', { traceId, campId })
+      : await requestAuthoritativeCampOpenProjection(window.rovai, campId, traceId)
     if (projection.schemaVersion !== 3) throw new Error('会话打开数据版本不兼容。')
     console.info(
       `[camp-open] trace=${traceId} stage=renderer_received method=${method} `
@@ -1012,7 +1078,7 @@ export function App(): React.JSX.Element {
     void activateCamp(campId, { reconcileDefaultLead: false })
   }), [activateCamp])
 
-  const refreshActiveCampSnapshot = useCallback(async (campId: string): Promise<void> => {
+  const refreshActiveCampSnapshotOnce = useCallback(async (campId: string): Promise<void> => {
     const { snapshot } = await requestCampProjection(campId, 'open')
     if (activeCampIdRef.current !== campId) return
     if (snapshot.throughGlobalSequence < campEventSequenceMarker.current) return
@@ -1020,6 +1086,16 @@ export function App(): React.JSX.Element {
     setCampSnapshot(snapshot)
     setConfirmingRunIds(new Set())
   }, [requestCampProjection, setCampSnapshot])
+
+  const activeCampRefreshCoordinator = useMemo(
+    () => createActiveCampRefreshCoordinator(refreshActiveCampSnapshotOnce),
+    [refreshActiveCampSnapshotOnce]
+  )
+
+  const refreshActiveCampSnapshot = useCallback(
+    (campId: string): Promise<void> => activeCampRefreshCoordinator.refresh(campId),
+    [activeCampRefreshCoordinator]
+  )
 
   const loadEarlierCampMessages = useCallback(async (): Promise<void> => {
     const requestedSnapshot = campSnapshotRef.current
@@ -1521,13 +1597,18 @@ export function App(): React.JSX.Element {
         }, 80)
       }
       const campId = activeCampIdRef.current
-      if (campId && shouldRefreshActiveCampForCoreEvent(event, campId)) {
-        void refreshActiveCampSnapshot(campId).catch((nextError) => {
+      const refresh = refreshActiveCampForCoreEvent(
+        event,
+        campId,
+        activeCampRefreshCoordinator
+      )
+      if (refresh && campId) {
+        void refresh.catch((nextError) => {
           if (activeCampIdRef.current === campId) setError(errorMessage(nextError))
         })
       }
     })
-  }, [loadHealth, loadMemberData, loadOverview, refreshActiveCampSnapshot])
+  }, [activeCampRefreshCoordinator, loadHealth, loadMemberData, loadOverview])
 
   useEffect(() => {
     if (!campSnapshot) {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -170,20 +170,21 @@ export function createActiveCampRefreshCoordinator(
       activeRefreshes.set(campId, entry)
       entry.completion = Promise.resolve()
         .then(async () => {
-          let lastError: unknown = null
-          do {
-            entry.dirty = false
-            try {
-              await refreshOnce(campId)
-              lastError = null
-            } catch (nextError) {
-              lastError = nextError
-            }
-          } while (entry.dirty)
-          if (lastError !== null) throw lastError
-        })
-        .finally(() => {
-          if (activeRefreshes.get(campId) === entry) activeRefreshes.delete(campId)
+          try {
+            let lastError: unknown = null
+            do {
+              entry.dirty = false
+              try {
+                await refreshOnce(campId)
+                lastError = null
+              } catch (nextError) {
+                lastError = nextError
+              }
+            } while (entry.dirty)
+            if (lastError !== null) throw lastError
+          } finally {
+            if (activeRefreshes.get(campId) === entry) activeRefreshes.delete(campId)
+          }
         })
       return entry.completion
     }

--- a/docs/architecture/camp-open-read-path.md
+++ b/docs/architecture/camp-open-read-path.md
@@ -3,7 +3,7 @@ document_type: architecture
 architecture: camp-open-read-path
 authority: desktop-camp-enter-and-progressive-read-boundaries
 status: accepted
-last_updated: 2026-08-19
+last_updated: 2026-08-25
 ---
 
 # Camp Open Read Path 架构
@@ -63,6 +63,11 @@ Renderer 可以对当前 Camp 做一次有界的额外 refresh；通知明确携
 `agent_run.runtime_model_observed` 与其他 Run projection 变化共用上述 invalidation/refresh 路径，但必须精确匹配
 当前 Camp。它只使 `AgentRunView.runtimeModel` 从默认未观察态收敛到首个可信模型，不进入 timeline、
 CampMessage 或 Run detail Evidence，也不自动打开执行台或改变当前 selection。
+
+同一 Camp 的 event-driven refresh 只允许一个 `camps.open` 在途；在途期间到达的一个或多个 invalidation
+合并为 dirty 状态，并在当前读取完成后至多追加一次 trailing refresh。不能只复用旧 Promise 后丢弃新的
+invalidation，因为后一个终态可能在首个 read transaction 开始后才持久化。trailing refresh 期间再次变脏时，
+按同一规则继续到安静点；Camp 切换与 high-water fence 仍负责拒绝旧 Camp 或倒退投影。
 
 缓存只保存最近的 Camp 投影；除完整 non-terminal Evidence 外，其他 collection 保持有界。cache hit 可立即
 恢复阅读面，但仍由 high-water refresh 验证；cache miss 不把

--- a/docs/versions/v1.28/README.md
+++ b/docs/versions/v1.28/README.md
@@ -65,7 +65,8 @@ Product Runtime 接入。复用本机 MiniMax API Key，但改用 Grok 官方 cu
 - macOS arm64、macOS x64 与 Windows x64 只在各自冻结的 adapter-scoped 证据通过后进入普通 discovery、
   检查、成员配置与执行路径；三个宿主平台不互相外推 evidence digest。
 - Windows x64 BYOK Camp 验收发现 Renderer 未消费 Core 已持久化后的通用 `agent_run.terminal` 通知；通用
-  Camp invalidation 已补齐并以平台无关回归覆盖，macOS/Windows 及所有 Runtime 共用同一终态收敛路径。
+  Camp invalidation 已补齐为 single-flight + trailing refresh，并以事件 → `camps.open` → `succeeded` 页面投影的
+  平台无关链路回归覆盖，macOS/Windows 及所有 Runtime 共用同一终态收敛路径。
 - 修复 macOS Runtime Files 持久身份误用 boot-local `st_dev` 的启动回归；marker schema 2 改用稳定卷 UUID，
   schema 1 只在确定性私有实例根内 rekey，并由 SQLite/Authority reconciliation 受控重建旧物理 View receipt。
 
@@ -93,7 +94,7 @@ External MCP 支持性裁决、文档治理与 Impeccable UI detector。
 | Decisions | 已更新 | [V1.28-D01](decisions.md#v1-28-d01)冻结 provider/Home/auth 边界，[V1.28-D02](decisions.md#v1-28-d02)冻结公开输出与平台准入，[V1.28-D03](decisions.md#v1-28-d03)冻结 External MCP 的 Plugin 追加边界，[V1.28-D04](decisions.md#v1-28-d04)保存初始 load-only 取舍，[V1.28-D05](decisions.md#v1-28-d05)冻结 native rules 与 structured compaction redelivery，[V1.28-D06](decisions.md#v1-28-d06)冻结 `>= 1.0.0` 与标准 ACP resume clean break，[V1.28-D07](decisions.md#v1-28-d07)冻结 macOS Runtime Files 稳定卷 identity 与旧 marker rekey，[V1.28-D08](decisions.md#v1-28-d08)冻结 startup rebuild failure 的 Camp-local fail-closed 边界，[V1.28-D09](decisions.md#v1-28-d09)冻结空集 controlled rebuild 的 completion 与 root receipt。 |
 | Contracts | 已更新 | [Runtime Launch and Verification v27](../../contracts/runtime-launch-and-verification-v27.md)收敛 Grok 版本门、Ready 与 continuation；[Runtime Platform Admission](../../contracts/runtime-platform-admission-v1.md)的逐平台证据边界不变。Runtime Files identity 与 Camp-local startup 隔离修复都不改变 View contract、receipt wire、错误 closed set 或 Data Contract，因此无需新建 Camp Published Attachment View contract。 |
 | Architecture | 已更新 | [Runtime Catalog Boundaries](../../architecture/runtime-catalog-boundaries.md)补充 Grok identity、provider 与原生状态边界；[Native Session Bootstrap Redelivery](../../architecture/native-session-bootstrap-redelivery.md)补充 Grok detector；[Camp Published Attachment View](../../architecture/camp-published-attachment-view.md)补充稳定卷 identity、schema-1 rekey、空集受控重建与 Camp-local fail-closed startup 隔离；[Camp Open Read Path](../../architecture/camp-open-read-path.md)明确可靠 `agent_run.terminal` 后的权威投影刷新。 |
-| UI | 已更新 | 复用现有 Runtime catalog、状态与成员参数组件；member-workspace brief 明确 generic agent text 可原样进入执行台与 final；Renderer 补齐通用 AgentRun 终态 invalidation，避免 Camp 保留运行中旧快照。 |
+| UI | 已更新 | 复用现有 Runtime catalog、状态与成员参数组件；member-workspace brief 明确 generic agent text 可原样进入执行台与 final；Renderer 补齐通用 AgentRun 终态 invalidation、single-flight/trailing refresh 与完整页面链路回归，避免 Camp 保留运行中旧快照或因连续终态通知并发读取。 |
 | Runtime Activity | 已更新 | [Registry](../../runtime-activity/registry.md)新增 Grok ACP run-level 映射。 |
 | Runtime compatibility | 已更新 | [兼容性清单](../../runtime-compatibility.md)与 macOS arm64/x64、Windows x64 三份 adapter-scoped 证据记录各自实测边界。 |
 | Documentation routing | 确认无需更新 | 既有 Runtime checklist、Research、Architecture、Contract 与 Version 路由足以到达本版本。 |

--- a/docs/versions/v1.28/checklist-report.md
+++ b/docs/versions/v1.28/checklist-report.md
@@ -57,6 +57,12 @@ fail closed，未增加 provider 专属修复，原命令有界重跑后必须�
 Windows 或 Grok 分支，因此 macOS 与其他 Runtime 同时覆盖；既有 Windows digest-bound qualification artifact
 保持字节不变。
 
+后续审查发现初版事件接线仍会让同一 Camp 的连续终态通知并发调用 `camps.open`，且测试只覆盖 invalidation
+predicate。最终实现改为 per-Camp single-flight：在途期间的失效合并为 dirty，并在当前读取后执行至多一次
+trailing refresh，避免丢失 read transaction 开始后才落库的终态。Renderer 回归同时覆盖通知接收、精确
+`camps.open` 请求、`succeeded` 权威投影返回，以及 Camp 页面从“执行中”收敛到“已完成”；burst 回归证明
+多个连续 invalidation 只产生一个在途读取和一个 trailing 读取。
+
 ## 2026-08-24 原始 `0.2.118` 基本结论（历史证据）
 
 ```text
@@ -150,7 +156,7 @@ ROVAI_GROK_PERMISSION_MODE=bypassPermissions \
 node scripts/smoke-acp-runtime.mjs
 ```
 
-最终分支的确定性门禁计数：`pnpm test` 通过 76 个 Vitest 文件（526 passed / 3 skipped）与 218 个选定
+最终分支的确定性门禁计数：`pnpm test` 通过 76 个 Vitest 文件（528 passed / 3 skipped）与 218 个选定
 Node 测试；`pnpm test:rust:pr` 通过 library 321（另 7 ignored）、CLI 27、slow 238 个测试；
 `pnpm test:rust:core` 通过 80 个测试，另有 2 个明确标记的 manual ignored 测试。`cargo fmt --all --check`、
 workspace/all-target Clippy `-D warnings`、TypeScript typecheck、Desktop build、CI 模式文档治理与 Grok 平台准入

--- a/docs/versions/v1.28/checklist-report.md
+++ b/docs/versions/v1.28/checklist-report.md
@@ -61,7 +61,8 @@ Windows 或 Grok 分支，因此 macOS 与其他 Runtime 同时覆盖；既有 W
 predicate。最终实现改为 per-Camp single-flight：在途期间的失效合并为 dirty，并在当前读取后执行至多一次
 trailing refresh，避免丢失 read transaction 开始后才落库的终态。Renderer 回归同时覆盖通知接收、精确
 `camps.open` 请求、`succeeded` 权威投影返回，以及 Camp 页面从“执行中”收敛到“已完成”；burst 回归证明
-多个连续 invalidation 只产生一个在途读取和一个 trailing 读取。
+多个连续 invalidation 只产生一个在途读取和一个 trailing 读取。completion-boundary 回归进一步证明：旧读取
+settle 后、coordinator cleanup 前到达的 invalidation 不会加入即将退出的旧 completion，而会启动后继读取。
 
 ## 2026-08-24 原始 `0.2.118` 基本结论（历史证据）
 
@@ -156,8 +157,8 @@ ROVAI_GROK_PERMISSION_MODE=bypassPermissions \
 node scripts/smoke-acp-runtime.mjs
 ```
 
-最终分支的确定性门禁计数：`pnpm test` 通过 76 个 Vitest 文件（528 passed / 3 skipped）与 218 个选定
-Node 测试；`pnpm test:rust:pr` 通过 library 321（另 7 ignored）、CLI 27、slow 238 个测试；
+最终分支的确定性门禁计数：`pnpm test` 通过 76 个 Vitest 文件（532 passed）与 198 个 Node 测试；
+`pnpm test:rust:pr` 通过 library 321（另 7 ignored）、CLI 27、slow 238 个测试；
 `pnpm test:rust:core` 通过 80 个测试，另有 2 个明确标记的 manual ignored 测试。`cargo fmt --all --check`、
 workspace/all-target Clippy `-D warnings`、TypeScript typecheck、Desktop build、CI 模式文档治理与 Grok 平台准入
 定向测试均通过。

--- a/docs/versions/v1.28/implementation-plan.md
+++ b/docs/versions/v1.28/implementation-plan.md
@@ -45,7 +45,8 @@ Checklist 仍拥有完整通用步骤，本页只记录本版本的具体状态�
   External MCP 与 Skill smoke，并更新 adapter-scoped v2 evidence；
 - [x] Windows x64 客户端以 `grok 1.0.5` + BYOK 完成同等目标主机验收，并新增独立 digest-bound evidence；
 - [x] Windows x64 BYOK Camp 验收发现 Core 已成功持久化终态但 Renderer 未消费 `agent_run.terminal`；补齐通用
-  Camp invalidation 与 Camp ID 过滤回归，macOS/Windows 和全部 Runtime 共用修复；
+  Camp invalidation、Camp ID 过滤、single-flight + trailing refresh，以及事件 → `camps.open` → `succeeded`
+  页面投影链路回归，macOS/Windows 和全部 Runtime 共用修复；
 - [x] macOS x64 使用原生 x86_64 `grok 1.0.5` 完成同等目标主机矩阵，并更新独立的 adapter-scoped v1 evidence；
 - [x] 以重启前后仅 `st_dev` 漂移的回归输入修复 macOS Runtime Files 启动失败；root/Entry identity 改用稳定
   volume UUID，schema-1 marker 在已准入私有实例根内原子 rekey，旧物理 receipt 由受控 rebuild 收敛；


### PR DESCRIPTION
## Summary

- coalesce Active Camp refreshes per Camp with one in-flight `camps.open` and dirty/trailing refresh semantics
- route terminal Core events through the authoritative Camp open path without Runtime or platform special cases
- close the completion-boundary race by removing the coordinator entry before its completion settles
- add Renderer regressions for `agent_run.terminal` → `camps.open` → succeeded projection → completed Camp UI, burst coalescing, and completion-boundary invalidation
- synchronize the Camp open architecture and v1.28 acceptance records

## Validation

- `pnpm typecheck`
- `pnpm test` (76 Vitest files: 532 passed; 198 Node tests)
- `pnpm build:desktop`
- `DOCS_BASE_REF=8feba02f8111661fdaf26d2335aafef8964e8e33 pnpm docs:check:ci`
- `pnpm test:rust:staged` (no staged Rust changes; skipped by policy)