### PR TITLE
fix(desktop): fail open when updater binding fails

### DIFF
--- a/apps/desktop/src/main/app-updates.test.ts
+++ b/apps/desktop/src/main/app-updates.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   AppUpdatesService,
   CHECK_INTERVAL_MS,
+  createAppUpdatesServiceFailOpen,
   FIRST_CHECK_DELAY_MS,
   type DesktopAutoUpdater
 } from './app-updates'
@@ -52,6 +53,34 @@ function emitAvailable(updater: FakeUpdater, overrides: Record<string, unknown> 
 }
 
 describe('AppUpdatesService', () => {
+  it('falls back to an unavailable service when updater binding throws', async () => {
+    const updater = new FakeUpdater()
+    const reportFailure = vi.fn()
+    Object.defineProperty(updater, 'autoDownload', {
+      configurable: true,
+      get: () => true,
+      set: () => { throw new Error('native updater binding failed') }
+    })
+
+    const updates = createAppUpdatesServiceFailOpen({
+      currentVersion: () => '0.0.2',
+      isPackaged: () => true,
+      updater: updater as unknown as DesktopAutoUpdater,
+      now: () => NOW
+    }, reportFailure)
+
+    expect(reportFailure).toHaveBeenCalledOnce()
+    expect(reportFailure.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
+      message: 'native updater binding failed'
+    }))
+    expect(updates.startAutomaticChecks()).toBe(false)
+    await expect(updates.check()).resolves.toMatchObject({
+      status: 'check_failed',
+      failureReason: 'updater_unavailable',
+      availableRelease: null
+    })
+  })
+
   it('keeps downloading and installation user-controlled', () => {
     const updater = new FakeUpdater()
     const updates = service(updater)

--- a/apps/desktop/src/main/app-updates.ts
+++ b/apps/desktop/src/main/app-updates.ts
@@ -55,6 +55,18 @@ interface AppUpdatesServiceOptions {
 type SnapshotListener = (snapshot: AppUpdateSnapshot) => void
 type FailedOperation = 'check' | 'download' | 'install'
 
+export function createAppUpdatesServiceFailOpen(
+  options: AppUpdatesServiceOptions,
+  reportFailure: (error: unknown) => void
+): AppUpdatesService {
+  try {
+    return new AppUpdatesService(options)
+  } catch (error) {
+    reportFailure(error)
+    return new AppUpdatesService({ ...options, updater: null })
+  }
+}
+
 export class AppUpdatesService {
   readonly #currentVersion: () => string
   readonly #isPackaged: () => boolean

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -81,7 +81,11 @@ import {
   prepareWindowsDataRoot,
   resolveWindowsDataRoot
 } from './windows-data-root'
-import { AppUpdatesService, type DesktopAutoUpdater } from './app-updates'
+import {
+  AppUpdatesService,
+  createAppUpdatesServiceFailOpen,
+  type DesktopAutoUpdater
+} from './app-updates'
 import { AppQuitCoordinator } from './app-quit-coordinator'
 
 const mainStartupStartedAt = performance.now()
@@ -255,7 +259,7 @@ async function initializeAppUpdates(): Promise<void> {
   } catch (error) {
     console.warn('[rovai] Application updater is unavailable; startup will continue.', error)
   }
-  const service = new AppUpdatesService({
+  const service = createAppUpdatesServiceFailOpen({
     currentVersion: () => app.getVersion(),
     isPackaged: () => app.isPackaged,
     updater: autoUpdater as unknown as DesktopAutoUpdater | null,
@@ -263,6 +267,8 @@ async function initializeAppUpdates(): Promise<void> {
       isolatedAcceptanceInstance
       && process.env.ROVAI_DISABLE_AUTO_UPDATE_CHECKS === '1'
     )
+  }, (error) => {
+    console.warn('[rovai] Application updater initialization failed; startup will continue.', error)
   })
   service.onChanged((snapshot) => {
     if (!mainWindow || mainWindow.isDestroyed() || mainWindow.webContents.isDestroyed()) return


### PR DESCRIPTION
## Finding

The external report was stale for scheduling, explicit download, global prompt, and release-note data: all four are already present on `main` via #80.

One narrower startup risk was valid. `electron-updater` import failures were already caught, but an exception while configuring/binding the native updater inside `AppUpdatesService` could still escape `initializeAppUpdates()` into the top-level startup catch and quit the App.

## Fix

- add a fail-open service factory around native updater binding
- on binding failure, report once and construct the same service with `updater: null`
- preserve a readable updater-unavailable path without scheduling automatic checks or blocking the main window
- add a regression that makes the native `autoDownload` setter throw and proves the fallback behavior

## Verification

- `pnpm exec vitest run apps/desktop/src/main/app-updates.test.ts` — 13 passed
- `pnpm typecheck`
- `pnpm test` — 82 Vitest files / 580 tests; 213 Node tests passed, 1 platform test skipped
- `pnpm build:desktop`
- `git diff --check`
