### PR TITLE
fix(test): follow accessible settings label

### DIFF
--- a/scripts/accept-member-lifecycle-ui.mjs
+++ b/scripts/accept-member-lifecycle-ui.mjs
@@ -148,7 +148,7 @@ try {
   await pressKey(running.cdp, 'Escape')
   await waitForExpression(running.cdp, `!document.querySelector('.new-camp-dialog')`)
 
-  await mouseClick(running.cdp, '.unified-sidebar button[aria-label="设置"]')
+  await mouseClick(running.cdp, '.unified-sidebar button[aria-label^="设置"]')
   await waitForSelector(running.cdp, '.settings-sidebar-menu')
   const settingsDestinations = await evaluate(running.cdp,
     `[...document.querySelectorAll('.settings-sidebar-menu strong')].map((node) => node.textContent)`)
@@ -490,7 +490,7 @@ try {
     '叮叮',
     outputDir
   ))
-  await mouseClick(running.cdp, '.unified-sidebar button[aria-label="设置"]')
+  await mouseClick(running.cdp, '.unified-sidebar button[aria-label^="设置"]')
   await waitForSelector(running.cdp, '.settings-sidebar-menu')
   await mouseClick(running.cdp, '.settings-sidebar-menu button', 'Agent 运行时', true)
   await waitForSelector(running.cdp, '.runtime-installations')
@@ -1152,7 +1152,7 @@ try {
     `Member content roster did not coexist with global navigation: ${JSON.stringify(quickChatRosterState)}`
   )
   await evaluate(running.cdp,
-    `document.querySelector('.unified-sidebar button[aria-label="设置"]')?.click()`)
+    `document.querySelector('.unified-sidebar button[aria-label^="设置"]')?.click()`)
   await waitForSelector(running.cdp, '.settings-sidebar-menu', 30_000)
   await mouseClick(running.cdp, '.settings-sidebar-back', '返回 App', true)
   await waitForSelector(running.cdp, '.members-view', 30_000)


### PR DESCRIPTION
## Summary
- update the member lifecycle packaged-App acceptance selectors to follow the expanded accessible Settings label introduced by proactive app updates
- keep the selector scoped to the unified sidebar and the `设置` accessible-name prefix

## Validation
- `node --check scripts/accept-member-lifecycle-ui.mjs`
- `ROVAI_MEMBER_LIFECYCLE_ACCEPT_NO_SANDBOX=1 pnpm accept:member-lifecycle-ui`
  - full packaged-App report passed, including dynamic Camp membership add/remove/re-add, frameless overflow menu, authoritative removal preview, Day/Night, compact layout, and no horizontal overflow
