### PR TITLE
fix: make command output deltas transient

### DIFF
--- a/apps/desktop/src/renderer/src/App.test.ts
+++ b/apps/desktop/src/renderer/src/App.test.ts
@@ -3777,8 +3777,43 @@ describe('task event projections', () => {
     expect(agentRunTerminalNote({
       terminalReasonCode: 'planned_shutdown_cancelled'
     })).toBe('因 Rovai 计划关闭，执行引擎已确认取消本次执行。')
+    expect(agentRunPresentation({
+      status: 'failed',
+      waitReason: null,
+      terminalReasonCode: 'runtime_interrupted'
+    })).toEqual({
+      label: '执行已中断',
+      tone: 'neutral'
+    })
+    expect(agentRunStateTag({
+      status: 'failed',
+      waitReason: null,
+      terminalReasonCode: 'runtime_interrupted'
+    })).toEqual({
+      tag: 'INTERRUPTED',
+      tone: 'neutral'
+    })
+    expect(agentRunTerminalNote({
+      terminalReasonCode: 'runtime_interrupted'
+    })).toBe('执行连续性已中断，最终结果无法确认；本次执行未被记为已取消。')
     expect(agentRunTerminalNote({ terminalReasonCode: null })).toBeNull()
     expect(formatByteSize(4_096)).toBe('4.0 KB')
+  })
+
+  it('drops 100,000 transient Command output frames before Renderer state', () => {
+    let accepted = 0
+    for (let index = 0; index < 100_000; index += 1) {
+      const event = liveRuntimeEventFromCore({
+        method: 'command.output.delta',
+        params: {
+          agentRunId: 'run-output-heavy',
+          executionEpoch: 3,
+          payload: { itemId: 'command-1', delta: `frame-${index}` }
+        }
+      }, `transient-${index}`)
+      if (event !== null) accepted += 1
+    }
+    expect(accepted).toBe(0)
   })
 
   it('omits live reasoning summaries while projecting narration, plans and execution steps', () => {
@@ -4076,6 +4111,35 @@ describe('task event projections', () => {
     expect(activityStatusForAgentRun('running', 'cancelled')).toBe('stopped')
     expect(activityStatusForAgentRun('completed', 'cancelled')).toBe('completed')
     expect(activityStatusForAgentRun('running', 'failed')).toBe('running')
+  })
+
+  it('projects an interrupted terminal as stopped without claiming cancellation', () => {
+    const canonical = canonicalActivity('command-interrupted', {
+      activityDomain: 'shell', phase: 'terminal', outcome: 'unsettled'
+    })
+    const progress = buildLiveExecutionProgress([{
+      id: 'command-interrupted-terminal',
+      agentRunId: 'run-interrupted',
+      eventType: 'activity.completed',
+      payload: {
+        reasonCode: 'runtime_interrupted',
+        item: {
+          id: 'command-interrupted',
+          type: 'commandExecution',
+          status: 'interrupted',
+          command: 'long-running-command',
+          aggregatedOutput: null
+        }
+      },
+      canonical,
+      createdAt: '2026-08-18T03:00:00Z'
+    }], 'run-interrupted')
+
+    expect(canonical.outcome).toBe('unsettled')
+    expect(progress.items[0]).toMatchObject({
+      kind: 'tool',
+      step: { status: 'stopped' }
+    })
   })
 
   it('shows a failed Claude run public failure even when no execution evidence was recorded', () => {

--- a/apps/desktop/src/renderer/src/CampWorkspace.tsx
+++ b/apps/desktop/src/renderer/src/CampWorkspace.tsx
@@ -501,9 +501,13 @@ export function attachmentDropIsBlocked({
 export function agentRunTerminalNote(
   run: Pick<AgentRunView, 'terminalReasonCode'>
 ): string | null {
-  return run.terminalReasonCode === 'planned_shutdown_cancelled'
-    ? '因 Rovai 计划关闭，执行引擎已确认取消本次执行。'
-    : null
+  if (run.terminalReasonCode === 'planned_shutdown_cancelled') {
+    return '因 Rovai 计划关闭，执行引擎已确认取消本次执行。'
+  }
+  if (run.terminalReasonCode === 'runtime_interrupted') {
+    return '执行连续性已中断，最终结果无法确认；本次执行未被记为已取消。'
+  }
+  return null
 }
 
 export function agentRunShowsUnsettledWarning(

--- a/apps/desktop/src/renderer/src/ui-model.ts
+++ b/apps/desktop/src/renderer/src/ui-model.ts
@@ -156,6 +156,9 @@ export function agentRunPresentation(
   if (run.status === 'queued') return { label: '已排队', tone: 'neutral' }
   if (run.status === 'running') return { label: '执行中', tone: 'info' }
   if (run.status === 'succeeded') return { label: '已完成', tone: 'success' }
+  if (run.terminalReasonCode === 'runtime_interrupted') {
+    return { label: '执行已中断', tone: 'neutral' }
+  }
   if (run.status === 'failed') return { label: '失败', tone: 'danger' }
   if (run.status === 'cancelled') {
     return run.terminalReasonCode === 'planned_shutdown_cancelled'
@@ -187,6 +190,9 @@ export function agentRunStateTag(
   if (run.status === 'running') return { tag: 'RUNNING', tone: 'brand' }
   if (run.status === 'queued') return { tag: 'QUEUED', tone: 'neutral' }
   if (run.status === 'succeeded') return { tag: 'DONE', tone: 'success' }
+  if (run.terminalReasonCode === 'runtime_interrupted') {
+    return { tag: 'INTERRUPTED', tone: 'neutral' }
+  }
   if (run.status === 'failed') return { tag: 'FAILED', tone: 'danger' }
   if (run.status === 'cancelled') {
     return run.terminalReasonCode === 'planned_shutdown_cancelled'
@@ -226,7 +232,6 @@ const LIVE_RUNTIME_EVENT_TYPES = new Set([
   'activity.started',
   'activity.completed',
   'agent.text.delta',
-  'command.output.delta',
   'file.change.updated',
   'agent.reasoning.summary.delta',
   'agent.thought.delta',
@@ -697,6 +702,7 @@ export function executionEvidenceResultText(
 function activityStatus(status: string | null, eventType: string): ActivityStatus {
   const normalized = status?.toLowerCase() ?? ''
   if (normalized.includes('fail') || normalized.includes('error')) return 'failed'
+  if (normalized.includes('interrupt') || normalized.includes('cancel') || normalized.includes('stop')) return 'stopped'
   if (normalized.includes('progress') || normalized.includes('running') || eventType === 'activity.started' || normalized === 'started') return 'running'
   if (normalized.includes('complete') || normalized.includes('success') || eventType === 'activity.completed') return 'completed'
   if (normalized.includes('wait') || normalized.includes('approval')) return 'waiting'
@@ -1329,6 +1335,7 @@ function canonicalActivityStatus(
   if (canonical.outcome === 'failed') return 'failed'
   if (canonical.outcome === 'succeeded') return 'completed'
   if (canonical.outcome === 'cancelled') return 'stopped'
+  if (canonical.phase === 'terminal' && fallback === 'stopped') return 'stopped'
   if (canonical.outcome !== 'unknown') return 'recorded'
   if (canonical.phase === 'started' || canonical.phase === 'progress') return 'running'
   return canonical.phase === 'terminal' ? 'recorded' : fallback

--- a/crates/rovai-core/src/antigravity.rs
+++ b/crates/rovai-core/src/antigravity.rs
@@ -1522,6 +1522,51 @@ mod tests {
     }
 
     #[test]
+    fn command_terminal_carries_the_complete_public_output() {
+        let conversation_id = "0bdd2166-d420-40c6-94be-70b93eb290c5";
+        let mut capture = AntigravityStreamCapture::default();
+        let started = normalize_antigravity_tool_step(
+            &serde_json::json!({
+                "conversation_id": conversation_id,
+                "step_index": 4,
+                "state": "RUNNING",
+                "step_type": "tool",
+                "tool_name": "run_command",
+                "tool_info": {
+                    "name": "run_command",
+                    "parameters": {"CommandLine": "pnpm test"}
+                }
+            }),
+            &mut capture,
+        )
+        .unwrap()
+        .unwrap();
+        let completed = normalize_antigravity_tool_step(
+            &serde_json::json!({
+                "conversation_id": conversation_id,
+                "step_index": 4,
+                "state": "DONE",
+                "step_type": "tool",
+                "tool_name": "run_command",
+                "tool_info": {
+                    "name": "run_command",
+                    "output": "complete Antigravity output"
+                }
+            }),
+            &mut capture,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(started.event_type, "runtime.action");
+        assert_eq!(started.payload["status"], "in_progress");
+        assert_eq!(completed.event_type, "runtime.action");
+        assert_eq!(completed.payload["status"], "completed");
+        assert_eq!(completed.payload["input"]["command"], "pnpm test");
+        assert_eq!(completed.payload["output"], "complete Antigravity output");
+    }
+
+    #[test]
     fn workspace_roots_include_canonical_execution_attachment_and_run_tmp_directories() {
         let root = std::env::temp_dir().join(format!(
             "rovai-antigravity-workspace-roots-test-{}",

--- a/crates/rovai-core/src/codex.rs
+++ b/crates/rovai-core/src/codex.rs
@@ -823,6 +823,12 @@ impl CodexRuntime {
         self.host.active_turn(&thread_id, &self.owner).await
     }
 
+    pub async fn active_command_output_route(&self) -> Option<(String, String)> {
+        let thread_id = self.thread_id().await?;
+        let turn_id = self.host.active_turn(&thread_id, &self.owner).await?;
+        Some((thread_id, turn_id))
+    }
+
     pub async fn observe_agent_message(&self, method: &str, params: &Value) {
         match method {
             "item/started" => {
@@ -844,13 +850,15 @@ impl CodexRuntime {
                     self.streamed_agent_text.lock().await.push_str(delta);
                 }
             }
-            "item/completed"
-                if params.pointer("/item/type").and_then(Value::as_str) == Some("agentMessage") =>
-            {
-                if let Some(text) = params.pointer("/item/text").and_then(Value::as_str)
-                    && !text.trim().is_empty()
-                {
-                    *self.completed_agent_message.write().await = Some(text.to_string());
+            "item/completed" => {
+                if params.pointer("/item/type").and_then(Value::as_str) == Some("agentMessage") {
+                    if let Some(text) = params.pointer("/item/text").and_then(Value::as_str)
+                        && !text.trim().is_empty()
+                    {
+                        *self.completed_agent_message.write().await = Some(text.to_string());
+                    }
+                } else if let Some(item_id) = params.pointer("/item/id").and_then(Value::as_str) {
+                    self.action_items.lock().await.remove(item_id);
                 }
             }
             _ => {}
@@ -859,6 +867,22 @@ impl CodexRuntime {
 
     pub async fn action_item(&self, item_id: &str) -> Option<Value> {
         self.action_items.lock().await.get(item_id).cloned()
+    }
+
+    pub async fn open_action_items(&self) -> Vec<Value> {
+        let mut items = self
+            .action_items
+            .lock()
+            .await
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        items.sort_by(|left, right| {
+            left.get("id")
+                .and_then(Value::as_str)
+                .cmp(&right.get("id").and_then(Value::as_str))
+        });
+        items
     }
 
     pub async fn final_agent_message(&self) -> Option<String> {
@@ -2295,14 +2319,19 @@ while IFS= read -r ignored; do :; done
     }
 
     #[test]
-    fn shared_host_route_rejects_events_from_an_old_native_turn() {
-        let route = CodexThreadRoute {
-            owner: CodexRuntimeOwner::AgentRun {
-                agent_run_id: "run-current".to_string(),
-                execution_epoch: 4,
-            },
-            active_turn_id: Some("turn-current".to_string()),
+    fn shared_host_route_rejects_old_terminalized_and_unbound_events() {
+        let owner = CodexRuntimeOwner::AgentRun {
+            agent_run_id: "run-current".to_string(),
+            execution_epoch: 4,
         };
+        let mut routes = HashMap::from([(
+            "thread-current".to_string(),
+            CodexThreadRoute {
+                owner: owner.clone(),
+                active_turn_id: Some("turn-current".to_string()),
+            },
+        )]);
+        let route = routes.get("thread-current").unwrap();
         assert!(route.owner_for_message(Some("turn-old")).is_none());
         assert!(matches!(
             route.owner_for_message(Some("turn-current")),
@@ -2311,6 +2340,22 @@ while IFS= read -r ignored; do :; done
                 execution_epoch: 4,
             }) if agent_run_id == "run-current"
         ));
+
+        routes.get_mut("thread-current").unwrap().active_turn_id = None;
+        assert!(
+            routes["thread-current"]
+                .owner_for_message(Some("turn-current"))
+                .is_none()
+        );
+        routes.remove("thread-current");
+        assert!(!routes.contains_key("thread-current"));
+        assert_eq!(
+            owner,
+            CodexRuntimeOwner::AgentRun {
+                agent_run_id: "run-current".to_string(),
+                execution_epoch: 4,
+            }
+        );
     }
 
     #[test]
@@ -2449,30 +2494,47 @@ while IFS= read -r ignored; do :; done
 
     #[test]
     fn completed_command_is_normalized_without_persisting_raw_output() {
-        let completed = completed_intercepted_action(
-            &json!({
-                "threadId": "thread-1",
-                "turnId": "turn-1",
-                "item": {
-                    "id": "item-1",
-                    "type": "commandExecution",
-                    "status": "completed",
-                    "exitCode": 0,
-                    "durationMs": 42,
-                    "aggregatedOutput": "secret output"
-                }
-            }),
-            "thread-1",
-            "turn-1",
-        )
-        .expect("valid completion should normalize")
-        .expect("command is an intercepted Action type");
+        let terminal_params = json!({
+            "threadId": "thread-1",
+            "turnId": "turn-1",
+            "item": {
+                "id": "item-1",
+                "type": "commandExecution",
+                "status": "completed",
+                "exitCode": 0,
+                "durationMs": 42,
+                "aggregatedOutput": "secret output"
+            }
+        });
+        let completed = completed_intercepted_action(&terminal_params, "thread-1", "turn-1")
+            .expect("valid completion should normalize")
+            .expect("command is an intercepted Action type");
         assert_eq!(completed.native_item_id, "item-1");
         assert!(matches!(completed.outcome, ActionResultOutcome::Succeeded));
         assert_eq!(completed.effect_disposition, "complete");
         assert_eq!(completed.result_data["exitCode"], 0);
         assert!(completed.result_data["outputDigest"].is_string());
         assert!(!completed.result_data.to_string().contains("secret output"));
+
+        let (delta_event_type, _) = normalize_event(
+            "item/commandExecution/outputDelta",
+            &json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "itemId": "item-1",
+                "delta": "secret",
+            }),
+        );
+        assert_eq!(delta_event_type, "command.output.delta");
+        let (terminal_event_type, terminal_payload) =
+            normalize_event("item/completed", &terminal_params);
+        assert_eq!(terminal_event_type, "activity.completed");
+        assert_eq!(terminal_payload["item"]["status"], "completed");
+        assert_eq!(terminal_payload["item"]["exitCode"], 0);
+        assert_eq!(
+            terminal_payload["item"]["aggregatedOutput"],
+            "secret output"
+        );
     }
 
     #[test]

--- a/crates/rovai-core/src/execution_evidence.rs
+++ b/crates/rovai-core/src/execution_evidence.rs
@@ -81,7 +81,7 @@ impl Deref for RecordedExecutionEvidence {
 pub struct ExecutionEvidenceService;
 
 impl ExecutionEvidenceService {
-    pub fn is_runtime_evidence_event(event_type: &str) -> bool {
+    pub fn is_durable_runtime_evidence_event(event_type: &str) -> bool {
         matches!(
             event_type,
             "agent.reasoning.summary.delta"
@@ -90,12 +90,15 @@ impl ExecutionEvidenceService {
                 | "runtime.plan"
                 | "runtime.plan.delta"
                 | "runtime.diagnostic"
-                | "command.output.delta"
                 | "file.change.updated"
                 | "runtime.action"
                 | "activity.started"
                 | "activity.completed"
         )
+    }
+
+    pub fn is_transient_command_output_event(event_type: &str) -> bool {
+        event_type == "command.output.delta"
     }
 
     pub fn is_batchable_runtime_delta_event(event_type: &str) -> bool {
@@ -105,9 +108,33 @@ impl ExecutionEvidenceService {
                 | "agent.thought.delta"
                 | "agent.text.delta"
                 | "runtime.plan.delta"
-                | "command.output.delta"
                 | "file.change.updated"
         )
+    }
+
+    pub fn command_output_delta_admission_open(
+        &self,
+        database: &Database,
+        agent_run_id: &str,
+        execution_epoch: i64,
+    ) -> Result<bool> {
+        database
+            .connection()
+            .query_row(
+                r#"
+                SELECT EXISTS(
+                    SELECT 1
+                    FROM agent_run
+                    WHERE id = ?1
+                      AND execution_epoch = ?2
+                      AND status IN ('running', 'waiting')
+                      AND cancel_requested_at IS NULL
+                )
+                "#,
+                params![agent_run_id, execution_epoch],
+                |row| row.get(0),
+            )
+            .map_err(Into::into)
     }
 
     pub fn prepare_runtime_event(
@@ -303,6 +330,51 @@ impl ExecutionEvidenceService {
             agent_run_id,
             execution_epoch,
             "runtime.action",
+            payload,
+            true,
+        )
+    }
+
+    pub fn record_interrupted_runtime_activity(
+        &self,
+        database: &mut Database,
+        blob_store: &ManagedBlobStore,
+        agent_run_id: &str,
+        execution_epoch: i64,
+        payload: &Value,
+    ) -> Result<Option<RecordedExecutionEvidence>> {
+        if payload.get("reasonCode").and_then(Value::as_str) != Some("runtime_interrupted")
+            || payload.pointer("/item/status").and_then(Value::as_str) != Some("interrupted")
+        {
+            anyhow::bail!("interrupted Runtime Activity must carry the interrupted terminal facts");
+        }
+        let item_id = payload
+            .pointer("/item/id")
+            .and_then(Value::as_str)
+            .context("interrupted Runtime Activity has no item id")?;
+        let started_source_key = format!("activity.started:{item_id}:updated");
+        let started_exists: bool = database.connection().query_row(
+            r#"
+            SELECT EXISTS(
+                SELECT 1
+                FROM agent_run_execution_evidence
+                WHERE agent_run_id = ?1
+                  AND execution_epoch = ?2
+                  AND source_event_key = ?3
+            )
+            "#,
+            params![agent_run_id, execution_epoch, started_source_key],
+            |row| row.get(0),
+        )?;
+        if !started_exists {
+            return Ok(None);
+        }
+        self.record_runtime_event_with_fence_policy(
+            database,
+            blob_store,
+            agent_run_id,
+            execution_epoch,
+            "activity.completed",
             payload,
             true,
         )
@@ -547,7 +619,6 @@ fn evidence_classification(
         "agent.text.delta" => Some(("narration", "updated")),
         "runtime.plan" | "runtime.plan.delta" => Some(("plan", "updated")),
         "runtime.diagnostic" => Some(("step", "updated")),
-        "command.output.delta" => Some(("command", "updated")),
         "file.change.updated" => Some(("file_change", "updated")),
         "runtime.action" => Some((
             if payload
@@ -597,10 +668,6 @@ fn normalize_public_payload(event_type: &str, payload: &Value) -> Value {
             "maxAttempts": payload.get("maxAttempts"),
             "retryAfterSeconds": payload.get("retryAfterSeconds"),
         }),
-        "command.output.delta" => serde_json::json!({
-            "itemId": payload.get("itemId"),
-            "delta": payload.get("delta").or_else(|| payload.get("output")),
-        }),
         "file.change.updated" => serde_json::json!({
             "itemId": payload.get("itemId"),
             "patch": payload.get("patch").or_else(|| payload.get("delta")),
@@ -633,6 +700,7 @@ fn normalize_public_payload(event_type: &str, payload: &Value) -> Value {
         "activity.started" | "activity.completed" => {
             let item = payload.get("item").unwrap_or(&Value::Null);
             serde_json::json!({
+                "reasonCode": payload.get("reasonCode"),
                 "item": {
                     "id": item.get("id"),
                     "type": item.get("type"),
@@ -1272,28 +1340,125 @@ mod tests {
             .prepare_binding_credential(&mut database, &run_id, execution_epoch, false)
             .unwrap();
         let blob_store = ManagedBlobStore::new(&directory);
-        let secret = format!("EVIDENCE_ONLY_{}", "x".repeat(20_000));
+        let output_delta = json!({ "itemId": "command-1", "delta": "transport only" });
+        for _ in 0..100_000 {
+            let evidence = ExecutionEvidenceService
+                .record_runtime_event(
+                    &mut database,
+                    &blob_store,
+                    &run_id,
+                    execution_epoch,
+                    "command.output.delta",
+                    &output_delta,
+                )
+                .unwrap();
+            assert!(evidence.is_none());
+        }
+        let durable_delta_count: i64 = database
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM agent_run_execution_evidence WHERE agent_run_id = ?1 AND event_type = 'command.output.delta'",
+                [&run_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(durable_delta_count, 0);
+        assert!(
+            ExecutionEvidenceService
+                .command_output_delta_admission_open(&database, &run_id, execution_epoch)
+                .unwrap()
+        );
+        assert!(
+            !ExecutionEvidenceService
+                .command_output_delta_admission_open(&database, &run_id, execution_epoch + 1)
+                .unwrap()
+        );
+        database
+            .connection()
+            .execute_batch("SAVEPOINT command_output_terminal_fence")
+            .unwrap();
+        let terminal_probe_at = chrono::Utc::now().to_rfc3339();
+        database
+            .connection()
+            .execute(
+                "UPDATE agent_run SET status = 'failed', ended_at = ?2, updated_at = ?2 WHERE id = ?1",
+                params![run_id, terminal_probe_at],
+            )
+            .unwrap();
+        assert!(
+            !ExecutionEvidenceService
+                .command_output_delta_admission_open(&database, &run_id, execution_epoch)
+                .unwrap()
+        );
+        database
+            .connection()
+            .execute_batch(
+                "ROLLBACK TO command_output_terminal_fence; RELEASE command_output_terminal_fence",
+            )
+            .unwrap();
+        assert!(
+            ExecutionEvidenceService
+                .command_output_delta_admission_open(&database, &run_id, execution_epoch)
+                .unwrap()
+        );
+
+        let secret = format!("EVIDENCE_ONLY_{}", "x".repeat(573_647));
+        let started_command = ExecutionEvidenceService
+            .record_runtime_event(
+                &mut database,
+                &blob_store,
+                &run_id,
+                execution_epoch,
+                "activity.started",
+                &json!({
+                    "item": {
+                        "id": "command-1",
+                        "type": "commandExecution",
+                        "command": "cargo test",
+                        "status": "inProgress",
+                    }
+                }),
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(started_command.sequence, 1);
         let evidence = ExecutionEvidenceService
             .record_runtime_event(
                 &mut database,
                 &blob_store,
                 &run_id,
                 execution_epoch,
-                "command.output.delta",
-                &json!({ "itemId": "command-1", "delta": secret }),
+                "activity.completed",
+                &json!({
+                    "item": {
+                        "id": "command-1",
+                        "type": "commandExecution",
+                        "command": "cargo test",
+                        "status": "completed",
+                        "exitCode": 0,
+                        "aggregatedOutput": secret,
+                    }
+                }),
             )
             .unwrap()
             .unwrap();
         assert!(evidence.inserted);
         assert!(evidence.is_truncated);
         assert!(evidence.content_blob_id.is_some());
-        assert_eq!(evidence.sequence, 1);
+        assert_eq!(evidence.sequence, 2);
         let canonical = evidence
             .canonical
             .as_ref()
             .expect("activity Evidence should persist its Canonical Projection");
         assert_eq!(canonical.activity_domain, "shell");
         assert_eq!(canonical.semantic_kind.as_deref(), Some("shell.execute"));
+        assert_eq!(evidence.payload["item"]["command"], "cargo test");
+        assert_eq!(evidence.payload["item"]["status"], "completed");
+        assert_eq!(evidence.payload["item"]["exitCode"], 0);
+        let full_payload = ExecutionEvidenceService
+            .read_full_payload(&database, &blob_store, &camp_id, &evidence.id)
+            .unwrap();
+        assert_eq!(full_payload["item"]["aggregatedOutput"], secret);
         let canonical_count: i64 = database
             .connection()
             .query_row(
@@ -1310,12 +1475,12 @@ mod tests {
                 json!({"itemId": "message-1", "delta": "hello "}),
             ),
             (
-                "command.output.delta",
-                json!({"itemId": "command-1", "delta": "line 1\n"}),
+                "agent.text.delta",
+                json!({"itemId": "message-2", "delta": "world"}),
             ),
             (
-                "command.output.delta",
-                json!({"itemId": "command-1", "delta": "line 2\n"}),
+                "agent.text.delta",
+                json!({"itemId": "message-3", "delta": "!"}),
             ),
         ]
         .into_iter()
@@ -1347,17 +1512,10 @@ mod tests {
                 .iter()
                 .map(|evidence| evidence.sequence)
                 .collect::<Vec<_>>(),
-            vec![2, 3, 4]
+            vec![3, 4, 5]
         );
         assert_eq!(batch[0].payload["delta"], "hello ");
-        assert!(batch[0].canonical.is_none());
-        let command_projection = batch[2]
-            .canonical
-            .as_ref()
-            .expect("Command Delta batch must retain its Canonical Projection");
-        assert_eq!(command_projection.last_evidence_sequence, 4);
-        assert_eq!(command_projection.revision, 3);
-        assert_eq!(command_projection.source_evidence_ids.len(), 3);
+        assert!(batch.iter().all(|evidence| evidence.canonical.is_none()));
 
         let runtime_diagnostic = ExecutionEvidenceService
             .prepare_runtime_event(
@@ -1417,7 +1575,27 @@ mod tests {
             .unwrap()
             .expect("a Built-in Tool start must be durable before execution");
         assert!(started_tool.inserted);
-        assert_eq!(started_tool.sequence, 5);
+        assert_eq!(started_tool.sequence, 6);
+
+        let interrupted_started = ExecutionEvidenceService
+            .record_runtime_event(
+                &mut database,
+                &blob_store,
+                &run_id,
+                execution_epoch,
+                "activity.started",
+                &json!({
+                    "item": {
+                        "id": "command-interrupted",
+                        "type": "commandExecution",
+                        "command": "long-running-command",
+                        "status": "inProgress",
+                    }
+                }),
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(interrupted_started.sequence, 7);
 
         let materialized = ContextService
             .materialize(
@@ -1463,6 +1641,35 @@ mod tests {
                 },
             )
             .unwrap();
+        assert!(
+            !ExecutionEvidenceService
+                .command_output_delta_admission_open(&database, &run_id, execution_epoch)
+                .unwrap()
+        );
+        let interrupted = ExecutionEvidenceService
+            .record_interrupted_runtime_activity(
+                &mut database,
+                &blob_store,
+                &run_id,
+                execution_epoch,
+                &json!({
+                    "reasonCode": "runtime_interrupted",
+                    "item": {
+                        "id": "command-interrupted",
+                        "type": "commandExecution",
+                        "command": "long-running-command",
+                        "status": "interrupted",
+                        "aggregatedOutput": null,
+                    }
+                }),
+            )
+            .unwrap()
+            .expect("an already-started Activity must receive one interruption terminal");
+        assert_eq!(interrupted.sequence, 8);
+        assert_eq!(interrupted.payload["reasonCode"], "runtime_interrupted");
+        let interrupted_canonical = interrupted.canonical.as_ref().unwrap();
+        assert_eq!(interrupted_canonical.phase, "terminal");
+        assert_eq!(interrupted_canonical.outcome, "unsettled");
         let late = ExecutionEvidenceService
             .record_runtime_event(
                 &mut database,
@@ -1518,7 +1725,7 @@ mod tests {
             .unwrap()
             .expect("terminal Team Tool result must survive the Turn fence");
         assert!(failed.inserted);
-        assert_eq!(failed.sequence, 6);
+        assert_eq!(failed.sequence, 9);
         assert_eq!(
             failed.payload["errorCode"],
             "team_tool.execution_budget_exhausted"
@@ -1550,7 +1757,7 @@ mod tests {
             .unwrap()
             .expect("the first replay observation must remain visible");
         assert!(replay.inserted);
-        assert_eq!(replay.sequence, 7);
+        assert_eq!(replay.sequence, 10);
         assert_eq!(replay.payload["idempotentReplay"], true);
 
         let replay_duplicate = ExecutionEvidenceService
@@ -1565,7 +1772,7 @@ mod tests {
             .unwrap();
         assert!(replay_duplicate.inserted);
         assert_ne!(replay_duplicate.id, replay.id);
-        assert_eq!(replay_duplicate.sequence, 8);
+        assert_eq!(replay_duplicate.sequence, 11);
 
         drop(database);
         std::fs::remove_dir_all(directory).unwrap();

--- a/crates/rovai-core/src/main.rs
+++ b/crates/rovai-core/src/main.rs
@@ -11788,6 +11788,36 @@ fn codex_delta_batch_identity(incoming: &CodexIncoming) -> Option<(&str, &str, i
     ))
 }
 
+fn is_codex_command_output_delta(message: &Value) -> bool {
+    message
+        .get("method")
+        .and_then(Value::as_str)
+        .is_some_and(|method| {
+            matches!(
+                method,
+                "item/commandExecution/outputDelta" | "command/exec/outputDelta"
+            )
+        })
+}
+
+fn is_codex_command_output_delta_batch(messages: &[Value]) -> bool {
+    !messages.is_empty() && messages.iter().all(is_codex_command_output_delta)
+}
+
+fn codex_command_output_delta_matches_route(
+    message: &Value,
+    native_thread_id: &str,
+    native_turn_id: &str,
+) -> bool {
+    message.get("method").and_then(Value::as_str) == Some("item/commandExecution/outputDelta")
+        && message.pointer("/params/threadId").and_then(Value::as_str) == Some(native_thread_id)
+        && message.pointer("/params/turnId").and_then(Value::as_str) == Some(native_turn_id)
+        && message
+            .pointer("/params/itemId")
+            .and_then(Value::as_str)
+            .is_some_and(|item_id| !item_id.trim().is_empty())
+}
+
 fn acp_delta_batch_identity(
     incoming: &AcpIncoming,
 ) -> Option<(AdapterKind, &str, &str, i64, &str, &str, &str)> {
@@ -12848,13 +12878,14 @@ async fn process_agent_run_acp_message(
                 eprintln!(
                     "failed to persist Runtime Evidence for AgentRun {agent_run_id}: {error:#}"
                 );
-                if ExecutionEvidenceService::is_runtime_evidence_event(event_type) {
+                if ExecutionEvidenceService::is_durable_runtime_evidence_event(event_type) {
                     return;
                 }
                 None
             }
         };
-    if ExecutionEvidenceService::is_runtime_evidence_event(event_type) && evidence.is_none() {
+    if ExecutionEvidenceService::is_durable_runtime_evidence_event(event_type) && evidence.is_none()
+    {
         return;
     }
     let evidence_id = evidence.as_ref().map(|evidence| evidence.id.as_str());
@@ -13241,7 +13272,7 @@ async fn persist_runtime_evidence(
     event_type: &str,
     payload: &Value,
 ) -> Result<Option<AgentRunExecutionEvidence>> {
-    if !ExecutionEvidenceService::is_runtime_evidence_event(event_type) {
+    if !ExecutionEvidenceService::is_durable_runtime_evidence_event(event_type) {
         return Ok(None);
     }
     let mut database = core.database.lock().await;
@@ -14202,6 +14233,37 @@ async fn process_runtime_usage_flusher(core: Arc<Core>, mut shutdown: oneshot::R
     }
 }
 
+async fn codex_command_output_delta_batch_admission_open(
+    core: &Core,
+    host_instance_id: &str,
+    agent_run_id: &str,
+    execution_epoch: i64,
+    messages: &[Value],
+) -> Result<bool> {
+    let Some(runtime) = core
+        .codex_cli
+        .get_agent_run_on_host(host_instance_id, agent_run_id, execution_epoch)
+        .await
+    else {
+        return Ok(false);
+    };
+    let Some((native_thread_id, native_turn_id)) = runtime.active_command_output_route().await
+    else {
+        return Ok(false);
+    };
+    if !messages.iter().all(|message| {
+        codex_command_output_delta_matches_route(message, &native_thread_id, &native_turn_id)
+    }) {
+        return Ok(false);
+    }
+    let database = core.database.lock().await;
+    ExecutionEvidenceService.command_output_delta_admission_open(
+        &database,
+        agent_run_id,
+        execution_epoch,
+    )
+}
+
 async fn process_agent_run_codex_delta_batch(
     core: &Arc<Core>,
     output: &mpsc::UnboundedSender<String>,
@@ -14211,6 +14273,27 @@ async fn process_agent_run_codex_delta_batch(
     messages: Vec<Value>,
     runtime_route_permit: &mut rovai_core::planned_shutdown::RuntimeRoutePermit,
 ) {
+    if is_codex_command_output_delta_batch(&messages) {
+        match codex_command_output_delta_batch_admission_open(
+            core,
+            host_instance_id,
+            agent_run_id,
+            execution_epoch,
+            &messages,
+        )
+        .await
+        {
+            Ok(true) => {}
+            Ok(false) => return,
+            Err(error) => {
+                eprintln!(
+                    "failed to apply the transient Command output fence for AgentRun {agent_run_id}: {error:#}"
+                );
+                return;
+            }
+        }
+        return;
+    }
     let prepared = match prepare_codex_delta_batch(&messages) {
         Ok(Some(prepared)) => prepared,
         Ok(None) => {
@@ -14309,6 +14392,60 @@ async fn process_agent_run_codex_delta_batch(
     }
 }
 
+async fn persist_interrupted_codex_activities(
+    core: &Core,
+    output: &mpsc::UnboundedSender<String>,
+    runtime: &CodexRuntime,
+    agent_run_id: &str,
+    execution_epoch: i64,
+) -> Result<usize> {
+    let mut inserted = 0_usize;
+    for mut item in runtime.open_action_items().await {
+        let Some(item_fields) = item.as_object_mut() else {
+            continue;
+        };
+        item_fields.insert(
+            "status".to_string(),
+            Value::String("interrupted".to_string()),
+        );
+        if item_fields.get("type").and_then(Value::as_str) == Some("commandExecution") {
+            item_fields.insert("aggregatedOutput".to_string(), Value::Null);
+        }
+        let payload = json!({
+            "reasonCode": "runtime_interrupted",
+            "item": item,
+        });
+        let recorded = {
+            let mut database = core.database.lock().await;
+            ExecutionEvidenceService.record_interrupted_runtime_activity(
+                &mut database,
+                &ManagedBlobStore::new(&core.data_dir),
+                agent_run_id,
+                execution_epoch,
+                &payload,
+            )?
+        };
+        let Some(recorded) = recorded else {
+            continue;
+        };
+        inserted += usize::from(recorded.inserted);
+        let evidence = recorded.into_evidence();
+        emit(
+            output,
+            &evidence.event_type,
+            json!({
+                "agentRunId": agent_run_id,
+                "executionEpoch": execution_epoch,
+                "nativeMethod": "turn/completed",
+                "evidenceId": evidence.id,
+                "payload": evidence.payload,
+                "canonical": evidence.canonical,
+            }),
+        );
+    }
+    Ok(inserted)
+}
+
 async fn process_agent_run_codex_message(
     core: &Arc<Core>,
     output: &mpsc::UnboundedSender<String>,
@@ -14380,11 +14517,32 @@ async fn process_agent_run_codex_message(
     {
         eprintln!("failed to persist Codex Usage for AgentRun {agent_run_id}: {error:#}");
     }
-    runtime.observe_agent_message(&method, &params).await;
     if method == "thread/tokenUsage/updated" {
         return;
     }
     let (event_type, payload) = codex::normalize_event(&method, &params);
+    if ExecutionEvidenceService::is_transient_command_output_event(event_type) {
+        match codex_command_output_delta_batch_admission_open(
+            core,
+            host_instance_id,
+            agent_run_id,
+            execution_epoch,
+            std::slice::from_ref(&message),
+        )
+        .await
+        {
+            Ok(true) => {}
+            Ok(false) => return,
+            Err(error) => {
+                eprintln!(
+                    "failed to apply the transient Command output fence for AgentRun {agent_run_id}: {error:#}"
+                );
+                return;
+            }
+        }
+        return;
+    }
+    runtime.observe_agent_message(&method, &params).await;
     let evidence =
         match persist_runtime_evidence(core, agent_run_id, execution_epoch, event_type, &payload)
             .await
@@ -14394,13 +14552,14 @@ async fn process_agent_run_codex_message(
                 eprintln!(
                     "failed to persist Runtime Evidence for AgentRun {agent_run_id}: {error:#}"
                 );
-                if ExecutionEvidenceService::is_runtime_evidence_event(event_type) {
+                if ExecutionEvidenceService::is_durable_runtime_evidence_event(event_type) {
                     return;
                 }
                 None
             }
         };
-    if ExecutionEvidenceService::is_runtime_evidence_event(event_type) && evidence.is_none() {
+    if ExecutionEvidenceService::is_durable_runtime_evidence_event(event_type) && evidence.is_none()
+    {
         return;
     }
     let evidence_id = evidence.as_ref().map(|evidence| evidence.id.as_str());
@@ -14506,6 +14665,20 @@ async fn process_agent_run_codex_message(
         eprintln!("ignored fenced native Turn completion for AgentRun {agent_run_id}");
         return;
     }
+    if completed.status == "interrupted"
+        && let Err(error) = persist_interrupted_codex_activities(
+            core,
+            output,
+            &runtime,
+            agent_run_id,
+            execution_epoch,
+        )
+        .await
+    {
+        eprintln!(
+            "failed to persist interrupted Runtime Activities for AgentRun {agent_run_id}: {error:#}"
+        );
+    }
     if let Err(error) =
         flush_runtime_monitoring_run(core, agent_run_id, execution_epoch, "terminal_flush").await
     {
@@ -14520,8 +14693,10 @@ async fn process_agent_run_codex_message(
     };
     let planned_outcome = if completed.status == "completed" && final_agent_message.is_some() {
         RuntimeTerminalOutcome::Succeeded
-    } else if matches!(completed.status.as_str(), "cancelled" | "interrupted") {
+    } else if completed.status == "cancelled" {
         RuntimeTerminalOutcome::Cancelled
+    } else if completed.status == "interrupted" {
+        RuntimeTerminalOutcome::Interrupted
     } else {
         RuntimeTerminalOutcome::Failed
     };
@@ -14560,10 +14735,10 @@ async fn process_agent_run_codex_message(
                 .flatten()
                 .map(|execution| execution.workspace.execution_root)
         };
-        let error_code = if completed.status == "completed" {
-            "runtime_missing_final_output".to_string()
-        } else {
-            format!("runtime_turn_{}", completed.status)
+        let error_code = match completed.status.as_str() {
+            "completed" => "runtime_missing_final_output".to_string(),
+            "interrupted" => "runtime_interrupted".to_string(),
+            status => format!("runtime_turn_{status}"),
         };
         let error_detail = Some(match &completed.error {
             Some(error) => format!(
@@ -14718,7 +14893,11 @@ async fn process_agent_run_codex_message(
                         agent_run_id: agent_run_id.to_string(),
                         expected_version: execution.version,
                         execution_epoch,
-                        error_code: format!("runtime_turn_{}", completed.status),
+                        error_code: if completed.status == "interrupted" {
+                            "runtime_interrupted".to_string()
+                        } else {
+                            format!("runtime_turn_{}", completed.status)
+                        },
                         error_detail: Some(match &completed.error {
                             Some(error) => format!(
                                 "Codex Native Turn {} ended as {}: {}",
@@ -17079,6 +17258,73 @@ while IFS= read -r _ignored; do :; done
         }
         let codex_terminal = codex_message("codex-host", "run-1", 2, "item/completed");
         assert!(codex_delta_batch_identity(&codex_terminal).is_none());
+        let command_output_delta = CodexIncoming::Message {
+            host_instance_id: "codex-host".to_string(),
+            agent_run_id: "run-1".to_string(),
+            execution_epoch: 2,
+            message: json!({
+                "method": "item/commandExecution/outputDelta",
+                "params": {
+                    "threadId": "thread-1",
+                    "turnId": "turn-1",
+                    "itemId": "command-1",
+                    "delta": "line one\n",
+                }
+            }),
+        };
+        assert_eq!(
+            codex_delta_batch_identity(&command_output_delta),
+            Some(("codex-host", "run-1", 2))
+        );
+        let CodexIncoming::Message {
+            message: command_output_message,
+            ..
+        } = command_output_delta
+        else {
+            unreachable!()
+        };
+        assert!(is_codex_command_output_delta_batch(std::slice::from_ref(
+            &command_output_message
+        )));
+        assert!(codex_command_output_delta_matches_route(
+            &command_output_message,
+            "thread-1",
+            "turn-1"
+        ));
+        assert!(!codex_command_output_delta_matches_route(
+            &command_output_message,
+            "thread-1",
+            "turn-old"
+        ));
+        assert!(!codex_command_output_delta_matches_route(
+            &command_output_message,
+            "thread-old",
+            "turn-1"
+        ));
+        let legacy_output_delta = json!({
+            "method": "command/exec/outputDelta",
+            "params": {"itemId": "command-1", "delta": "legacy"}
+        });
+        assert!(is_codex_command_output_delta(&legacy_output_delta));
+        assert!(!codex_command_output_delta_matches_route(
+            &legacy_output_delta,
+            "thread-1",
+            "turn-1"
+        ));
+        let missing_item_id = json!({
+            "method": "item/commandExecution/outputDelta",
+            "params": {"threadId": "thread-1", "turnId": "turn-1", "delta": "late"}
+        });
+        assert!(!codex_command_output_delta_matches_route(
+            &missing_item_id,
+            "thread-1",
+            "turn-1"
+        ));
+        assert!(
+            prepare_codex_delta_batch(std::slice::from_ref(&command_output_message))
+                .unwrap()
+                .is_none()
+        );
 
         let acp_delta = acp_message(
             (
@@ -18286,6 +18532,42 @@ while IFS= read -r _ignored; do :; done
             assert_eq!(payload["output"], expected_output, "{adapter_kind}");
             assert!(!serialized.contains(secret), "{adapter_kind}");
             assert!(payload["rawOutputDigest"].is_string(), "{adapter_kind}");
+        }
+    }
+
+    #[test]
+    fn every_acp_adapter_uses_terminal_runtime_action_output_not_command_delta() {
+        let acp_adapters = AdapterKind::ALL
+            .into_iter()
+            .filter(|adapter_kind| adapter_kind.uses_acp())
+            .collect::<Vec<_>>();
+        assert_eq!(acp_adapters.len(), 10);
+        for adapter_kind in acp_adapters {
+            let expected_output = format!("{} terminal output", adapter_kind.as_str());
+            let (event_type, payload) = normalize_acp_event(
+                adapter_kind,
+                "session/update",
+                &json!({
+                    "update": {
+                        "sessionUpdate": "tool_call_update",
+                        "toolCallId": format!("{}-command", adapter_kind.as_str()),
+                        "status": "completed",
+                        "kind": "execute",
+                        "content": [{"type": "text", "text": expected_output}],
+                    }
+                }),
+            );
+            assert_eq!(event_type, "runtime.action", "{adapter_kind:?}");
+            assert_eq!(payload["status"], "completed", "{adapter_kind:?}");
+            assert_eq!(payload["output"], expected_output, "{adapter_kind:?}");
+            assert!(
+                ExecutionEvidenceService::is_durable_runtime_evidence_event(event_type),
+                "{adapter_kind:?}"
+            );
+            assert!(
+                !ExecutionEvidenceService::is_transient_command_output_event(event_type),
+                "{adapter_kind:?}"
+            );
         }
     }
 

--- a/crates/rovai-core/src/planned_shutdown.rs
+++ b/crates/rovai-core/src/planned_shutdown.rs
@@ -40,6 +40,7 @@ pub enum RuntimeTerminalOutcome {
     Succeeded,
     Failed,
     Cancelled,
+    Interrupted,
 }
 
 impl RuntimeTerminalOutcome {
@@ -48,6 +49,7 @@ impl RuntimeTerminalOutcome {
             Self::Succeeded => "succeeded",
             Self::Failed => "failed",
             Self::Cancelled => "cancelled",
+            Self::Interrupted => "interrupted",
         }
     }
 }

--- a/crates/rovai-core/src/runtime.rs
+++ b/crates/rovai-core/src/runtime.rs
@@ -4880,6 +4880,7 @@ fn planned_shutdown_abortive_terminal_facts(
     match outcome {
         RuntimeTerminalOutcome::Failed => Ok(("failed", "planned_shutdown_failed")),
         RuntimeTerminalOutcome::Cancelled => Ok(("cancelled", "planned_shutdown_cancelled")),
+        RuntimeTerminalOutcome::Interrupted => Ok(("failed", "runtime_interrupted")),
         RuntimeTerminalOutcome::Succeeded => {
             anyhow::bail!("planned shutdown abortive settlement cannot record success")
         }
@@ -6796,6 +6797,10 @@ mod tests {
                 (
                     RuntimeTerminalOutcome::Cancelled,
                     ("cancelled", "planned_shutdown_cancelled"),
+                ),
+                (
+                    RuntimeTerminalOutcome::Interrupted,
+                    ("failed", "runtime_interrupted"),
                 ),
             ] {
                 assert_eq!(

--- a/docs/architecture/foundational-invariants.md
+++ b/docs/architecture/foundational-invariants.md
@@ -1,7 +1,7 @@
 ---
 document_type: architecture
 authority: current-foundational-invariants
-last_updated: 2026-08-25
+last_updated: 2026-08-26
 ---
 
 # 当前基础架构不变量
@@ -366,7 +366,7 @@ last_updated: 2026-08-25
 - Canonical Runtime Activity 是 Core 从不可变 Evidence 构建、持久但可重建的版本化投影，不是新的效果真源。Lifecycle/Read Side 只从选定的 canonical projection 派生，不跳过它直接从 Runtime 标题或 evidence payload 猜状态。
 - `source_event_key` 与 Core-scoped `operationId` 是严格分离的身份：前者只在一个已声明 observation scope 内去重单个来源事件，后者才能跨 phase/evidence 合并同一操作。Core 只接受协议原生 ID、自有调用/receipt 关联或 Adapter 按封闭规则构造的可证明身份；不用时间、文本、路径或顺序相似性聚合。重放使用同一规则得到同一 identity/归约结果。
 - Activity Domain（历史字段名 `capabilityKind`）是稳定顶层观测域；可选 `semanticKind` 只能在 Evidence 支持时细分，`presentationHint` 永不成为 canonical semantics。Domain/kind 词汇扩展必须在 Mapping Registry 注册、版本化并提供 replay fixture；无证据时保留已有域或 `unknown`。
-- `phase` 只表示 started/progress/terminal 位置，`outcome` 独立表示证据支持的结果。乱序、冲突、waiting、Run 终态和 recovery 使用同一 reducer，不能从进程退出或 UI 消失猜 success/cancelled。
+- `phase` 只表示 started/progress/terminal 位置，`outcome` 独立表示证据支持的结果。乱序、冲突、waiting、Run 终态和 recovery 使用同一 reducer，不能从进程退出或 UI 消失猜 success/cancelled。Runtime 明确报告连续性中断时，未结算 operation 使用 `phase=terminal / outcome=unsettled / reasonCode=runtime_interrupted`；只有 Runtime 的权威取消终态才能写成 `cancelled`，仍可恢复的 Host 失联继续属于 recovery 而不是 interruption terminal。
 - 每个 operation 的默认 classifier/version 首次建立后固定。新分类器通过显式平行 reprojection 和可追溯迁移产生，不静默改写历史，也不中途改变 live operation 语义。
 - 分类升级生成显式平行 projection/version，携带来源 Evidence set、classifier/mapping digest、输出 digest 和可回滚迁移记录；默认历史读取保持首次建立版本，live operation 不中途换 classifier。当前产品只维护一张 current Canonical Activity Projection 和当前 Mapping Registry；任意历史身份 replay 基础设施未准入前，不伪造已支持的重放能力。
 - 所有已接入 Runtime 共享同一 Activity contract/schema；Coverage level 只描述 Adapter 能实际观测的 `fine_grained | run_level | unknown`，不降级全局合同，也不表示未观测操作未发生。初始分层和每次升级都必须有真实 Runtime evidence、Registry 变更、fixture 与恢复一致性验证。
@@ -377,6 +377,14 @@ last_updated: 2026-08-25
   相邻 raw object 字段不公开；command 观察必须绑定同一原生 operation identity，terminal 优先采用自身当前的
   公共 command，仅在缺失时回退 started phase 缓存，不能要求 Renderer 从 digest、title、output 或私有
   terminal 还原。
+- Codex `command.output.delta` 只是 stdout/stderr 运输片段。未来新事件必须在同一 Host/Run/execution epoch、
+  Native Thread/Turn、active route 与 Run cancellation/terminal fence 下完成准入检查，随后直接丢弃；它不写
+  Execution Evidence、不推进 Canonical Activity、不创建 Managed Blob，也不进入 Renderer live event state。
+  `item/completed` 的 `aggregatedOutput` 是 Command 最终输出的唯一权威，大输出继续按既有阈值进入 Managed Blob。
+  已存在的历史 delta Evidence/Blob 保持原样且仍可读取，本规则不迁移、删除、重写或重建历史。
+- Adapter 必须优先从原生 terminal semantic event 提供完整公开输出。若未来某个 Adapter 无法提供完整 terminal
+  aggregate，只能在 Adapter 内使用有硬上限、Run 结束即删除的临时 spool，并在 terminal 生成完整或明确
+  truncated 的单一结果；Core 与 Renderer 都不得无限拼接字符串，也不得退回逐片段持久化。
 
 <a id="evidence-usage"></a>
 

--- a/docs/contracts/run-process-detail-surface-v20.md
+++ b/docs/contracts/run-process-detail-surface-v20.md
@@ -4,7 +4,7 @@ contract: run-process-detail-surface-v20
 authority: agent-process-tool-grouping
 status: accepted
 source_version: v1.28
-last_updated: 2026-08-25
+last_updated: 2026-08-26
 ---
 
 # Run Process Detail Surface v20（连续 Tool 聚合）
@@ -29,6 +29,9 @@ Tool 组默认收起。存在 running 或 waiting Tool 时，摘要显示最后�
 停止和仅记录必须分别进入摘要，不能统一写成成功。新 Tool 只原位更新组摘要；用户手动展开后保持展开，
 组完成时不自动收起、不抢焦点。
 
+Runtime 明确报告 `runtime_interrupted` 时，未结算 Tool 显示为 stopped/interrupted，使用中性状态；它不能因
+AgentRun 的存储状态为 failed 或进程已经消失而显示为 cancelled。只有 Runtime 权威取消终态才显示 cancelled。
+
 ## 3. 两级 disclosure 与性能边界
 
 点击 Tool 组只展开全部 Tool summary；单条 Tool 的完整公开结果仍由第二级 disclosure 独立打开。完整
@@ -41,6 +44,12 @@ Tool 组默认收起。存在 running 或 waiting Tool 时，摘要显示最后�
 不把该最坏情况误报为虚拟化。terminal Run 的 Evidence history 仍只在用户打开精确 Run 后读取，
 non-terminal Run 的完整 Evidence open projection 不变。
 
+未来新产生的 Codex `command.output.delta` 不属于 Renderer live event 输入，不追加到 `liveRuntimeEvents`，也不触发
+排序或 progress rebuild。Command 详情只消费 terminal semantic result 的 `aggregatedOutput`；超过既有阈值时仍在
+用户首次展开精确 Tool 后惰性读取 Managed Blob。历史 Evidence 中已有的 delta 保持可读，但不迁移、不改写，
+也不因此恢复新事件的 live path。删除 delta durability 不改变 Tool identity、chronology、分组、计数或精确 Tool
+结果 disclosure。
+
 ## 4. 键盘与辅助技术
 
 组 summary 使用原生 disclosure 键盘语义和可见焦点。摘要的辅助技术名称包含未视觉截断的当前操作与真实
@@ -51,7 +60,10 @@ Home/End；Escape 返回对应 Tool summary，而不是跳过 Tool 层直接返�
 
 - `Tool → Tool → narration → Tool` 派生为两个组，展开后的 Tool 顺序与 identity 完整保留；
 - running、waiting、succeeded、failed、cancelled 与 recorded 组摘要均诚实，活动组后不重复“正在处理”；
+- `runtime_interrupted` 投影为 stopped/interrupted 与 unsettled，不投影为 cancelled；
 - 默认收起时不挂载任何完整结果 region；首次打开精确 Tool 才显示本地结果或读取 Managed Blob；
+- 100,000 个 `command.output.delta` 不新增任何 Renderer live event，terminal Command 仍显示正确 command、status、
+  exitCode 与 `aggregatedOutput`；
 - 新 Tool 与组终态更新不改变用户的展开状态或焦点；
 - 同一个 Drawer 在底部与 Inspector 之间移动后保持组、Tool、结果和阅读状态；
 - Day/Night、310px/260px Inspector、`1040×700`、200% zoom、reduced motion 与 Forced Colors 无页面级横向溢出。

--- a/docs/decisions/CURRENT.md
+++ b/docs/decisions/CURRENT.md
@@ -1,7 +1,7 @@
 ---
 document_type: current-decision-navigation
 authority: current-authority-and-rationale-routing
-last_updated: 2026-08-25
+last_updated: 2026-08-26
 ---
 
 # 当前规范与决定理由导航
@@ -40,6 +40,7 @@ last_updated: 2026-08-25
 - 当前 Published Attachment View startup rebuild failure 的 Camp-local fail-closed 边界理由：[V1.28-D08](../versions/v1.28/decisions.md#v1-28-d08)。
 - 当前零附件 Camp 的空集 controlled rebuild completion 与 root receipt 更新理由：[V1.28-D09](../versions/v1.28/decisions.md#v1-28-d09)。
 - 当前已成功发布附件的当前可读性局部降级、Camp 继续运行与自动恢复理由：[V1.28-D10](../versions/v1.28/decisions.md#v1-28-d10)。
+- 当前 Windows Runtime PATH hydration、entrypoint closed set 与 command-shim identity 理由：[V1.28-D11](../versions/v1.28/decisions.md#v1-28-d11)。
 - 理由来源：[v0.16](../versions/v0.16/decisions.md)、[v0.17](../versions/v0.17/decisions.md)、[v0.19](../versions/v0.19/decisions.md)、[v0.20](../versions/v0.20/decisions.md)、[v0.58](../versions/v0.58/decisions.md)、[v0.64](../versions/v0.64/decisions.md)、[v0.66](../versions/v0.66/decisions.md)、[v1.01](../versions/v1.01/decisions.md)、[v1.03](../versions/v1.03/decisions.md)、[v1.04](../versions/v1.04/decisions.md)、[v1.05](../versions/v1.05/decisions.md)、[v1.11](../versions/v1.11/decisions.md)、[v1.12](../versions/v1.12/decisions.md)、[v1.13](../versions/v1.13/decisions.md)、[V1.15-D04](../versions/v1.15/decisions.md#v1-15-d04)、[V1.15-D06](../versions/v1.15/decisions.md#v1-15-d06)、[V1.17-D02](../versions/v1.17/decisions.md#v1-17-d02)、[V1.19-D01](../versions/v1.19/decisions.md#v1-19-d01)、[V1.20-D02](../versions/v1.20/decisions.md#v1-20-d02)、[V1.21-D03](../versions/v1.21/decisions.md#v1-21-d03)、[V1.22-D01](../versions/v1.22/decisions.md#v1-22-d01)、[V1.24-D01](../versions/v1.24/decisions.md#v1-24-d01)。
 
 ## Session、Context 与 Bootstrap
@@ -65,7 +66,7 @@ last_updated: 2026-08-25
 ## Evidence、Runtime Activity 与 Usage
 
 - 当前规范：[Evidence/Activity 基础不变量](../architecture/foundational-invariants.md#evidence-canonical-activity)、[Runtime Monitoring](../architecture/runtime-monitoring.md)、[Runtime Usage Monitoring v3](../contracts/runtime-usage-monitoring-v3.md)、[Runtime Activity Registry](../runtime-activity/registry.md)。
-- 理由来源：[v0.17](../versions/v0.17/decisions.md)、[v0.41](../versions/v0.41/decisions.md)、[v0.96](../versions/v0.96/decisions.md)、[v0.99](../versions/v0.99/decisions.md)。
+- 理由来源：[v0.17](../versions/v0.17/decisions.md)、[v0.41](../versions/v0.41/decisions.md)、[v0.96](../versions/v0.96/decisions.md)、[v0.99](../versions/v0.99/decisions.md)、[V1.28-D12](../versions/v1.28/decisions.md#v1-28-d12)。
 
 ## Qualification 与 Benchmark
 
@@ -75,7 +76,7 @@ last_updated: 2026-08-25
 ## Product 与 Renderer
 
 - 当前规范：[产品/Renderer 基础不变量](../architecture/foundational-invariants.md#product-execution-surface)、[UI 规范](../ui/README.md)、[Run Process Detail Surface v20](../contracts/run-process-detail-surface-v20.md)。
-- 理由来源：[v0.11](../versions/v0.11/decisions.md)、[v0.24](../versions/v0.24/decisions.md)、[v0.55](../versions/v0.55/decisions.md)、[v0.58](../versions/v0.58/decisions.md)、[v0.84](../versions/v0.84/decisions.md)、[v1.12](../versions/v1.12/decisions.md)、[v1.13](../versions/v1.13/decisions.md)、[V1.15-D01](../versions/v1.15/decisions.md#v1-15-d01)、[V1.15-D02](../versions/v1.15/decisions.md#v1-15-d02)、[V1.15-D05](../versions/v1.15/decisions.md#v1-15-d05)、[V1.18-D01](../versions/v1.18/decisions.md#v1-18-d01)、[V1.20-D02](../versions/v1.20/decisions.md#v1-20-d02)。
+- 理由来源：[v0.11](../versions/v0.11/decisions.md)、[v0.24](../versions/v0.24/decisions.md)、[v0.55](../versions/v0.55/decisions.md)、[v0.58](../versions/v0.58/decisions.md)、[v0.84](../versions/v0.84/decisions.md)、[v1.12](../versions/v1.12/decisions.md)、[v1.13](../versions/v1.13/decisions.md)、[V1.15-D01](../versions/v1.15/decisions.md#v1-15-d01)、[V1.15-D02](../versions/v1.15/decisions.md#v1-15-d02)、[V1.15-D05](../versions/v1.15/decisions.md#v1-15-d05)、[V1.18-D01](../versions/v1.18/decisions.md#v1-18-d01)、[V1.20-D02](../versions/v1.20/decisions.md#v1-20-d02)、[V1.28-D12](../versions/v1.28/decisions.md#v1-28-d12)。
 
 ## 文档治理
 

--- a/docs/runtime-activity/registry.md
+++ b/docs/runtime-activity/registry.md
@@ -2,7 +2,7 @@
 document_type: runtime-activity-mapping-registry
 authority: runtime-activity-mapping-catalog
 classifier_version: activity-v1
-last_updated: 2026-08-25
+last_updated: 2026-08-26
 ---
 
 # Runtime Activity Mapping Registry
@@ -92,6 +92,26 @@ command output 与生命周期投影，不把一次 pass 扩大为所有模型�
 均证明 `commandExecution.title` 可以为空，而 `commandActions` 是协议必填字段；修复 fixture 使用该真实
 wire shape，Core post-fix live smoke 仍需单独运行。
 
+### Command output durability audit
+
+2026-08-26 对全部 13 个 Adapter 的归一化路径逐项核验后，terminal output 权威如下：
+
+| 协议路径 | Adapter identities | terminal semantic output | 临时输出片段 |
+|---|---|---|---|
+| Codex app-server | identity：`codex-cli` | `item/completed` 的 `commandExecution.aggregatedOutput`，并保留 `command`、`status`、`exitCode` | `command.output.delta` 通过 Host/Run/epoch/Thread/Turn/active-route/Run-state fence 后直接丢弃 |
+| ACP v1 | identities：`opencode-cli`、`copilot-cli`、`kiro-cli`、`qoder-cli`、`codebuddy-cli`、`qwen-code`、`trae-cn-cli`、`cursor-agent`、`kimi-code-cli`、`grok-build` | terminal `tool_call_update` 归一为一条 `runtime.action.payload.output` | 这十个 Adapter 不产生 `command.output.delta` |
+| Claude stream-json | identity：`claude-code-cli` | terminal Bash `tool_result` 归一为一条 `runtime.action.payload.output` | 不产生 `command.output.delta` |
+| Antigravity stream-json | identity：`antigravity-app` | terminal tool step 归一为一条 `runtime.action.payload.output` | 不产生 `command.output.delta` |
+
+因此当前 Adapter 均不需要输出 spool。未来只有在原生 terminal 无法给出完整 aggregate 时，才允许 Adapter-owned
+临时 spool；它必须有明确硬上限、生成完整或明确 truncated 的 terminal result，并在 Run 结束后删除。Core 或
+Renderer 不得用无界字符串 accumulator 补偿协议缺口，也不得把片段逐条持久化。
+
+Codex 的 transport-only delta 不写 Execution Evidence、不更新 Canonical Activity、不创建 Managed Blob，也不进入
+Renderer `liveRuntimeEvents`。终态、取消请求、Host unbind/exit、Turn 替换、epoch supersede 或 route/lease fence
+关闭后到达的旧片段直接拒绝。既有历史 `command.output.delta` Evidence/Blob 不迁移、不删除、不重写，并继续由
+历史只读展示路径解析。
+
 ### ACP v1
 
 | ACP `kind` | activityDomain | semanticKind |
@@ -164,6 +184,9 @@ Canonical Activity 分类，结构化 kind 仍映射 `shell.execute`。
 - 只有相同 operationId 合并；
 - lifecycle completion 可以只报告 identity/status；这类稀疏更新只推进 phase/outcome，不得用 Evidence-kind fallback 覆盖同一 operation 已报告的结构化 domain、semantic kind 或 title；
 - terminal 冲突为 `unsettled`；
+- Runtime 明确报告 interruption 时，已 started 且尚未结算的 operation 归约为
+  `phase=terminal / outcome=unsettled / reasonCode=runtime_interrupted`，Renderer 显示 stopped/interrupted；
+  只有 Runtime 权威取消终态才归约为 `cancelled`；
 - 无结构化工具名时显示 presentation hint 或 activity-domain fallback，不伪造函数名；
 - title、provider 和 Runtime 名称永远不决定 domain 或 identity；唯一例外是 Adapter 白名单公开的 ACP
   `rawInput.command`，以及仅 `trae-cn-cli` 的 `rawInput.Command`，可在原生 kind 缺失时证明

--- a/docs/versions/v1.28/README.md
+++ b/docs/versions/v1.28/README.md
@@ -6,7 +6,7 @@ authority: version-scope-and-status
 design_status: confirmed
 implementation_status: in_progress
 model_context_change: true
-last_updated: 2026-08-25
+last_updated: 2026-08-26
 ---
 
 # Rovai-ai v1.28：Grok Build + MiniMax M3 本地 Runtime 接入
@@ -20,6 +20,8 @@ last_updated: 2026-08-25
 > 不变，把 Grok 首次交付改为原生 `_meta.rules`，并以结构化 completion 驱动 Redelivery v2。实现经
 > 独立 worktree 验收后通过 PR 交付 `main`；`>= 1.0.0 / session.resume` clean break 的确定性实现已完成，
 > macOS arm64/x64 与 Windows x64 已分别用 `grok 1.0.5` 完成真实 Deep Probe、cold resume 与产品矩阵。
+> 新产生的 Codex command output delta 已改为 fence 后直接丢弃；Command terminal aggregate 保持唯一输出权威，
+> 历史 Evidence/Blob 不迁移。全部 13 个 Adapter 的 terminal output 路径已逐项核验，无 Adapter 需要新增 spool。
 
 前置版本：[v1.27 Kimi Code + MiniMax M3](../v1.27/README.md)已按冻结时事实转为 historical。
 
@@ -79,6 +81,12 @@ Product Runtime 接入。复用本机 MiniMax API Key，但改用 Grok 官方 cu
 - Camp 执行台把同一 Run 内最大连续的 Tool 派生为默认收起的摘要，运行中显示最后一条非终态操作，展开后
   保留完整 chronology，并把完整 Tool 结果延迟到精确 Tool 首次展开；分组不改变 Core Evidence、Tool identity
   或 non-terminal open projection。
+- Codex `command.output.delta` 对未来数据采用 transport-only clean break：通过 Host/Run/epoch/Thread/Turn、
+  active route 与 Run-state fence 后直接丢弃，不写 Evidence/Canonical/Blob，也不进入 Renderer live state；
+  terminal `aggregatedOutput` 继续作为 Command 输出唯一权威并沿用大正文 Managed Blob 阈值。十个 ACP Adapter、
+  Claude Code 与 Antigravity 已在各自 terminal semantic event 中给出完整公开输出，不需要临时 spool。
+- Runtime 明确报告 interruption 时，尚未结算的 Activity 记录为 terminal/unsettled，reason code 为
+  `runtime_interrupted`；Renderer 显示 stopped/interrupted。只有 Runtime 权威取消终态才写成 cancelled。
 
 ## 安全与兼容边界
 
@@ -88,6 +96,8 @@ Product Runtime 接入。复用本机 MiniMax API Key，但改用 Grok 官方 cu
 - `_x.ai/*` vendor notification 只按已知 Session metadata/lifecycle 路由，不作为公开 assistant 输出；
 - 原生 Session ID 仅保留在既有绑定边界，资格证据不持久化完整 Native ID；
 - Cursor 与 Kimi 的平台准入、provider 和 continuation 结论不因新增 Grok identity 改变。
+- 本次只改变未来新产生的 command output transport；不迁移、删除、重写任何历史 Evidence 或 Blob，也不重建
+  canonical history。PR #63 的 Tool identity、chronology、Renderer-only 连续分组与精确 Tool Blob 惰性读取不变。
 
 ## 验收
 
@@ -101,11 +111,11 @@ External MCP 支持性裁决、文档治理与 Impeccable UI detector。
 | 范围 | 结论 | 证据或理由 |
 | --- | --- | --- |
 | Version lifecycle | 已更新 | 本概览、[实施计划](implementation-plan.md)、[决定](decisions.md)与[版本索引](../README.md)共同切换 `current_version`。 |
-| Decisions | 已更新 | [V1.28-D01](decisions.md#v1-28-d01)冻结 provider/Home/auth 边界，[V1.28-D02](decisions.md#v1-28-d02)冻结公开输出与平台准入，[V1.28-D03](decisions.md#v1-28-d03)冻结 External MCP 的 Plugin 追加边界，[V1.28-D04](decisions.md#v1-28-d04)保存初始 load-only 取舍，[V1.28-D05](decisions.md#v1-28-d05)冻结 native rules 与 structured compaction redelivery，[V1.28-D06](decisions.md#v1-28-d06)冻结 `>= 1.0.0` 与标准 ACP resume clean break，[V1.28-D07](decisions.md#v1-28-d07)冻结 macOS Runtime Files 稳定卷 identity 与旧 marker rekey，[V1.28-D08](decisions.md#v1-28-d08)冻结 startup rebuild failure 的 Camp-local fail-closed 边界，[V1.28-D09](decisions.md#v1-28-d09)冻结空集 controlled rebuild 的 completion 与 root receipt，[V1.28-D10](decisions.md#v1-28-d10)冻结已成功发布附件的当前可读性局部降级与 Camp 继续运行，[V1.28-D11](decisions.md#v1-28-d11)冻结 Windows PATH hydration、`.exe/.cmd/.bat` entrypoint 与 command-shim identity。 |
-| Contracts | 已更新 | [Runtime Launch and Verification v27](../../contracts/runtime-launch-and-verification-v27.md)收敛 Grok 版本门、Ready 与 continuation；[Camp Published Attachment View v4](../../contracts/camp-published-attachment-view-v4.md)区分不可变发布历史与当前 Runtime availability，并定义附件局部降级、Context 省略和自动恢复；[Run Process Detail Surface v20](../../contracts/run-process-detail-surface-v20.md)定义 Renderer-only 连续 Tool 聚合与第二级结果惰性 disclosure；[Managed Runtime Process v1](../../contracts/managed-runtime-process-v1.md)补充受控 Windows `.cmd/.bat` identity、argv 与 Job 边界；[Runtime Platform Admission](../../contracts/runtime-platform-admission-v1.md)的逐平台证据边界不变。receipt wire、Data Contract 与 Renderer API 不变。 |
-| Architecture | 已更新 | [Runtime Catalog Boundaries](../../architecture/runtime-catalog-boundaries.md)补充 Grok identity、provider 与原生状态边界；[Native Session Bootstrap Redelivery](../../architecture/native-session-bootstrap-redelivery.md)补充 Grok detector；[Camp Published Attachment View](../../architecture/camp-published-attachment-view.md)补充稳定卷 identity、schema-1 rekey、空集受控重建、附件局部可用性与 pre-dispatch repair；[Camp Open Read Path](../../architecture/camp-open-read-path.md)明确可靠 `agent_run.terminal` 后的权威投影刷新。 |
-| UI | 已更新 | 复用现有 Runtime catalog、状态与成员参数组件；member-workspace brief 明确 generic agent text 可原样进入执行台与 final；Renderer 补齐通用 AgentRun 终态 invalidation、single-flight/trailing refresh 与完整页面链路回归，避免 Camp 保留运行中旧快照或因连续终态通知并发读取；Camp 会话工作区增加连续 Tool 摘要、真实失败/停止/仅记录计数与完整结果按精确 Tool 惰性挂载。 |
-| Runtime Activity | 已更新 | [Registry](../../runtime-activity/registry.md)新增 Grok ACP run-level 映射。 |
+| Decisions | 已更新 | [V1.28-D01](decisions.md#v1-28-d01)冻结 provider/Home/auth 边界，[V1.28-D02](decisions.md#v1-28-d02)冻结公开输出与平台准入，[V1.28-D03](decisions.md#v1-28-d03)冻结 External MCP 的 Plugin 追加边界，[V1.28-D04](decisions.md#v1-28-d04)保存初始 load-only 取舍，[V1.28-D05](decisions.md#v1-28-d05)冻结 native rules 与 structured compaction redelivery，[V1.28-D06](decisions.md#v1-28-d06)冻结 `>= 1.0.0` 与标准 ACP resume clean break，[V1.28-D07](decisions.md#v1-28-d07)冻结 macOS Runtime Files 稳定卷 identity 与旧 marker rekey，[V1.28-D08](decisions.md#v1-28-d08)冻结 startup rebuild failure 的 Camp-local fail-closed 边界，[V1.28-D09](decisions.md#v1-28-d09)冻结空集 controlled rebuild 的 completion 与 root receipt，[V1.28-D10](decisions.md#v1-28-d10)冻结已成功发布附件的当前可读性局部降级与 Camp 继续运行，[V1.28-D11](decisions.md#v1-28-d11)冻结 Windows PATH hydration、`.exe/.cmd/.bat` entrypoint 与 command-shim identity，[V1.28-D12](decisions.md#v1-28-d12)冻结 command output delta 的 transport-only clean break、terminal aggregate 权威与 interrupted 语义。 |
+| Contracts | 已更新 | [Runtime Launch and Verification v27](../../contracts/runtime-launch-and-verification-v27.md)收敛 Grok 版本门、Ready 与 continuation；[Camp Published Attachment View v4](../../contracts/camp-published-attachment-view-v4.md)区分不可变发布历史与当前 Runtime availability，并定义附件局部降级、Context 省略和自动恢复；[Run Process Detail Surface v20](../../contracts/run-process-detail-surface-v20.md)定义 Renderer-only 连续 Tool 聚合、第二级结果惰性 disclosure、delta 非 live-state 与 interrupted 展示；[Managed Runtime Process v1](../../contracts/managed-runtime-process-v1.md)补充受控 Windows `.cmd/.bat` identity、argv 与 Job 边界；[Runtime Platform Admission](../../contracts/runtime-platform-admission-v1.md)的逐平台证据边界不变。receipt wire、Data Contract 与 Renderer API 不变。 |
+| Architecture | 已更新 | [Runtime Catalog Boundaries](../../architecture/runtime-catalog-boundaries.md)补充 Grok identity、provider 与原生状态边界；[Native Session Bootstrap Redelivery](../../architecture/native-session-bootstrap-redelivery.md)补充 Grok detector；[Camp Published Attachment View](../../architecture/camp-published-attachment-view.md)补充稳定卷 identity、schema-1 rekey、空集受控重建、附件局部可用性与 pre-dispatch repair；[Camp Open Read Path](../../architecture/camp-open-read-path.md)明确可靠 `agent_run.terminal` 后的权威投影刷新；[基础不变量](../../architecture/foundational-invariants.md#evidence-canonical-activity)补充 transient delta、terminal aggregate 与 interruption 边界。 |
+| UI | 已更新 | 复用现有 Runtime catalog、状态与成员参数组件；member-workspace brief 明确 generic agent text 可原样进入执行台与 final；Renderer 补齐通用 AgentRun 终态 invalidation、single-flight/trailing refresh 与完整页面链路回归，避免 Camp 保留运行中旧快照或因连续终态通知并发读取；Camp 会话工作区增加连续 Tool 摘要、真实失败/停止/仅记录计数与完整结果按精确 Tool 惰性挂载，并排除新 command output delta 的 live-state 累积。 |
+| Runtime Activity | 已更新 | [Registry](../../runtime-activity/registry.md)新增 Grok ACP run-level 映射，并记录全部 13 个 Adapter 的 terminal output authority 与无需 spool 的核验结论。 |
 | Runtime compatibility | 已更新 | [兼容性清单](../../runtime-compatibility.md)与 macOS arm64/x64、Windows x64 三份 adapter-scoped 证据记录各自实测边界。 |
 | Documentation routing | 确认无需更新 | 既有 Runtime checklist、Research、Architecture、Contract 与 Version 路由足以到达本版本。 |
 | Root README | 确认无需更新 | 本次新增兼容 Runtime，不改变项目定位或常青产品承诺。 |

--- a/docs/versions/v1.28/decisions.md
+++ b/docs/versions/v1.28/decisions.md
@@ -2,7 +2,7 @@
 document_type: version-decisions
 version: v1.28
 lifecycle: current
-last_updated: 2026-08-25
+last_updated: 2026-08-26
 ---
 
 # v1.28 决策记录
@@ -415,3 +415,55 @@ interpreter、PATH winner 或 reported version 变化都会触发新 Probe/Host 
 - 使用 `cmd.exe /c` 字符串拼接：允许 metacharacter 注入、AutoRun 改义与不可验证 argv；
 - 对 npm shim 执行后观察 child 来猜 target：执行了未验证脚本，也可能把任意 executable 误绑定为 Codex；
 - 显式路径失败后继续 PATH：把用户选择静默替换成另一安装，破坏 fail-closed 语义。
+
+<a id="v1-28-d12"></a>
+## V1.28-D12：Command output delta 改为 fenced transient，terminal aggregate 是唯一输出权威
+
+### 背景
+
+Codex app-server 会把命令 stdout/stderr 拆成大量 `command.output.delta`。旧路径把每片都写入
+`agent_run_execution_evidence`，长命令可产生数万至十万行，而当前 Renderer 实际不消费这些 delta 展示实时输出；
+最终 `item/completed` 已携带完整 `command`、`status`、`exitCode` 和 `aggregatedOutput`。继续逐片段持久化既不增加
+用户可见事实，又放大数据库、恢复与 Renderer 投影成本。
+
+对全部 13 个 Adapter 的归一化路径逐项核验：只有 `codex-cli` 产生这种 output delta；十个 ACP Adapter 的 terminal
+`tool_call_update`、Claude Code 的 Bash `tool_result` 与 Antigravity 的 terminal tool step 都已经生成包含完整公开
+output 的单一 `runtime.action`。当前没有 Adapter 需要额外 accumulator 或 spool。
+
+### 决定
+
+只对未来新产生的数据采用 clean break。既有历史 Evidence、Managed Blob 与 Canonical Activity 不迁移、不删除、
+不改写、不重建，旧 Camp 的历史性能问题留待独立治理，历史 delta 继续可读。
+
+Codex `command.output.delta` 仍须通过现有 Host instance、AgentRun、execution epoch、Native Thread/Turn、delivery、
+active route 与 lease/Run-state fence。route 与 Run-state 准入在 transient path 的唯一临界读取中完成；任何 terminal、
+cancel request、Host unbind/exit、Turn replacement、epoch supersede 或 route/lease fence 关闭后到达的片段都直接拒绝。
+通过 fence 的片段同样直接丢弃：不写 Execution Evidence、不更新 Canonical Activity、不创建 Managed Blob，也不进入
+Renderer `liveRuntimeEvents`。该路径没有接受后的可变输出状态，因此 fence 检查之后不存在可被迟到片段更新的窗口。
+
+Codex `item/completed.commandExecution.aggregatedOutput` 是最终 Command 输出的唯一权威，terminal semantic record 继续
+保留 `command`、`status` 与 `exitCode`；超过现有阈值时继续写 Managed Blob，并只在用户展开精确 Tool 时惰性读取。
+十个 ACP Adapter、Claude Code 与 Antigravity 保持现有 terminal semantic output，不新增 spool。未来若某个 Adapter
+无法提供完整 terminal aggregate，只允许 Adapter-owned 临时 spool，必须有硬上限、在 terminal 生成完整或明确
+truncated 的单一输出，并在 Run 结束后删除；Core 与 Renderer 不得无限拼接 String 或恢复逐 delta 持久化。
+
+Runtime 权威报告 interruption 时，尚未结算的已 started Activity 写入
+`phase=terminal / outcome=unsettled / reasonCode=runtime_interrupted`，Renderer 显示 stopped/interrupted。进程失联或
+Host 退出若仍有恢复可能，继续走 recovery；只有 Runtime 权威取消终态才能记录为 `cancelled`。
+
+PR #63 的每个 Tool identity、chronology、状态、结果与 Renderer-only 连续分组不变；terminal 大输出仍绑定精确 Tool
+并按既有第二级 disclosure 惰性读取。
+
+### 后果
+
+一个产生 100,000 个 output delta 的 Command 对未来数据库与 Renderer live state 都新增 0 个 delta 项，只留下单一
+terminal semantic result。数据库写放大和 React state/排序风险不再随 stdout/stderr frame 数增长；大输出容量仍由
+Managed Blob 合同承担。历史数据量不会因本决定缩小。
+
+### 被拒绝方案
+
+- 把 delta 继续写 Evidence，只在读取时合并：仍保留数据库写放大和历史恢复成本；
+- 把每个 delta 改放 Renderer state：把膨胀从 SQLite 转移到 React 内存、排序与 progress rebuild；
+- 在 Core 中无限拼接完整 output：把协议流量变成无界常驻内存；
+- 借本次修改清理或重写历史：扩大故障面并改变既有 Evidence/Blob 审计事实；
+- 将 interruption 写成 cancelled：把连续性未知伪装成 Runtime 权威取消。

--- a/docs/versions/v1.28/implementation-plan.md
+++ b/docs/versions/v1.28/implementation-plan.md
@@ -3,7 +3,7 @@ document_type: implementation-plan
 version: v1.28
 authority: implementation-and-acceptance-status
 status: in_progress
-last_updated: 2026-08-25
+last_updated: 2026-08-26
 ---
 
 # v1.28 实施计划
@@ -65,6 +65,18 @@ Checklist 仍拥有完整通用步骤，本页只记录本版本的具体状态�
   resolved locator evidence 持久化与 snapshot/Host fencing、PATH 传播、Job cleanup 与 Windows 回归；`.ps1`
   保持关闭；
 - [x] 运行 Impeccable detector，整理 worktree 交接，并通过 PR 交付 `main`。
+
+## Command output 持久化优化
+
+- [x] 逐项核验 13 个 Adapter：仅 Codex 产生 `command.output.delta`；十个 ACP Adapter、Claude Code 与
+  Antigravity 都已有完整 terminal semantic output，当前无需 spool；
+- [x] 对未来 Codex delta 保留 Host/Run/epoch/Thread/Turn/route/Run-state fence 后直接丢弃，停止 Evidence、
+  Canonical、Managed Blob 与 Renderer live-state 写入；历史 Evidence/Blob 保持原样；
+- [x] 保留 terminal Command 的 command/status/exitCode/aggregatedOutput，大输出继续进入精确 Tool 的 Managed Blob；
+- [x] 将 Runtime interruption 投影为 terminal/unsettled + `runtime_interrupted`，Renderer 显示
+  stopped/interrupted，不伪造 cancelled；
+- [x] 覆盖 100,000 delta 零 DB/Renderer 项、cancel/terminal/Host/epoch/route fence、terminal aggregate/blob、
+  interruption 与 PR #63 Tool chronology/grouping/lazy disclosure 回归。
 
 ## 验收原则
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1125,6 +1125,7 @@ export interface AgentRunView {
     | 'planned_shutdown_completed'
     | 'planned_shutdown_failed'
     | 'planned_shutdown_cancelled'
+    | 'runtime_interrupted'
     | null
   failure: RuntimeFailureView | null
   runtimeModel: { modelId: string | null } | null


### PR DESCRIPTION
## Summary

- Treat future Codex command output deltas as fenced transient transport: no Execution Evidence, Canonical Activity, Managed Blob, or Renderer live event.
- Keep the terminal command semantic record authoritative for command, status, exitCode, and aggregatedOutput; large output still uses the existing Managed Blob threshold.
- Preserve historical Evidence and Blob data unchanged, project runtime interruption as terminal/unsettled instead of cancelled, and keep PR #63 Tool chronology, grouping, and precise-Tool lazy loading intact.
- Audit all 13 adapters: only Codex emits command output deltas; all 10 ACP adapters, Claude Code, and Antigravity already provide terminal semantic output, so no spool is required.

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- pnpm test:rust:pr (353 lib passed / 7 ignored; 27 CLI passed; 239 slow passed)
- cargo test -p rovai-core --bin rovai-core (82 passed / 2 ignored)
- pnpm typecheck
- vitest run (80 files; 550 passed / 3 skipped)
- targeted Renderer App suite (125 passed)
- pnpm docs:test, pnpm docs:check, and docs:check:ci against current main
- pnpm build:desktop

## Windows runner notes

The top-level pnpm test completes all Vitest suites but three unchanged macOS daily-installer Node tests fail on Windows because they require literal /Applications semantics and symbolic-link creation privileges. The affected scripts are unchanged from main. The staged Rust wrapper also hits a bundled-Node spawn EINVAL for pnpm.cmd on Windows; its selected full Rust route was run directly via the PR Rust suite plus the Core binary suite above.