### PR TITLE
fix(renderer): apply Steel Mist to code blocks

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -153,8 +153,9 @@ only boundary of an input or control.
   accent. Semantic danger or attention may replace the accent when meaning requires it.
 - **Evidence:** uses the dedicated evidence and diff tokens, monospaced type where appropriate, and
   structural `+`/`-`, line numbers or labels in addition to color.
-- **Inline code:** narrative inline code uses its dedicated quiet canvas with `0 2px` padding and a
-  `3px` radius; fenced code and bounded evidence surfaces keep the stronger evidence canvas.
+- **Code:** narrative inline code uses its dedicated quiet canvas with `0 2px` padding and a `3px`
+  radius; fenced code uses the matching block canvas with an evidence border, while other bounded
+  evidence surfaces keep the stronger evidence canvas.
 - **Identity:** portraits and eight stable identity tokens are a narrow exception to the neutral
   workspace. Identity treatments do not spread into background decoration.
 

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -88,6 +88,7 @@
   --shadow-card: none;
   --approval-line: #d8bd87;
   --inline-code-canvas: #eef2f5;
+  --code-block-canvas: #eef2f5;
   --evidence-canvas: #f4f6f3;
   --evidence-surface: #ffffff;
   --evidence-ink: #252a36;
@@ -199,6 +200,7 @@
   --shadow-float: 0 22px 64px rgba(0, 0, 0, 0.42);
   --approval-line: #8f7447;
   --inline-code-canvas: #1d252b;
+  --code-block-canvas: #1d252b;
   --evidence-canvas: #12191d;
   --evidence-surface: #171f24;
   --evidence-ink: #dce4e9;
@@ -2022,7 +2024,7 @@ button.camp-world-map-live-caption { cursor: pointer; font: inherit; }
 .safe-markdown ul, .safe-markdown ol { margin: 7px 0 10px; padding-left: 21px; }
 .safe-markdown li + li { margin-top: 3px; }
 .safe-markdown blockquote { margin: 8px 0; padding: 3px 10px; border-left: 3px solid var(--line-strong); color: var(--muted); }
-.safe-markdown pre { max-width: 100%; margin: 9px 0; overflow: auto; padding: 9px 10px; border: 1px solid var(--evidence-line); border-radius: 6px; color: var(--evidence-ink); background: var(--evidence-canvas); font: 11px/1.55 ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre; }
+.safe-markdown pre { max-width: 100%; margin: 9px 0; overflow: auto; padding: 9px 10px; border: 1px solid var(--evidence-line); border-radius: 6px; color: var(--evidence-ink); background: var(--code-block-canvas); font: 11px/1.55 ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre; }
 .safe-markdown code { padding: 0 2px; border-radius: 3px; color: var(--evidence-ink); background: var(--inline-code-canvas); font: .9em/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
 .safe-markdown pre code { padding: 0; background: transparent; font-size: inherit; }
 .safe-markdown table { display: block; width: 100%; margin: 9px 0; overflow-x: auto; border-spacing: 0; border-collapse: collapse; font-size: 11px; }

--- a/apps/desktop/src/renderer/src/theme-tokens.test.ts
+++ b/apps/desktop/src/renderer/src/theme-tokens.test.ts
@@ -53,6 +53,7 @@ const requiredTokens = [
   '--focus',
   '--overlay',
   '--inline-code-canvas',
+  '--code-block-canvas',
   '--evidence-canvas',
   '--evidence-surface',
   '--evidence-ink',
@@ -101,6 +102,7 @@ function expectTextContrast(tokens: Record<string, string>): void {
     ['--info', '--info-soft'],
     ['--neutral', '--neutral-soft'],
     ['--evidence-ink', '--inline-code-canvas'],
+    ['--evidence-ink', '--code-block-canvas'],
     ['--evidence-ink', '--evidence-surface'],
     ['--evidence-muted', '--evidence-surface'],
     ['--diff-add', '--diff-add-soft'],
@@ -170,6 +172,7 @@ describe('Porcelain Day + Steel Night theme tokens', () => {
     expect(day['--rail-logo']).toBe('#526f88')
     expect(day['--mention-ink']).toBe('#2f61c8')
     expect(day['--inline-code-canvas']).toBe('#eef2f5')
+    expect(day['--code-block-canvas']).toBe('#eef2f5')
     expect(contrast(day['--mention-ink'], day['--surface'])).toBeGreaterThanOrEqual(4.5)
     expect(css).toContain('.camp-workspace { background: var(--conversation-surface); }')
     expect(css).toContain('border-left: 1px solid var(--conversation-inspector-line)')
@@ -195,6 +198,7 @@ describe('Porcelain Day + Steel Night theme tokens', () => {
     expect(night['--brand-soft']).toBe('#22303a')
     expect(night['--mention-ink']).toBe('#9cc7e2')
     expect(night['--inline-code-canvas']).toBe('#1d252b')
+    expect(night['--code-block-canvas']).toBe('#1d252b')
     expect(night['--success']).not.toBe(night['--brand'])
     expect(night['--attention']).not.toBe(night['--brand'])
     expect(night['--danger']).not.toBe(night['--brand'])
@@ -273,7 +277,7 @@ describe('Porcelain Day + Steel Night theme tokens', () => {
     expect(css).toMatch(/\.message-body\s*\{[^}]*position: relative[^}]*padding-right: 76px/)
     expect(css).toMatch(/\.message-surface\s*\{[^}]*position: static/)
     expect(css).toMatch(/\.safe-markdown code\s*\{[^}]*padding:\s*0 2px[^}]*border-radius:\s*3px[^}]*background:\s*var\(--inline-code-canvas\)/)
-    expect(css).toMatch(/\.safe-markdown pre\s*\{[^}]*background:\s*var\(--evidence-canvas\)/)
+    expect(css).toMatch(/\.safe-markdown pre\s*\{[^}]*background:\s*var\(--code-block-canvas\)/)
     expect(css).toMatch(/\.safe-markdown pre code\s*\{[^}]*padding:\s*0[^}]*background:\s*transparent/)
     expect(css).toContain('.conversation-bubble:hover .message-copy-button')
     expect(css).toContain('.conversation-bubble:hover .message-reply-button')

--- a/docs/ui/themes/porcelain-day.md
+++ b/docs/ui/themes/porcelain-day.md
@@ -4,7 +4,7 @@ authority: renderer-theme
 status: accepted
 theme_id: porcelain-day
 mode: light
-last_updated: 2026-08-24
+last_updated: 2026-08-25
 ---
 
 # Porcelain Day
@@ -120,6 +120,7 @@ Light. `color-scheme: light`.
 | Token | Value |
 |---|---:|
 | `--inline-code-canvas` | `#eef2f5` |
+| `--code-block-canvas` | `#eef2f5` |
 | `--evidence-canvas` | `#f4f6f3` |
 | `--evidence-surface` | `#ffffff` |
 | `--evidence-ink` | `#252a36` |
@@ -160,8 +161,9 @@ Light. `color-scheme: light`.
 - `danger` is for stop, permanent deletion, forgetting and confirmed failure—not ordinary disabled state.
 - Stable IDs map to `--identity-1..8`; identity color never signals state or permission.
 - Evidence never inherits brand gradients, identity fills or portraits.
-- Narrative inline code uses the quieter `--inline-code-canvas`; fenced code and bounded evidence
-  surfaces continue to use `--evidence-canvas`.
+- Narrative inline code uses `--inline-code-canvas`; fenced code uses the bounded
+  `--code-block-canvas` with its evidence border, while other evidence surfaces continue to use
+  `--evidence-canvas`.
 
 ## Contrast requirements
 

--- a/docs/ui/themes/steel-night.md
+++ b/docs/ui/themes/steel-night.md
@@ -4,7 +4,7 @@ authority: renderer-theme
 status: accepted
 theme_id: steel-night
 mode: dark
-last_updated: 2026-08-24
+last_updated: 2026-08-25
 ---
 
 # Steel Night
@@ -120,6 +120,7 @@ Dark. `color-scheme: dark`.
 | Token | Value |
 |---|---:|
 | `--inline-code-canvas` | `#1d252b` |
+| `--code-block-canvas` | `#1d252b` |
 | `--evidence-canvas` | `#12191d` |
 | `--evidence-surface` | `#171f24` |
 | `--evidence-ink` | `#dce4e9` |
@@ -160,8 +161,8 @@ Night inherits the shared non-color structure from `:root`; aliases resolve agai
 
 The same semantic separation as Day applies. Brightened identity colors retain stable ID mapping;
 they do not become statuses. Evidence and diffs remain neutral and structurally labeled. Narrative
-inline code uses the quieter `--inline-code-canvas`; fenced code and bounded evidence surfaces
-continue to use `--evidence-canvas`.
+inline code uses `--inline-code-canvas`; fenced code uses the bounded `--code-block-canvas` with its
+evidence border, while other evidence surfaces continue to use `--evidence-canvas`.
 
 ## Contrast requirements
 


### PR DESCRIPTION
## Summary

- add a dedicated Steel Mist canvas token for fenced code blocks in both themes
- keep the evidence border so block code remains a bounded artifact
- update the theme contract, design guidance, and regression coverage

## Verification

- pnpm exec vitest run apps/desktop/src/renderer/src/theme-tokens.test.ts
- pnpm typecheck
- pnpm test
- pnpm build:desktop
- Impeccable detector run; only pre-existing repository warnings found