### PR TITLE
fix(renderer): truncate long Quick Chat titles

### DIFF
--- a/apps/desktop/src/renderer/src/quick-chat-layout.test.ts
+++ b/apps/desktop/src/renderer/src/quick-chat-layout.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const styles = readFileSync(new URL('./styles.css', import.meta.url), 'utf8')
+
+describe('Quick Chat layout', () => {
+  it('shrinks long recent Camp titles into the available row width', () => {
+    expect(styles).toMatch(
+      /\.truncate\s*\{[^}]*overflow:\s*hidden;[^}]*text-overflow:\s*ellipsis;[^}]*white-space:\s*nowrap;[^}]*\}/
+    )
+    expect(styles).toMatch(
+      /\.quick-chat-continue-row \.truncate\s*\{[^}]*min-width:\s*0;[^}]*flex:\s*1 1 auto;[^}]*\}/
+    )
+  })
+})

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1601,6 +1601,7 @@ button.camp-world-map-live-caption { cursor: pointer; font: inherit; }
 .quick-chat-continue-title { padding: 0 2px 6px; color: var(--faint); font-size: 10.5px; font-weight: 700; letter-spacing: 0.6px; }
 .quick-chat-continue-row { display: flex; width: 100%; min-height: 32px; align-items: center; gap: 8px; padding: 6px 8px; border: 0; border-radius: 6px; color: var(--ink); background: transparent; cursor: pointer; font-size: 12.5px; text-align: left; }
 .quick-chat-continue-row:hover { background: var(--surface-muted); }
+.quick-chat-continue-row .truncate { min-width: 0; flex: 1 1 auto; }
 .quick-chat-continue-row .camp-marker-slot { display: block; width: 7px; height: 7px; flex: 0 0 7px; }
 .quick-chat-continue-row .camp-marker-slot .task-dot { display: block; width: 7px; height: 7px; border: 0; border-radius: 50%; background: var(--info); }
 .quick-chat-continue-row .camp-loading-spinner { margin-left: auto; }


### PR DESCRIPTION
## Summary
- let long Quick Chat recent-Camp titles shrink within their flex row
- keep the centered home stage from expanding into horizontal scrolling
- add a CSS regression test covering ellipsis and flex shrink behavior

## Validation
- `pnpm exec vitest run` (79 files, 544 passed, 3 skipped)
- `pnpm typecheck`
- `pnpm build:desktop`