### PR TITLE
fix(desktop): preserve failed install retry

### DIFF
--- a/apps/desktop/src/main/app-updates.test.ts
+++ b/apps/desktop/src/main/app-updates.test.ts
@@ -401,4 +401,33 @@ describe('AppUpdatesService', () => {
     expect(failing.install()).toBe(false)
     expect(failingUpdater.quitAndInstall).toHaveBeenCalledTimes(2)
   })
+
+  it('keeps a failed staged install retryable when an interval check fires', async () => {
+    const updater = new FakeUpdater()
+    const updates = service(updater)
+    updater.checkForUpdates.mockImplementation(async () => {
+      emitAvailable(updater)
+      return {}
+    })
+    updater.quitAndInstall.mockImplementation(() => {
+      throw new Error('installer unavailable')
+    })
+
+    await updates.check()
+    await updates.download()
+    expect(updates.install()).toBe(false)
+    expect(updates.get()).toMatchObject({
+      status: 'install_failed',
+      availableRelease: { version: '0.0.3' }
+    })
+
+    await expect(updates.check('interval')).resolves.toMatchObject({
+      status: 'install_failed',
+      availableRelease: { version: '0.0.3' }
+    })
+    expect(updater.checkForUpdates).toHaveBeenCalledOnce()
+    expect(updates.install()).toBe(false)
+    expect(updater.quitAndInstall).toHaveBeenCalledTimes(2)
+    expect(updater.downloadUpdate).toHaveBeenCalledOnce()
+  })
 })

--- a/apps/desktop/src/main/app-updates.ts
+++ b/apps/desktop/src/main/app-updates.ts
@@ -511,6 +511,7 @@ function blocksCheck(status: AppUpdateSnapshot['status']): boolean {
     || status === 'downloading'
     || status === 'ready_to_install'
     || status === 'installing'
+    || status === 'install_failed'
 }
 
 function isFailureStatus(status: AppUpdateSnapshot['status']): boolean {


### PR DESCRIPTION
## Summary

- block update checks while a staged installer remains in `install_failed`
- preserve the direct retry-install path instead of degrading back to `available`
- add a regression test covering download, synchronous install failure, interval check, and retry without re-download

## Verification

- `pnpm exec vitest run apps/desktop/src/main/app-updates.test.ts`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build:desktop`
- `git diff --check`