### PR TITLE
fix: drop Codex command deltas at ingress

### DIFF
--- a/crates/rovai-core/src/codex.rs
+++ b/crates/rovai-core/src/codex.rs
@@ -134,11 +134,18 @@ pub(crate) struct CodexHost {
     stdin: Mutex<ManagedChildStdin>,
     pending: Mutex<HashMap<u64, PendingRpc>>,
     next_id: AtomicU64,
-    routes: RwLock<HashMap<String, CodexThreadRoute>>,
+    routes: CodexThreadRoutes,
     incoming: mpsc::UnboundedSender<CodexIncoming>,
     alive: AtomicBool,
     executable_path: PathBuf,
     builtin_tools: Option<BuiltinToolProcessConfig>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CodexIngressDisposition {
+    Forward,
+    DropCurrentDelta,
+    DropRejectedDelta,
 }
 
 #[derive(Debug, Clone)]
@@ -153,6 +160,181 @@ impl CodexThreadRoute {
             None
         } else {
             Some(self.owner.clone())
+        }
+    }
+}
+
+#[derive(Default)]
+struct CodexThreadRoutes {
+    inner: RwLock<HashMap<String, CodexThreadRoute>>,
+}
+
+impl CodexThreadRoutes {
+    async fn bind_thread(&self, thread_id: &str, owner: &CodexRuntimeOwner) -> Result<()> {
+        let mut routes = self.inner.write().await;
+        if let Some(existing) = routes.get(thread_id)
+            && &existing.owner != owner
+        {
+            bail!("Codex Native Thread is already bound to another logical runtime");
+        }
+        routes.insert(
+            thread_id.to_string(),
+            CodexThreadRoute {
+                owner: owner.clone(),
+                active_turn_id: None,
+            },
+        );
+        Ok(())
+    }
+
+    async fn activate_turn(
+        &self,
+        thread_id: &str,
+        owner: &CodexRuntimeOwner,
+        turn_id: &str,
+    ) -> Result<()> {
+        let mut routes = self.inner.write().await;
+        let route = routes
+            .get_mut(thread_id)
+            .context("Codex Native Thread has no logical runtime binding")?;
+        if &route.owner != owner
+            || route
+                .active_turn_id
+                .as_deref()
+                .is_some_and(|active| active != turn_id)
+        {
+            bail!("Codex Native Turn failed Host/Thread/Run fencing");
+        }
+        route.active_turn_id = Some(turn_id.to_string());
+        Ok(())
+    }
+
+    async fn deactivate_turn(
+        &self,
+        thread_id: &str,
+        owner: &CodexRuntimeOwner,
+        completed_turn_id: Option<&str>,
+    ) {
+        let mut routes = self.inner.write().await;
+        let Some(route) = routes.get_mut(thread_id) else {
+            return;
+        };
+        if &route.owner == owner
+            && (completed_turn_id.is_none() || route.active_turn_id.as_deref() == completed_turn_id)
+        {
+            route.active_turn_id = None;
+        }
+    }
+
+    async fn active_turn(&self, thread_id: &str, owner: &CodexRuntimeOwner) -> Option<String> {
+        self.inner
+            .read()
+            .await
+            .get(thread_id)
+            .filter(|route| &route.owner == owner)
+            .and_then(|route| route.active_turn_id.clone())
+    }
+
+    async fn unbind_thread(&self, thread_id: &str, owner: &CodexRuntimeOwner) {
+        let mut routes = self.inner.write().await;
+        if routes.get(thread_id).map(|route| &route.owner) == Some(owner) {
+            routes.remove(thread_id);
+        }
+    }
+
+    async fn owners(&self) -> HashSet<CodexRuntimeOwner> {
+        self.inner
+            .read()
+            .await
+            .values()
+            .map(|route| route.owner.clone())
+            .collect()
+    }
+
+    async fn is_empty(&self) -> bool {
+        self.inner.read().await.is_empty()
+    }
+
+    async fn ingress_route(
+        &self,
+        message: &Value,
+    ) -> (CodexIngressDisposition, Option<CodexRuntimeOwner>) {
+        let routes = self.inner.read().await;
+        let disposition = codex_ingress_disposition(message, &routes);
+        if disposition != CodexIngressDisposition::Forward {
+            return (disposition, None);
+        }
+        let thread_id = message
+            .pointer("/params/threadId")
+            .and_then(Value::as_str)
+            .or_else(|| message.pointer("/params/thread/id").and_then(Value::as_str));
+        let turn_id = message
+            .pointer("/params/turnId")
+            .and_then(Value::as_str)
+            .or_else(|| message.pointer("/params/turn/id").and_then(Value::as_str));
+        let owner = thread_id
+            .and_then(|thread_id| routes.get(thread_id))
+            .and_then(|route| route.owner_for_message(turn_id));
+        (disposition, owner)
+    }
+}
+
+fn codex_ingress_disposition(
+    message: &Value,
+    routes: &HashMap<String, CodexThreadRoute>,
+) -> CodexIngressDisposition {
+    if message.get("id").is_some() {
+        return CodexIngressDisposition::Forward;
+    }
+    match message.get("method").and_then(Value::as_str) {
+        Some("command/exec/outputDelta") => CodexIngressDisposition::DropRejectedDelta,
+        Some("item/commandExecution/outputDelta") => {
+            let Some(thread_id) = message.pointer("/params/threadId").and_then(Value::as_str)
+            else {
+                return CodexIngressDisposition::DropRejectedDelta;
+            };
+            let Some(turn_id) = message.pointer("/params/turnId").and_then(Value::as_str) else {
+                return CodexIngressDisposition::DropRejectedDelta;
+            };
+            if !message
+                .pointer("/params/itemId")
+                .and_then(Value::as_str)
+                .is_some_and(|item_id| !item_id.trim().is_empty())
+            {
+                return CodexIngressDisposition::DropRejectedDelta;
+            }
+            if routes
+                .get(thread_id)
+                .is_some_and(|route| route.active_turn_id.as_deref() == Some(turn_id))
+            {
+                CodexIngressDisposition::DropCurrentDelta
+            } else {
+                CodexIngressDisposition::DropRejectedDelta
+            }
+        }
+        _ => CodexIngressDisposition::Forward,
+    }
+}
+
+async fn route_codex_stdout_ingress(
+    host_instance_id: &str,
+    routes: &CodexThreadRoutes,
+    incoming: &mpsc::UnboundedSender<CodexIncoming>,
+    message: Value,
+) -> (CodexIngressDisposition, Option<Value>) {
+    let request_id = message.get("id").cloned();
+    let (disposition, owner) = routes.ingress_route(&message).await;
+    match disposition {
+        CodexIngressDisposition::DropCurrentDelta | CodexIngressDisposition::DropRejectedDelta => {
+            (disposition, None)
+        }
+        CodexIngressDisposition::Forward => {
+            if let Some(owner) = owner {
+                let _ = incoming.send(owner.message(host_instance_id, message));
+                (disposition, None)
+            } else {
+                (disposition, request_id)
+            }
         }
     }
 }
@@ -201,7 +383,7 @@ impl CodexHost {
             stdin: Mutex::new(stdin),
             pending: Mutex::new(HashMap::new()),
             next_id: AtomicU64::new(1),
-            routes: RwLock::new(HashMap::new()),
+            routes: CodexThreadRoutes::default(),
             incoming,
             alive: AtomicBool::new(true),
             executable_path: codex_path.to_path_buf(),
@@ -286,29 +468,19 @@ impl CodexHost {
                             }
                             continue;
                         }
-                        let thread_id = message
-                            .pointer("/params/threadId")
-                            .and_then(Value::as_str)
-                            .or_else(|| {
-                                message.pointer("/params/thread/id").and_then(Value::as_str)
-                            });
-                        let route = if let Some(thread_id) = thread_id {
-                            host.routes.read().await.get(thread_id).cloned()
-                        } else {
-                            None
-                        };
-                        let message_turn_id = message
-                            .pointer("/params/turnId")
-                            .and_then(Value::as_str)
-                            .or_else(|| message.pointer("/params/turn/id").and_then(Value::as_str));
-                        let owner =
-                            route.and_then(|route| route.owner_for_message(message_turn_id));
-                        if let Some(owner) = owner {
-                            let _ = host
-                                .incoming
-                                .send(owner.message(&host.host_instance_id, message));
-                        } else if message.get("id").is_some() {
-                            let id = message.get("id").cloned().unwrap_or(Value::Null);
+                        let (disposition, unrouted_request_id) = route_codex_stdout_ingress(
+                            &host.host_instance_id,
+                            &host.routes,
+                            &host.incoming,
+                            message,
+                        )
+                        .await;
+                        match disposition {
+                            CodexIngressDisposition::DropCurrentDelta
+                            | CodexIngressDisposition::DropRejectedDelta => continue,
+                            CodexIngressDisposition::Forward => {}
+                        }
+                        if let Some(id) = unrouted_request_id {
                             let _ = host
                                 .send(json!({
                                     "id": id,
@@ -354,20 +526,7 @@ impl CodexHost {
     }
 
     async fn bind_thread(&self, thread_id: &str, owner: &CodexRuntimeOwner) -> Result<()> {
-        let mut routes = self.routes.write().await;
-        if let Some(existing) = routes.get(thread_id)
-            && &existing.owner != owner
-        {
-            bail!("Codex Native Thread is already bound to another logical runtime");
-        }
-        routes.insert(
-            thread_id.to_string(),
-            CodexThreadRoute {
-                owner: owner.clone(),
-                active_turn_id: None,
-            },
-        );
-        Ok(())
+        self.routes.bind_thread(thread_id, owner).await
     }
 
     async fn activate_turn(
@@ -376,20 +535,7 @@ impl CodexHost {
         owner: &CodexRuntimeOwner,
         turn_id: &str,
     ) -> Result<()> {
-        let mut routes = self.routes.write().await;
-        let route = routes
-            .get_mut(thread_id)
-            .context("Codex Native Thread has no logical runtime binding")?;
-        if &route.owner != owner
-            || route
-                .active_turn_id
-                .as_deref()
-                .is_some_and(|active| active != turn_id)
-        {
-            bail!("Codex Native Turn failed Host/Thread/Run fencing");
-        }
-        route.active_turn_id = Some(turn_id.to_string());
-        Ok(())
+        self.routes.activate_turn(thread_id, owner, turn_id).await
     }
 
     async fn deactivate_turn(
@@ -398,40 +544,21 @@ impl CodexHost {
         owner: &CodexRuntimeOwner,
         completed_turn_id: Option<&str>,
     ) {
-        let mut routes = self.routes.write().await;
-        let Some(route) = routes.get_mut(thread_id) else {
-            return;
-        };
-        if &route.owner == owner
-            && (completed_turn_id.is_none() || route.active_turn_id.as_deref() == completed_turn_id)
-        {
-            route.active_turn_id = None;
-        }
+        self.routes
+            .deactivate_turn(thread_id, owner, completed_turn_id)
+            .await;
     }
 
     async fn active_turn(&self, thread_id: &str, owner: &CodexRuntimeOwner) -> Option<String> {
-        self.routes
-            .read()
-            .await
-            .get(thread_id)
-            .filter(|route| &route.owner == owner)
-            .and_then(|route| route.active_turn_id.clone())
+        self.routes.active_turn(thread_id, owner).await
     }
 
     async fn unbind_thread(&self, thread_id: &str, owner: &CodexRuntimeOwner) {
-        let mut routes = self.routes.write().await;
-        if routes.get(thread_id).map(|route| &route.owner) == Some(owner) {
-            routes.remove(thread_id);
-        }
+        self.routes.unbind_thread(thread_id, owner).await;
     }
 
     async fn owners(&self) -> HashSet<CodexRuntimeOwner> {
-        self.routes
-            .read()
-            .await
-            .values()
-            .map(|route| route.owner.clone())
-            .collect()
+        self.routes.owners().await
     }
 
     async fn broadcast_stderr(&self, text: String) {
@@ -467,9 +594,7 @@ impl CodexHost {
     }
 
     pub(crate) async fn is_quiescent(&self) -> bool {
-        self.is_alive()
-            && self.pending.lock().await.is_empty()
-            && self.routes.read().await.is_empty()
+        self.is_alive() && self.pending.lock().await.is_empty() && self.routes.is_empty().await
     }
 
     pub(crate) async fn shutdown_and_reap(&self) {
@@ -821,12 +946,6 @@ impl CodexRuntime {
     pub async fn turn_id(&self) -> Option<String> {
         let thread_id = self.thread_id().await?;
         self.host.active_turn(&thread_id, &self.owner).await
-    }
-
-    pub async fn active_command_output_route(&self) -> Option<(String, String)> {
-        let thread_id = self.thread_id().await?;
-        let turn_id = self.host.active_turn(&thread_id, &self.owner).await?;
-        Some((thread_id, turn_id))
     }
 
     pub async fn observe_agent_message(&self, method: &str, params: &Value) {
@@ -2318,44 +2437,171 @@ while IFS= read -r ignored; do :; done
         assert!(result.is_err());
     }
 
-    #[test]
-    fn shared_host_route_rejects_old_terminalized_and_unbound_events() {
+    #[tokio::test]
+    async fn stdout_ingress_drops_command_output_flood_and_preserves_terminal_events() {
         let owner = CodexRuntimeOwner::AgentRun {
             agent_run_id: "run-current".to_string(),
             execution_epoch: 4,
         };
-        let mut routes = HashMap::from([(
-            "thread-current".to_string(),
-            CodexThreadRoute {
-                owner: owner.clone(),
-                active_turn_id: Some("turn-current".to_string()),
-            },
-        )]);
-        let route = routes.get("thread-current").unwrap();
-        assert!(route.owner_for_message(Some("turn-old")).is_none());
+        let routes = CodexThreadRoutes::default();
+        routes.bind_thread("thread-current", &owner).await.unwrap();
+        routes
+            .activate_turn("thread-current", &owner, "turn-current")
+            .await
+            .unwrap();
+        let (incoming, mut receiver) = mpsc::unbounded_channel();
+        let output_delta = json!({
+            "method": "item/commandExecution/outputDelta",
+            "params": {
+                "threadId": "thread-current",
+                "turnId": "turn-current",
+                "itemId": "command-1",
+                "delta": "line one\n",
+            }
+        });
+
+        for _ in 0..100_000 {
+            let (disposition, unrouted_request_id) = route_codex_stdout_ingress(
+                "host-current",
+                &routes,
+                &incoming,
+                output_delta.clone(),
+            )
+            .await;
+            assert_eq!(disposition, CodexIngressDisposition::DropCurrentDelta);
+            assert!(unrouted_request_id.is_none());
+        }
         assert!(matches!(
-            route.owner_for_message(Some("turn-current")),
-            Some(CodexRuntimeOwner::AgentRun {
-                ref agent_run_id,
-                execution_epoch: 4,
-            }) if agent_run_id == "run-current"
+            receiver.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
         ));
 
-        routes.get_mut("thread-current").unwrap().active_turn_id = None;
-        assert!(
-            routes["thread-current"]
-                .owner_for_message(Some("turn-current"))
-                .is_none()
-        );
-        routes.remove("thread-current");
-        assert!(!routes.contains_key("thread-current"));
-        assert_eq!(
-            owner,
-            CodexRuntimeOwner::AgentRun {
-                agent_run_id: "run-current".to_string(),
-                execution_epoch: 4,
+        let item_completed = json!({
+            "method": "item/completed",
+            "params": {
+                "threadId": "thread-current",
+                "turnId": "turn-current",
+                "item": {
+                    "id": "command-1",
+                    "type": "commandExecution",
+                    "command": "cargo test",
+                    "status": "completed",
+                    "exitCode": 0,
+                    "aggregatedOutput": "terminal output",
+                }
             }
+        });
+        let turn_completed = json!({
+            "method": "turn/completed",
+            "params": {
+                "threadId": "thread-current",
+                "turn": {"id": "turn-current", "status": "completed"}
+            }
+        });
+        for message in [item_completed, turn_completed] {
+            let (disposition, unrouted_request_id) =
+                route_codex_stdout_ingress("host-current", &routes, &incoming, message).await;
+            assert_eq!(disposition, CodexIngressDisposition::Forward);
+            assert!(unrouted_request_id.is_none());
+        }
+        let CodexIncoming::Message {
+            agent_run_id,
+            execution_epoch,
+            message,
+            ..
+        } = receiver.try_recv().unwrap()
+        else {
+            panic!("item/completed must remain a semantic Message");
+        };
+        assert_eq!(agent_run_id, "run-current");
+        assert_eq!(execution_epoch, 4);
+        assert_eq!(message["method"], "item/completed");
+        assert_eq!(
+            message["params"]["item"]["aggregatedOutput"],
+            "terminal output"
         );
+        let CodexIncoming::Message { message, .. } = receiver.try_recv().unwrap() else {
+            panic!("turn/completed must remain a terminal Message");
+        };
+        assert_eq!(message["method"], "turn/completed");
+        assert!(matches!(
+            receiver.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+
+        let old_turn_delta = json!({
+            "method": "item/commandExecution/outputDelta",
+            "params": {
+                "threadId": "thread-current",
+                "turnId": "turn-old",
+                "itemId": "command-1",
+                "delta": "late",
+            }
+        });
+        let rejected_deltas = [
+            old_turn_delta,
+            json!({
+                "method": "item/commandExecution/outputDelta",
+                "params": {"turnId": "turn-current", "itemId": "command-1", "delta": "late"}
+            }),
+            json!({
+                "method": "item/commandExecution/outputDelta",
+                "params": {"threadId": "thread-current", "itemId": "command-1", "delta": "late"}
+            }),
+            json!({
+                "method": "item/commandExecution/outputDelta",
+                "params": {"threadId": "thread-current", "turnId": "turn-current", "delta": "late"}
+            }),
+            json!({
+                "method": "item/commandExecution/outputDelta",
+                "params": {"threadId": "thread-current", "turnId": "turn-current", "itemId": "  ", "delta": "late"}
+            }),
+            json!({
+                "method": "command/exec/outputDelta",
+                "params": {"itemId": "command-1", "delta": "legacy"}
+            }),
+        ];
+        for message in rejected_deltas {
+            let (disposition, unrouted_request_id) =
+                route_codex_stdout_ingress("host-current", &routes, &incoming, message).await;
+            assert_eq!(disposition, CodexIngressDisposition::DropRejectedDelta);
+            assert!(unrouted_request_id.is_none());
+        }
+        assert!(matches!(
+            receiver.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+
+        let mut server_request = output_delta.clone();
+        server_request["id"] = json!(91);
+        let (disposition, unrouted_request_id) =
+            route_codex_stdout_ingress("host-current", &routes, &incoming, server_request).await;
+        assert_eq!(disposition, CodexIngressDisposition::Forward);
+        assert!(unrouted_request_id.is_none());
+        let CodexIncoming::Message { message, .. } = receiver.try_recv().unwrap() else {
+            panic!("an id-bearing outputDelta method must reach request routing");
+        };
+        assert_eq!(message["id"], 91);
+
+        routes
+            .deactivate_turn("thread-current", &owner, Some("turn-current"))
+            .await;
+        let (disposition, _) =
+            route_codex_stdout_ingress("host-current", &routes, &incoming, output_delta.clone())
+                .await;
+        assert_eq!(disposition, CodexIngressDisposition::DropRejectedDelta);
+        routes
+            .activate_turn("thread-current", &owner, "turn-current")
+            .await
+            .unwrap();
+        routes.unbind_thread("thread-current", &owner).await;
+        let (disposition, _) =
+            route_codex_stdout_ingress("host-current", &routes, &incoming, output_delta).await;
+        assert_eq!(disposition, CodexIngressDisposition::DropRejectedDelta);
+        assert!(matches!(
+            receiver.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
     }
 
     #[test]

--- a/crates/rovai-core/src/execution_evidence.rs
+++ b/crates/rovai-core/src/execution_evidence.rs
@@ -112,31 +112,6 @@ impl ExecutionEvidenceService {
         )
     }
 
-    pub fn command_output_delta_admission_open(
-        &self,
-        database: &Database,
-        agent_run_id: &str,
-        execution_epoch: i64,
-    ) -> Result<bool> {
-        database
-            .connection()
-            .query_row(
-                r#"
-                SELECT EXISTS(
-                    SELECT 1
-                    FROM agent_run
-                    WHERE id = ?1
-                      AND execution_epoch = ?2
-                      AND status IN ('running', 'waiting')
-                      AND cancel_requested_at IS NULL
-                )
-                "#,
-                params![agent_run_id, execution_epoch],
-                |row| row.get(0),
-            )
-            .map_err(Into::into)
-    }
-
     pub fn prepare_runtime_event(
         &self,
         event_type: &str,
@@ -1341,19 +1316,17 @@ mod tests {
             .unwrap();
         let blob_store = ManagedBlobStore::new(&directory);
         let output_delta = json!({ "itemId": "command-1", "delta": "transport only" });
-        for _ in 0..100_000 {
-            let evidence = ExecutionEvidenceService
-                .record_runtime_event(
-                    &mut database,
-                    &blob_store,
-                    &run_id,
-                    execution_epoch,
-                    "command.output.delta",
-                    &output_delta,
-                )
-                .unwrap();
-            assert!(evidence.is_none());
-        }
+        let evidence = ExecutionEvidenceService
+            .record_runtime_event(
+                &mut database,
+                &blob_store,
+                &run_id,
+                execution_epoch,
+                "command.output.delta",
+                &output_delta,
+            )
+            .unwrap();
+        assert!(evidence.is_none());
         let durable_delta_count: i64 = database
             .connection()
             .query_row(
@@ -1363,44 +1336,6 @@ mod tests {
             )
             .unwrap();
         assert_eq!(durable_delta_count, 0);
-        assert!(
-            ExecutionEvidenceService
-                .command_output_delta_admission_open(&database, &run_id, execution_epoch)
-                .unwrap()
-        );
-        assert!(
-            !ExecutionEvidenceService
-                .command_output_delta_admission_open(&database, &run_id, execution_epoch + 1)
-                .unwrap()
-        );
-        database
-            .connection()
-            .execute_batch("SAVEPOINT command_output_terminal_fence")
-            .unwrap();
-        let terminal_probe_at = chrono::Utc::now().to_rfc3339();
-        database
-            .connection()
-            .execute(
-                "UPDATE agent_run SET status = 'failed', ended_at = ?2, updated_at = ?2 WHERE id = ?1",
-                params![run_id, terminal_probe_at],
-            )
-            .unwrap();
-        assert!(
-            !ExecutionEvidenceService
-                .command_output_delta_admission_open(&database, &run_id, execution_epoch)
-                .unwrap()
-        );
-        database
-            .connection()
-            .execute_batch(
-                "ROLLBACK TO command_output_terminal_fence; RELEASE command_output_terminal_fence",
-            )
-            .unwrap();
-        assert!(
-            ExecutionEvidenceService
-                .command_output_delta_admission_open(&database, &run_id, execution_epoch)
-                .unwrap()
-        );
 
         let secret = format!("EVIDENCE_ONLY_{}", "x".repeat(573_647));
         let started_command = ExecutionEvidenceService
@@ -1641,11 +1576,6 @@ mod tests {
                 },
             )
             .unwrap();
-        assert!(
-            !ExecutionEvidenceService
-                .command_output_delta_admission_open(&database, &run_id, execution_epoch)
-                .unwrap()
-        );
         let interrupted = ExecutionEvidenceService
             .record_interrupted_runtime_activity(
                 &mut database,

--- a/crates/rovai-core/src/main.rs
+++ b/crates/rovai-core/src/main.rs
@@ -11777,8 +11777,6 @@ fn codex_delta_batch_identity(incoming: &CodexIncoming) -> Option<(&str, &str, i
         "item/agentMessage/delta"
             | "item/reasoning/summaryTextDelta"
             | "item/plan/delta"
-            | "item/commandExecution/outputDelta"
-            | "command/exec/outputDelta"
             | "item/fileChange/patchUpdated"
     )
     .then_some((
@@ -11788,34 +11786,17 @@ fn codex_delta_batch_identity(incoming: &CodexIncoming) -> Option<(&str, &str, i
     ))
 }
 
-fn is_codex_command_output_delta(message: &Value) -> bool {
-    message
-        .get("method")
-        .and_then(Value::as_str)
-        .is_some_and(|method| {
-            matches!(
-                method,
-                "item/commandExecution/outputDelta" | "command/exec/outputDelta"
-            )
-        })
-}
-
-fn is_codex_command_output_delta_batch(messages: &[Value]) -> bool {
-    !messages.is_empty() && messages.iter().all(is_codex_command_output_delta)
-}
-
-fn codex_command_output_delta_matches_route(
-    message: &Value,
-    native_thread_id: &str,
-    native_turn_id: &str,
-) -> bool {
-    message.get("method").and_then(Value::as_str) == Some("item/commandExecution/outputDelta")
-        && message.pointer("/params/threadId").and_then(Value::as_str) == Some(native_thread_id)
-        && message.pointer("/params/turnId").and_then(Value::as_str) == Some(native_turn_id)
+fn is_codex_command_output_delta_notification(message: &Value) -> bool {
+    message.get("id").is_none()
         && message
-            .pointer("/params/itemId")
+            .get("method")
             .and_then(Value::as_str)
-            .is_some_and(|item_id| !item_id.trim().is_empty())
+            .is_some_and(|method| {
+                matches!(
+                    method,
+                    "item/commandExecution/outputDelta" | "command/exec/outputDelta"
+                )
+            })
 }
 
 fn acp_delta_batch_identity(
@@ -11977,6 +11958,11 @@ async fn process_codex_events(
                 _ = &mut shutdown => break,
             },
         };
+        if let CodexIncoming::Message { message, .. } = &incoming
+            && is_codex_command_output_delta_notification(message)
+        {
+            continue;
+        }
         let Some(mut runtime_route_permit) = core.planned_shutdown.enter_runtime_route().await
         else {
             break;
@@ -14233,37 +14219,6 @@ async fn process_runtime_usage_flusher(core: Arc<Core>, mut shutdown: oneshot::R
     }
 }
 
-async fn codex_command_output_delta_batch_admission_open(
-    core: &Core,
-    host_instance_id: &str,
-    agent_run_id: &str,
-    execution_epoch: i64,
-    messages: &[Value],
-) -> Result<bool> {
-    let Some(runtime) = core
-        .codex_cli
-        .get_agent_run_on_host(host_instance_id, agent_run_id, execution_epoch)
-        .await
-    else {
-        return Ok(false);
-    };
-    let Some((native_thread_id, native_turn_id)) = runtime.active_command_output_route().await
-    else {
-        return Ok(false);
-    };
-    if !messages.iter().all(|message| {
-        codex_command_output_delta_matches_route(message, &native_thread_id, &native_turn_id)
-    }) {
-        return Ok(false);
-    }
-    let database = core.database.lock().await;
-    ExecutionEvidenceService.command_output_delta_admission_open(
-        &database,
-        agent_run_id,
-        execution_epoch,
-    )
-}
-
 async fn process_agent_run_codex_delta_batch(
     core: &Arc<Core>,
     output: &mpsc::UnboundedSender<String>,
@@ -14273,27 +14228,6 @@ async fn process_agent_run_codex_delta_batch(
     messages: Vec<Value>,
     runtime_route_permit: &mut rovai_core::planned_shutdown::RuntimeRoutePermit,
 ) {
-    if is_codex_command_output_delta_batch(&messages) {
-        match codex_command_output_delta_batch_admission_open(
-            core,
-            host_instance_id,
-            agent_run_id,
-            execution_epoch,
-            &messages,
-        )
-        .await
-        {
-            Ok(true) => {}
-            Ok(false) => return,
-            Err(error) => {
-                eprintln!(
-                    "failed to apply the transient Command output fence for AgentRun {agent_run_id}: {error:#}"
-                );
-                return;
-            }
-        }
-        return;
-    }
     let prepared = match prepare_codex_delta_batch(&messages) {
         Ok(Some(prepared)) => prepared,
         Ok(None) => {
@@ -14455,6 +14389,9 @@ async fn process_agent_run_codex_message(
     message: Value,
     runtime_route_permit: &mut rovai_core::planned_shutdown::RuntimeRoutePermit,
 ) {
+    if is_codex_command_output_delta_notification(&message) {
+        return;
+    }
     let Some(runtime) = core
         .codex_cli
         .get_agent_run_on_host(host_instance_id, agent_run_id, execution_epoch)
@@ -14521,27 +14458,6 @@ async fn process_agent_run_codex_message(
         return;
     }
     let (event_type, payload) = codex::normalize_event(&method, &params);
-    if ExecutionEvidenceService::is_transient_command_output_event(event_type) {
-        match codex_command_output_delta_batch_admission_open(
-            core,
-            host_instance_id,
-            agent_run_id,
-            execution_epoch,
-            std::slice::from_ref(&message),
-        )
-        .await
-        {
-            Ok(true) => {}
-            Ok(false) => return,
-            Err(error) => {
-                eprintln!(
-                    "failed to apply the transient Command output fence for AgentRun {agent_run_id}: {error:#}"
-                );
-                return;
-            }
-        }
-        return;
-    }
     runtime.observe_agent_message(&method, &params).await;
     let evidence =
         match persist_runtime_evidence(core, agent_run_id, execution_epoch, event_type, &payload)
@@ -17272,10 +17188,7 @@ while IFS= read -r _ignored; do :; done
                 }
             }),
         };
-        assert_eq!(
-            codex_delta_batch_identity(&command_output_delta),
-            Some(("codex-host", "run-1", 2))
-        );
+        assert!(codex_delta_batch_identity(&command_output_delta).is_none());
         let CodexIncoming::Message {
             message: command_output_message,
             ..
@@ -17283,42 +17196,23 @@ while IFS= read -r _ignored; do :; done
         else {
             unreachable!()
         };
-        assert!(is_codex_command_output_delta_batch(std::slice::from_ref(
+        assert!(is_codex_command_output_delta_notification(
             &command_output_message
-        )));
-        assert!(codex_command_output_delta_matches_route(
-            &command_output_message,
-            "thread-1",
-            "turn-1"
-        ));
-        assert!(!codex_command_output_delta_matches_route(
-            &command_output_message,
-            "thread-1",
-            "turn-old"
-        ));
-        assert!(!codex_command_output_delta_matches_route(
-            &command_output_message,
-            "thread-old",
-            "turn-1"
         ));
         let legacy_output_delta = json!({
             "method": "command/exec/outputDelta",
             "params": {"itemId": "command-1", "delta": "legacy"}
         });
-        assert!(is_codex_command_output_delta(&legacy_output_delta));
-        assert!(!codex_command_output_delta_matches_route(
-            &legacy_output_delta,
-            "thread-1",
-            "turn-1"
+        assert!(is_codex_command_output_delta_notification(
+            &legacy_output_delta
         ));
-        let missing_item_id = json!({
+        let id_bearing_output_delta = json!({
+            "id": 7,
             "method": "item/commandExecution/outputDelta",
-            "params": {"threadId": "thread-1", "turnId": "turn-1", "delta": "late"}
+            "params": {"threadId": "thread-1", "turnId": "turn-1", "itemId": "command-1", "delta": "request"}
         });
-        assert!(!codex_command_output_delta_matches_route(
-            &missing_item_id,
-            "thread-1",
-            "turn-1"
+        assert!(!is_codex_command_output_delta_notification(
+            &id_bearing_output_delta
         ));
         assert!(
             prepare_codex_delta_batch(std::slice::from_ref(&command_output_message))

--- a/docs/architecture/foundational-invariants.md
+++ b/docs/architecture/foundational-invariants.md
@@ -377,9 +377,15 @@ last_updated: 2026-08-26
   相邻 raw object 字段不公开；command 观察必须绑定同一原生 operation identity，terminal 优先采用自身当前的
   公共 command，仅在缺失时回退 started phase 缓存，不能要求 Renderer 从 digest、title、output 或私有
   terminal 还原。
-- Codex `command.output.delta` 只是 stdout/stderr 运输片段。未来新事件必须在同一 Host/Run/execution epoch、
-  Native Thread/Turn、active route 与 Run cancellation/terminal fence 下完成准入检查，随后直接丢弃；它不写
-  Execution Evidence、不推进 Canonical Activity、不创建 Managed Blob，也不进入 Renderer live event state。
+- Codex `command.output.delta` 只是 stdout/stderr 运输片段。未来无 `id` 的
+  `item/commandExecution/outputDelta` 在 Codex Host stdout ingress 的当前 Native Thread/Turn route 读锁内分类；
+  精确当前 route 与非空 `itemId` 记为 current delta，旧 Turn、已 deactivate/unbind、字段缺失及 legacy
+  `command/exec/outputDelta` 记为 rejected delta，两类都在构造或发送 `CodexIncoming` 前直接丢弃。带 `id` 的
+  同名 JSON-RPC request 不参与 early-drop，继续走既有 request response 路径；Core 的漏网防御在 shutdown route
+  permit、batching、Runtime lookup 和数据库读取前无条件丢弃 delta notification。因为没有任何 delta 接受态或可变
+  sink，该路径不再执行 Run/epoch/lease 数据库 admission；terminal 尚未被 Core 消费的竞态中即使分类为 current，
+  结果仍是丢弃。它不写 Execution Evidence、不推进 Canonical Activity、不创建 Managed Blob，也不进入 Renderer
+  live event state。
   `item/completed` 的 `aggregatedOutput` 是 Command 最终输出的唯一权威，大输出继续按既有阈值进入 Managed Blob。
   已存在的历史 delta Evidence/Blob 保持原样且仍可读取，本规则不迁移、删除、重写或重建历史。
 - Adapter 必须优先从原生 terminal semantic event 提供完整公开输出。若未来某个 Adapter 无法提供完整 terminal

--- a/docs/runtime-activity/registry.md
+++ b/docs/runtime-activity/registry.md
@@ -98,7 +98,7 @@ wire shape，Core post-fix live smoke 仍需单独运行。
 
 | 协议路径 | Adapter identities | terminal semantic output | 临时输出片段 |
 |---|---|---|---|
-| Codex app-server | identity：`codex-cli` | `item/completed` 的 `commandExecution.aggregatedOutput`，并保留 `command`、`status`、`exitCode` | `command.output.delta` 通过 Host/Run/epoch/Thread/Turn/active-route/Run-state fence 后直接丢弃 |
+| Codex app-server | identity：`codex-cli` | `item/completed` 的 `commandExecution.aggregatedOutput`，并保留 `command`、`status`、`exitCode` | 无 `id` 的 `command.output.delta` 在 Host stdout ingress 按当前 Thread/Turn route 分类后直接丢弃，不进入 `CodexIncoming`；legacy shape fail closed |
 | ACP v1 | identities：`opencode-cli`、`copilot-cli`、`kiro-cli`、`qoder-cli`、`codebuddy-cli`、`qwen-code`、`trae-cn-cli`、`cursor-agent`、`kimi-code-cli`、`grok-build` | terminal `tool_call_update` 归一为一条 `runtime.action.payload.output` | 这十个 Adapter 不产生 `command.output.delta` |
 | Claude stream-json | identity：`claude-code-cli` | terminal Bash `tool_result` 归一为一条 `runtime.action.payload.output` | 不产生 `command.output.delta` |
 | Antigravity stream-json | identity：`antigravity-app` | terminal tool step 归一为一条 `runtime.action.payload.output` | 不产生 `command.output.delta` |
@@ -108,9 +108,11 @@ wire shape，Core post-fix live smoke 仍需单独运行。
 Renderer 不得用无界字符串 accumulator 补偿协议缺口，也不得把片段逐条持久化。
 
 Codex 的 transport-only delta 不写 Execution Evidence、不更新 Canonical Activity、不创建 Managed Blob，也不进入
-Renderer `liveRuntimeEvents`。终态、取消请求、Host unbind/exit、Turn 替换、epoch supersede 或 route/lease fence
-关闭后到达的旧片段直接拒绝。既有历史 `command.output.delta` Evidence/Blob 不迁移、不删除、不重写，并继续由
-历史只读展示路径解析。
+Renderer `liveRuntimeEvents`。Host ingress 对精确当前 Thread/Turn + 非空 `itemId` 与 stale/malformed/unbound/legacy
+分别给出 current/rejected 分类，但两者都在同一 route 读锁下消费并丢弃；因此 terminal 尚未被 Core 消费前的 delta
+即使仍分类为 current，也没有可更新的状态。带 `id` 的同名 request 保持 request response 路径，下游漏网 guard 位于
+shutdown route permit、batching、Runtime lookup 与数据库之前。既有历史 `command.output.delta` Evidence/Blob 不迁移、
+不删除、不重写，并继续由历史只读展示路径解析。
 
 ### ACP v1
 

--- a/docs/versions/v1.28/README.md
+++ b/docs/versions/v1.28/README.md
@@ -20,7 +20,7 @@ last_updated: 2026-08-26
 > 不变，把 Grok 首次交付改为原生 `_meta.rules`，并以结构化 completion 驱动 Redelivery v2。实现经
 > 独立 worktree 验收后通过 PR 交付 `main`；`>= 1.0.0 / session.resume` clean break 的确定性实现已完成，
 > macOS arm64/x64 与 Windows x64 已分别用 `grok 1.0.5` 完成真实 Deep Probe、cold resume 与产品矩阵。
-> 新产生的 Codex command output delta 已改为 fence 后直接丢弃；Command terminal aggregate 保持唯一输出权威，
+> 新产生的 Codex command output delta 已改为 Host stdout ingress route 分类后直接丢弃，不进入 Core 无界队列；Command terminal aggregate 保持唯一输出权威，
 > 历史 Evidence/Blob 不迁移。全部 13 个 Adapter 的 terminal output 路径已逐项核验，无 Adapter 需要新增 spool。
 
 前置版本：[v1.27 Kimi Code + MiniMax M3](../v1.27/README.md)已按冻结时事实转为 historical。
@@ -81,8 +81,10 @@ Product Runtime 接入。复用本机 MiniMax API Key，但改用 Grok 官方 cu
 - Camp 执行台把同一 Run 内最大连续的 Tool 派生为默认收起的摘要，运行中显示最后一条非终态操作，展开后
   保留完整 chronology，并把完整 Tool 结果延迟到精确 Tool 首次展开；分组不改变 Core Evidence、Tool identity
   或 non-terminal open projection。
-- Codex `command.output.delta` 对未来数据采用 transport-only clean break：通过 Host/Run/epoch/Thread/Turn、
-  active route 与 Run-state fence 后直接丢弃，不写 Evidence/Canonical/Blob，也不进入 Renderer live state；
+- Codex `command.output.delta` 对未来数据采用 transport-only clean break：Host stdout ingress 在处理 JSON-RPC response
+  后识别无 `id` notification，按当前 Thread/Turn route 把精确与 stale/malformed/legacy delta 分类并全部丢弃，
+  不构造 `CodexIncoming`、不进入 Core 无界队列，也不写 Evidence/Canonical/Blob 或 Renderer live state；带 `id`
+  的同名 request 保留既有 response 路径，下游漏网 guard 早于 batching、Runtime lookup 与数据库读取；
   terminal `aggregatedOutput` 继续作为 Command 输出唯一权威并沿用大正文 Managed Blob 阈值。十个 ACP Adapter、
   Claude Code 与 Antigravity 已在各自 terminal semantic event 中给出完整公开输出，不需要临时 spool。
 - Runtime 明确报告 interruption 时，尚未结算的 Activity 记录为 terminal/unsettled，reason code 为

--- a/docs/versions/v1.28/decisions.md
+++ b/docs/versions/v1.28/decisions.md
@@ -417,7 +417,7 @@ interpreter、PATH winner 或 reported version 变化都会触发新 Probe/Host 
 - 显式路径失败后继续 PATH：把用户选择静默替换成另一安装，破坏 fail-closed 语义。
 
 <a id="v1-28-d12"></a>
-## V1.28-D12：Command output delta 改为 fenced transient，terminal aggregate 是唯一输出权威
+## V1.28-D12：Command output delta 在 Host ingress 丢弃，terminal aggregate 是唯一输出权威
 
 ### 背景
 
@@ -435,11 +435,17 @@ output 的单一 `runtime.action`。当前没有 Adapter 需要额外 accumulato
 只对未来新产生的数据采用 clean break。既有历史 Evidence、Managed Blob 与 Canonical Activity 不迁移、不删除、
 不改写、不重建，旧 Camp 的历史性能问题留待独立治理，历史 delta 继续可读。
 
-Codex `command.output.delta` 仍须通过现有 Host instance、AgentRun、execution epoch、Native Thread/Turn、delivery、
-active route 与 lease/Run-state fence。route 与 Run-state 准入在 transient path 的唯一临界读取中完成；任何 terminal、
-cancel request、Host unbind/exit、Turn replacement、epoch supersede 或 route/lease fence 关闭后到达的片段都直接拒绝。
-通过 fence 的片段同样直接丢弃：不写 Execution Evidence、不更新 Canonical Activity、不创建 Managed Blob，也不进入
-Renderer `liveRuntimeEvents`。该路径没有接受后的可变输出状态，因此 fence 检查之后不存在可被迟到片段更新的窗口。
+Codex Host 必须先处理既有 JSON-RPC response，再对无 `id` notification 识别
+`item/commandExecution/outputDelta` 与 `command/exec/outputDelta`。识别和 route 验证分离：精确匹配当前 Native
+Thread/Turn 且 `itemId` 非空时分类为 current delta；旧 Turn、已 deactivate/unbind、字段缺失或 legacy shape 分类为
+rejected delta。两类都必须在同一 route 读锁临界区内消费并直接丢弃，不构造或发送 `CodexIncoming`。带 `id` 的
+同名 server request 不参与 early-drop，继续走既有 request routing / unsupported-request response。
+
+Host ingress 不因看到 `turn/completed` 提前 deactivate Turn；Core 继续拥有既有 terminal 顺序。在 terminal 通知已到达、
+但 Core 尚未消费的窗口内，delta 可能仍分类为 current，但结果同样是丢弃。由于该 transport 没有接受态、accumulator
+或其他可变 sink，不再执行 AgentRun/execution epoch/lease/Run-state 数据库 admission。Core 仍保留无条件漏网 guard，
+并把它放在 shutdown route permit、batching、Runtime lookup 与数据库读取之前。最终效果仍是不写 Execution Evidence、
+不更新 Canonical Activity、不创建 Managed Blob，也不进入 Renderer `liveRuntimeEvents`。
 
 Codex `item/completed.commandExecution.aggregatedOutput` 是最终 Command 输出的唯一权威，terminal semantic record 继续
 保留 `command`、`status` 与 `exitCode`；超过现有阈值时继续写 Managed Blob，并只在用户展开精确 Tool 时惰性读取。
@@ -456,14 +462,16 @@ PR #63 的每个 Tool identity、chronology、状态、结果与 Renderer-only �
 
 ### 后果
 
-一个产生 100,000 个 output delta 的 Command 对未来数据库与 Renderer live state 都新增 0 个 delta 项，只留下单一
-terminal semantic result。数据库写放大和 React state/排序风险不再随 stdout/stderr frame 数增长；大输出容量仍由
-Managed Blob 合同承担。历史数据量不会因本决定缩小。
+一个产生 100,000 个 output delta 的 Command 向 Core `codex_tx` 发送 0 条 delta，对未来数据库与 Renderer live
+state 也都新增 0 个 delta 项，只留下单一 terminal semantic result。无界队列、数据库写放大和 React state/排序风险
+均不再随 stdout/stderr frame 数增长；大输出容量仍由 Managed Blob 合同承担。历史数据量不会因本决定缩小。
 
 ### 被拒绝方案
 
 - 把 delta 继续写 Evidence，只在读取时合并：仍保留数据库写放大和历史恢复成本；
 - 把每个 delta 改放 Renderer state：把膨胀从 SQLite 转移到 React 内存、排序与 progress rebuild；
 - 在 Core 中无限拼接完整 output：把协议流量变成无界常驻内存；
+- 把整个 `codex_tx` 改成 bounded blocking channel：stdout reader 还负责 JSON-RPC response 与 terminal event，阻塞
+  会把 output flood 的背压扩散到控制与终态路径；
 - 借本次修改清理或重写历史：扩大故障面并改变既有 Evidence/Blob 审计事实；
 - 将 interruption 写成 cancelled：把连续性未知伪装成 Runtime 权威取消。

--- a/docs/versions/v1.28/implementation-plan.md
+++ b/docs/versions/v1.28/implementation-plan.md
@@ -71,13 +71,16 @@ Checklist 仍拥有完整通用步骤，本页只记录本版本的具体状态�
 
 - [x] 逐项核验 13 个 Adapter：仅 Codex 产生 `command.output.delta`；十个 ACP Adapter、Claude Code 与
   Antigravity 都已有完整 terminal semantic output，当前无需 spool；
-- [x] 对未来 Codex delta 保留 Host/Run/epoch/Thread/Turn/route/Run-state fence 后直接丢弃，停止 Evidence、
-  Canonical、Managed Blob 与 Renderer live-state 写入；历史 Evidence/Blob 保持原样；
+- [x] 对未来 Codex delta 在 Host stdout ingress 完成三态 method/route 分类并直接丢弃：精确当前 route 与
+  stale/malformed/legacy 都不构造 `CodexIncoming`；下游漏网 guard 早于 shutdown route permit、batching、
+  Runtime lookup 与数据库读取，停止 Evidence、Canonical、Managed Blob 与 Renderer live-state 写入；历史
+  Evidence/Blob 保持原样；
 - [x] 保留 terminal Command 的 command/status/exitCode/aggregatedOutput，大输出继续进入精确 Tool 的 Managed Blob；
 - [x] 将 Runtime interruption 投影为 terminal/unsettled + `runtime_interrupted`，Renderer 显示
   stopped/interrupted，不伪造 cancelled；
-- [x] 覆盖 100,000 delta 零 DB/Renderer 项、cancel/terminal/Host/epoch/route fence、terminal aggregate/blob、
-  interruption 与 PR #63 Tool chronology/grouping/lazy disclosure 回归。
+- [x] 覆盖真实 Host ingress 连续 100,000 delta 零 `CodexIncoming`、零 DB/Renderer 项，current/old/deactivate/
+  unbind/malformed/legacy 分类、带 `id` request 保留、flood 后 terminal 顺序、terminal aggregate/blob、interruption
+  与 PR #63 Tool chronology/grouping/lazy disclosure 回归。
 
 ## 验收原则
 


### PR DESCRIPTION
## Summary
- drop Codex command output delta notifications at Host stdout ingress before CodexIncoming
- preserve id-bearing JSON-RPC requests and terminal semantic events
- remove downstream Runtime/database admission work and retain cheap defense-in-depth guards

## Validation
- cargo test -p rovai-core
- cargo clippy -p rovai-core --all-targets -- -D warnings
- pnpm typecheck
- Renderer 100,000 delta regression
- documentation test/check/CI gates