### PR TITLE
ci: package Windows only on main

### DIFF
--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -1,18 +1,6 @@
 name: Windows x64 package
 
 on:
-  pull_request:
-    paths:
-      - "apps/desktop/**"
-      - "build/**"
-      - "crates/rovai-core/**"
-      - "resources/**"
-      - "scripts/**"
-      - "Cargo.lock"
-      - "Cargo.toml"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - ".github/workflows/windows-package.yml"
   push:
     branches:
       - main
@@ -39,7 +27,7 @@ concurrency:
 jobs:
   unsigned-package:
     name: Windows x64 unsigned package
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.ref == 'refs/heads/main'
     runs-on: windows-2022
     timeout-minutes: 120
     steps:
@@ -68,7 +56,6 @@ jobs:
         run: pnpm dist:windows:x64
 
       - name: Upload unsigned package evidence
-        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: rovai-windows-x64-unsigned-${{ github.sha }}


### PR DESCRIPTION
## Summary

- stop running the full Windows x64 NSIS package workflow on pull requests
- keep automatic packaging for matching pushes to `main`
- retain manual dispatch while guarding the package job to `main`
- simplify upload behavior now that PR runs are removed

## Validation

- parsed `.github/workflows/windows-package.yml` with the repository `yaml` dependency and asserted the main-only trigger/guard
- `git diff --check`