### PR TITLE
docs(mac): fix daily install invocation

### DIFF
--- a/docs/development/local-workflow.md
+++ b/docs/development/local-workflow.md
@@ -155,7 +155,7 @@ AI Agent 不得把 `open "$(pwd)/dist/mac-arm64/Rovai AI.app"` 当作打包验�
 
 ```bash
 pnpm package:mac:daily
-pnpm install:mac:daily -- --backup "/Applications/Rovai AI.backup-before-<timestamp>.app"
+pnpm install:mac:daily --backup "/Applications/Rovai AI.backup-before-<timestamp>.app"
 ```
 
 安装脚本以 no-follow 路径项检查准入 target 和 backup：任何既有 backup 路径项、以及符号链接 target 都在

--- a/docs/development/packaging.md
+++ b/docs/development/packaging.md
@@ -137,7 +137,7 @@ codesign --verify --strict \
 
 ```bash
 pnpm package:mac:daily
-pnpm install:mac:daily -- --backup "/Applications/Rovai AI.backup-before-<timestamp>.app"
+pnpm install:mac:daily --backup "/Applications/Rovai AI.backup-before-<timestamp>.app"
 ```
 
 `package:mac:daily` 不读取本机 Keychain 证书；构建后立即验证 App、Core、CLI 的架构、ad-hoc 签名、


### PR DESCRIPTION
## Summary

- remove the pnpm argument separator that pnpm 11 forwards literally to the daily install script
- keep the documented command aligned with the accepted CLI syntax

## Verification

- `pnpm docs:test`
- `pnpm docs:check`
- `git diff --check`