### PR TITLE
fix(desktop): preserve IME after trailing newline

### DIFF
--- a/apps/desktop/src/renderer/src/StructuredMentionComposer.test.ts
+++ b/apps/desktop/src/renderer/src/StructuredMentionComposer.test.ts
@@ -10,6 +10,7 @@ import {
   skillQueryAfterNativeTextInput,
   skillQueryAfterTypedText,
   shouldHandleStructuredComposerBackspaceAtStart,
+  shouldReconcileStructuredComposerComposition,
   shouldSubmitStructuredComposerOnEnter,
   structuredMentionOptions,
   structuredSkillOptions
@@ -51,7 +52,24 @@ describe('StructuredMentionComposer', () => {
       onSubmit: () => undefined
     }))
 
+    expect(markup).toContain('data-editor-segment="text" data-editor-empty="true"')
+    expect(markup).toContain('<br data-editor-empty-break="true"/>')
     expect(markup).toContain('</div><span class="structured-mention-placeholder"')
+  })
+
+  it('renders model newlines as native line boxes with a trailing caret host', () => {
+    const markup = renderToStaticMarkup(createElement(StructuredMentionComposer, {
+      id: 'multiline-composer',
+      value: [{ kind: 'text', text: '前\n后\n' }],
+      members,
+      ariaLabel: '写消息',
+      onChange: () => undefined,
+      onSubmit: () => undefined
+    }))
+
+    expect(markup).toContain(
+      '前<br data-editor-line-break="true"/>后<br data-editor-line-break="true"/><span data-editor-caret-host="true">\u200B</span>'
+    )
   })
 
   it('renders repeated member occurrences and one all-members occurrence as atomic tokens', () => {
@@ -255,6 +273,33 @@ describe('StructuredMentionComposer', () => {
       isComposing: false,
       suggestionMenuOpen: false
     })).toBe(true)
+  })
+
+  it('reconciles only the composition generation that still owns the same idle editor', () => {
+    expect(shouldReconcileStructuredComposerComposition({
+      scheduledGeneration: 3,
+      currentGeneration: 3,
+      isComposing: false,
+      sameEditor: true
+    })).toBe(true)
+    expect(shouldReconcileStructuredComposerComposition({
+      scheduledGeneration: 3,
+      currentGeneration: 4,
+      isComposing: false,
+      sameEditor: true
+    })).toBe(false)
+    expect(shouldReconcileStructuredComposerComposition({
+      scheduledGeneration: 3,
+      currentGeneration: 3,
+      isComposing: true,
+      sameEditor: true
+    })).toBe(false)
+    expect(shouldReconcileStructuredComposerComposition({
+      scheduledGeneration: 3,
+      currentGeneration: 3,
+      isComposing: false,
+      sameEditor: false
+    })).toBe(false)
   })
 
   it('allows Enter to submit ordinary @ text when there is no selectable candidate', () => {

--- a/apps/desktop/src/renderer/src/StructuredMentionComposer.tsx
+++ b/apps/desktop/src/renderer/src/StructuredMentionComposer.tsx
@@ -14,6 +14,7 @@ import {
   type KeyboardEvent,
   type MouseEvent,
   type PointerEvent,
+  type ReactNode,
   type RefObject
 } from 'react'
 import {
@@ -242,6 +243,17 @@ export function shouldSubmitStructuredComposerOnEnter(input: {
     && !input.suggestionMenuOpen
 }
 
+export function shouldReconcileStructuredComposerComposition(input: {
+  scheduledGeneration: number
+  currentGeneration: number
+  isComposing: boolean
+  sameEditor: boolean
+}): boolean {
+  return input.scheduledGeneration === input.currentGeneration
+    && !input.isComposing
+    && input.sameEditor
+}
+
 export function shouldHandleStructuredComposerBackspaceAtStart(input: {
   key: string
   isComposing: boolean
@@ -279,6 +291,8 @@ const EDITOR_STYLE: CSSProperties = {
   cursor: 'text'
 }
 
+const EDITOR_CARET_SENTINEL = '\u200B'
+
 type StructuredComposerQuery =
   | { kind: 'mention'; value: StructuredMentionQuery }
   | { kind: 'skill'; value: StructuredSkillQuery }
@@ -308,6 +322,7 @@ export function StructuredMentionComposer({
   const lastSelectionRef = useRef<StructuredMentionSelection>({ anchor: 0, focus: 0 })
   const isComposingRef = useRef(false)
   const compositionFrameRef = useRef<number | null>(null)
+  const compositionGenerationRef = useRef(0)
   const [query, setQuery] = useState<StructuredComposerQuery | null>(null)
   const [activeOption, setActiveOption] = useState(0)
   const [editorDomRevision, setEditorDomRevision] = useState(0)
@@ -344,8 +359,10 @@ export function StructuredMentionComposer({
   }, [query?.kind, query?.value.query, query?.value.start])
 
   useEffect(() => () => {
+    compositionGenerationRef.current += 1
     if (compositionFrameRef.current !== null) {
       window.cancelAnimationFrame(compositionFrameRef.current)
+      compositionFrameRef.current = null
     }
   }, [])
 
@@ -391,12 +408,13 @@ export function StructuredMentionComposer({
     ) setQuery(null)
   }
 
-  const syncNativeDom = (nativeEvent?: InputEvent): void => {
+  const syncNativeDom = (nativeEvent?: InputEvent): StructuredMentionEditorState | null => {
     const editor = editorRef.current
-    if (!editor) return
+    if (!editor) return null
     const nextContent = readStructuredContent(editor)
     const nextSelection = readDomSelection(editor)
     const requiresOwnershipReset = !editorDomMatchesReactProjection(editor, content)
+    const contentChanged = !structuredContentEqual(content, nextContent)
     lastSelectionRef.current = nextSelection
     if (requiresOwnershipReset) {
       // IME and native contenteditable editing may wrap, replace, or insert
@@ -409,7 +427,7 @@ export function StructuredMentionComposer({
         || document.activeElement === editor
       setEditorDomRevision((current) => current + 1)
     }
-    if (!structuredContentEqual(content, nextContent)) {
+    if (contentChanged) {
       pendingSelectionRef.current = nextSelection
       onChange(nextContent)
     }
@@ -437,6 +455,16 @@ export function StructuredMentionComposer({
     } else if (nativeEvent) {
       setQuery(null)
     }
+    return { content: nextContent, selection: nextSelection }
+  }
+
+  const reconcilePendingComposition = (): StructuredMentionEditorState | null => {
+    const frame = compositionFrameRef.current
+    if (frame === null || isComposingRef.current) return null
+    window.cancelAnimationFrame(frame)
+    compositionFrameRef.current = null
+    compositionGenerationRef.current += 1
+    return syncNativeDom()
   }
 
   const chooseMentionOption = (option: StructuredMentionOption | undefined): void => {
@@ -465,11 +493,14 @@ export function StructuredMentionComposer({
     window.requestAnimationFrame(() => editorRef.current?.focus())
   }
 
-  const deleteFromKeyboard = (direction: 'backward' | 'forward'): void => {
-    const selection = currentSelection()
+  const deleteFromKeyboard = (
+    direction: 'backward' | 'forward',
+    state = editorState()
+  ): void => {
+    const selection = state.selection
     const next = direction === 'backward'
-      ? deleteStructuredBackward(editorState(selection))
-      : deleteStructuredForward(editorState(selection))
+      ? deleteStructuredBackward(state)
+      : deleteStructuredForward(state)
     setQuery((current) => {
       if (!current) return null
       const nextQuery = queryAfterDeletion(current.value, selection, direction)
@@ -535,6 +566,9 @@ export function StructuredMentionComposer({
       || event.nativeEvent.keyCode === 229
     if (isComposing) return
     if (document.activeElement !== event.currentTarget) return
+    const reconciledCompositionState = ['Enter', 'Backspace', 'Delete'].includes(event.key)
+      ? reconcilePendingComposition()
+      : null
 
     if (menuOpen && (event.key === 'ArrowDown' || event.key === 'ArrowUp')) {
       event.preventDefault()
@@ -565,7 +599,7 @@ export function StructuredMentionComposer({
       && shouldHandleStructuredComposerBackspaceAtStart({
         key: event.key,
         isComposing,
-        selection: currentSelection()
+        selection: reconciledCompositionState?.selection ?? currentSelection()
       })
     ) {
       event.preventDefault()
@@ -575,18 +609,18 @@ export function StructuredMentionComposer({
     }
     if (event.key === 'Backspace') {
       event.preventDefault()
-      deleteFromKeyboard('backward')
+      deleteFromKeyboard('backward', reconciledCompositionState ?? editorState())
       return
     }
     if (event.key === 'Delete') {
       event.preventDefault()
-      deleteFromKeyboard('forward')
+      deleteFromKeyboard('forward', reconciledCompositionState ?? editorState())
       return
     }
     if (event.key === 'Enter' && event.shiftKey) {
       event.preventDefault()
       setQuery(null)
-      emitState(insertStructuredText(editorState(), '\n'))
+      emitState(insertStructuredText(reconciledCompositionState ?? editorState(), '\n'))
       return
     }
     if (shouldSubmitStructuredComposerOnEnter({
@@ -627,16 +661,29 @@ export function StructuredMentionComposer({
 
   const handleCompositionStart = (_event: CompositionEvent<HTMLDivElement>): void => {
     isComposingRef.current = true
+    compositionGenerationRef.current += 1
+    if (compositionFrameRef.current !== null) {
+      window.cancelAnimationFrame(compositionFrameRef.current)
+      compositionFrameRef.current = null
+    }
     setQuery(null)
   }
 
-  const handleCompositionEnd = (_event: CompositionEvent<HTMLDivElement>): void => {
+  const handleCompositionEnd = (event: CompositionEvent<HTMLDivElement>): void => {
     isComposingRef.current = false
     if (compositionFrameRef.current !== null) {
       window.cancelAnimationFrame(compositionFrameRef.current)
     }
+    const scheduledGeneration = compositionGenerationRef.current
+    const scheduledEditor = event.currentTarget
     compositionFrameRef.current = window.requestAnimationFrame(() => {
       compositionFrameRef.current = null
+      if (!shouldReconcileStructuredComposerComposition({
+        scheduledGeneration,
+        currentGeneration: compositionGenerationRef.current,
+        isComposing: isComposingRef.current,
+        sameEditor: editorRef.current === scheduledEditor
+      })) return
       syncNativeDom()
     })
   }
@@ -694,11 +741,16 @@ export function StructuredMentionComposer({
         onMouseUp={(_event: MouseEvent<HTMLDivElement>) => closeQueryIfSelectionMoved()}
         onBlur={() => setQuery(null)}
       >
+        {content.length === 0 && (
+          <span data-editor-segment="text" data-editor-empty="true" key="text-0">
+            <br data-editor-empty-break="true" />
+          </span>
+        )}
         {content.map((segment, index) => {
           if (segment.kind === 'text') {
             return (
               <span data-editor-segment="text" key={`text-${index}`}>
-                {segment.text}
+                {renderEditorText(segment.text)}
               </span>
             )
           }
@@ -980,15 +1032,48 @@ function readStructuredContent(editor: HTMLDivElement): StructuredMentionContent
         }
         continue
       }
-      if (element.tagName === 'BR') {
-        content.push({ kind: 'text', text: '\n' })
+      if (element.dataset.editorSegment === 'text') {
+        const text = readEditorTextNode(element)
+        if (text) content.push({ kind: 'text', text })
         continue
       }
     }
-    const text = node.textContent ?? ''
+    const text = readEditorTextNode(node)
     if (text) content.push({ kind: 'text', text })
   }
   return normalizeStructuredMentionContent(content)
+}
+
+function renderEditorText(text: string): ReactNode[] {
+  const lines = text.split('\n')
+  const nodes: ReactNode[] = []
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+    if (line) nodes.push(line)
+    if (index < lines.length - 1) {
+      nodes.push(<br data-editor-line-break="true" key={`line-break-${index}`} />)
+    }
+  }
+  if (text.endsWith('\n')) {
+    nodes.push(
+      <span data-editor-caret-host="true" key="caret-host">
+        {EDITOR_CARET_SENTINEL}
+      </span>
+    )
+  }
+  return nodes
+}
+
+function readEditorTextNode(node: Node): string {
+  if (node.nodeType === Node.TEXT_NODE) return node.textContent ?? ''
+  if (node.nodeType === Node.ELEMENT_NODE) {
+    const element = node as HTMLElement
+    if (isEditorCaretHost(element)) return readEditorCaretHostText(element)
+    if (element.tagName === 'BR') {
+      return isEditorCaretBreak(element) ? '' : '\n'
+    }
+  }
+  return [...node.childNodes].map(readEditorTextNode).join('')
 }
 
 function editorDomMatchesReactProjection(
@@ -996,6 +1081,9 @@ function editorDomMatchesReactProjection(
   content: StructuredMentionContent
 ): boolean {
   const children = [...editor.childNodes]
+  if (content.length === 0) {
+    return children.length === 1 && isEditorTextSegment(children[0], true)
+  }
   if (children.length !== content.length) return false
   return children.every((node, index) => {
     if (node.nodeType !== Node.ELEMENT_NODE) return false
@@ -1003,8 +1091,7 @@ function editorDomMatchesReactProjection(
     const segment = content[index]
     if (!segment) return false
     if (segment.kind === 'text') {
-      return element.dataset.editorSegment === 'text'
-        && [...element.childNodes].every((child) => child.nodeType === Node.TEXT_NODE)
+      return isEditorTextSegment(element)
     }
     if (element.dataset.editorSegment !== 'token') return false
     if (segment.kind === 'all_members_mention') {
@@ -1018,6 +1105,18 @@ function editorDomMatchesReactProjection(
     return element.dataset.tokenKind === 'member_mention'
       && element.dataset.agentId === segment.agentId
   })
+}
+
+function isEditorTextSegment(node: Node | undefined, allowEmptyBreak = false): boolean {
+  return node?.nodeType === Node.ELEMENT_NODE
+    && (node as HTMLElement).dataset.editorSegment === 'text'
+    && [...node.childNodes].every((child) => child.nodeType === Node.TEXT_NODE
+      || (child.nodeType === Node.ELEMENT_NODE
+        && (isEditorCaretHost(child as HTMLElement)
+          || ((child as HTMLElement).tagName === 'BR'
+            && ((allowEmptyBreak && (child as HTMLElement).dataset.editorEmptyBreak === 'true')
+              || (child as HTMLElement).dataset.editorLineBreak === 'true'
+              || (child as HTMLElement).dataset.editorCaretBreak === 'true')))))
 }
 
 function readDomSelection(editor: HTMLDivElement): StructuredMentionSelection {
@@ -1082,7 +1181,7 @@ function domPointOffset(editor: HTMLDivElement, node: Node, offset: number): num
     const range = document.createRange()
     range.selectNodeContents(segment)
     range.setEnd(node, offset)
-    return start + range.toString().length
+    return start + editorTextNodeLength(range.cloneContents())
   } catch {
     return start
   }
@@ -1101,9 +1200,32 @@ function editorNodeLength(node: Node): number {
   if (node.nodeType === Node.ELEMENT_NODE) {
     const element = node as HTMLElement
     if (element.dataset.editorSegment === 'token') return 1
-    if (element.tagName === 'BR') return 1
   }
-  return node.textContent?.length ?? 0
+  return editorTextNodeLength(node)
+}
+
+function editorTextNodeLength(node: Node): number {
+  if (node.nodeType === Node.TEXT_NODE) return node.textContent?.length ?? 0
+  if (node.nodeType === Node.ELEMENT_NODE) {
+    const element = node as HTMLElement
+    if (isEditorCaretHost(element)) return readEditorCaretHostText(element).length
+    if (element.tagName === 'BR') return isEditorCaretBreak(element) ? 0 : 1
+  }
+  return [...node.childNodes]
+    .reduce((length, child) => length + editorTextNodeLength(child), 0)
+}
+
+function isEditorCaretBreak(element: HTMLElement): boolean {
+  return element.dataset.editorEmptyBreak === 'true'
+    || element.dataset.editorCaretBreak === 'true'
+}
+
+function isEditorCaretHost(element: HTMLElement): boolean {
+  return element.dataset.editorCaretHost === 'true'
+}
+
+function readEditorCaretHostText(element: HTMLElement): string {
+  return (element.textContent ?? '').replaceAll(EDITOR_CARET_SENTINEL, '')
 }
 
 function domPointAtOffset(editor: HTMLDivElement, targetOffset: number): { node: Node; offset: number } {
@@ -1130,16 +1252,22 @@ function textPointAtOffset(root: Node, targetOffset: number): { node: Node; offs
   if (root.nodeType === Node.TEXT_NODE) {
     return { node: root, offset: clamp(targetOffset, 0, root.textContent?.length ?? 0) }
   }
-  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
-  let remaining = targetOffset
-  let textNode = walker.nextNode()
-  while (textNode) {
-    const length = textNode.textContent?.length ?? 0
-    if (remaining <= length) return { node: textNode, offset: remaining }
-    remaining -= length
-    textNode = walker.nextNode()
+  const children = [...root.childNodes]
+  let cursor = 0
+  for (let index = 0; index < children.length; index += 1) {
+    const child = children[index]
+    const length = editorTextNodeLength(child)
+    if (child.nodeType === Node.ELEMENT_NODE && (child as HTMLElement).tagName === 'BR') {
+      if (targetOffset <= cursor) return { node: root, offset: index }
+      cursor += length
+      if (targetOffset <= cursor) return { node: root, offset: index + 1 }
+      continue
+    }
+    const end = cursor + length
+    if (targetOffset <= end) return textPointAtOffset(child, targetOffset - cursor)
+    cursor = end
   }
-  return { node: root, offset: 0 }
+  return { node: root, offset: children.length }
 }
 
 function closestEditorSegment(node: Node): HTMLElement | null {

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -2731,7 +2731,7 @@ details summary { min-height: 28px; padding: 5px 0; color: var(--muted); font-si
 .structured-mention-composer { width: 100%; min-height: 0; }
 .structured-mention-editor { display: block; width: 100%; min-height: 42px; max-height: min(180px, 26vh); overflow-x: hidden; overflow-y: auto; overscroll-behavior: contain; outline: 0; scrollbar-width: thin; }
 .structured-mention-editor:focus-visible { outline: 0; }
-.structured-mention-editor:not(:empty) + .structured-mention-placeholder { visibility: hidden; }
+.structured-mention-editor:not(:has(> [data-editor-empty="true"]:only-child > [data-editor-empty-break="true"]:only-child)) + .structured-mention-placeholder { visibility: hidden; }
 .composer-reply-region { display: grid; min-width: 0; gap: 4px; padding: 1px 0 2px; }
 .composer-reply-line {
   display: grid;

--- a/apps/desktop/src/renderer/src/theme-tokens.test.ts
+++ b/apps/desktop/src/renderer/src/theme-tokens.test.ts
@@ -284,7 +284,7 @@ describe('Porcelain Day + Steel Night theme tokens', () => {
     expect(css).toContain('.composer-box:focus-within')
     expect(css).toContain('.composer.suppress-pointer-focus-ring .composer-box:focus-within')
     expect(css).toMatch(/\.structured-mention-editor:focus-visible\s*\{[^}]*outline:\s*0/)
-    expect(css).toMatch(/\.structured-mention-editor:not\(:empty\) \+ \.structured-mention-placeholder\s*\{[^}]*visibility:\s*hidden/)
+    expect(css).toMatch(/\.structured-mention-editor:not\(:has\(> \[data-editor-empty="true"\]:only-child > \[data-editor-empty-break="true"\]:only-child\)\) \+ \.structured-mention-placeholder\s*\{[^}]*visibility:\s*hidden/)
     expect(css).not.toContain('.composer.suppress-reply-focus-ring')
     expect(css).toMatch(/\.composer-continuation\s*\{[^}]*background:\s*transparent|\.composer-continuation\s*\{[^}]*color:/)
     expect(css).toContain('--conversation-wide-width: 1040px;')

--- a/docs/postmortems/2026-08-26-composer-ime-trailing-newline-caret-host.md
+++ b/docs/postmortems/2026-08-26-composer-ime-trailing-newline-caret-host.md
@@ -1,0 +1,319 @@
+---
+document_type: postmortem
+incident_id: INC-2026-08-26-COMPOSER-IME-TRAILING-NEWLINE
+incident_date: 2026-08-26
+status: closed
+systems:
+  - desktop-composer
+  - structured-mention-editor
+  - contenteditable-dom-ownership
+  - macos-ime
+  - desktop-acceptance
+last_updated: 2026-08-27
+---
+
+# Camp Composer 行尾换行破坏中文输入法首字符组合
+
+> **爱丽丝的小结：** 这次最容易误导我们的证据恰好也是真的：旧的 IME 对账任务确实可能
+> 越过下一轮组合，空编辑器也确实可能失去 DOM 所有权，但它们都不是用户仍能复现的最后一根刺。
+> 真正的问题藏在一个看似普通的行尾 `\n` 里——模型已经换行，浏览器却没有给下一行一块能让
+> 光标和输入法共同站稳的地方。以后面对输入法缺陷，我们既要检查状态机，也必须让真实浏览器
+> 证明字符最终落在了哪里。
+
+## 摘要
+
+2026-08-26，用户报告 macOS Desktop 的 Camp Composer 在腾讯拼音下存在一组连续症状：输入
+`123213213` 后，第一次 `Shift+Enter` 看起来不换行，需要第二次才出现换行；无论换行前后，
+接下来输入的第一个拼音字母都不能正常进入中文组合，只表现为英文。截图中的系统候选条说明
+输入法仍参与了部分按键处理。
+
+最初调查发现两个真实缺陷：上一轮 `compositionend` 延迟到 `requestAnimationFrame` 的 DOM
+对账可能跨入下一轮 `compositionstart`；空 `contenteditable` 也没有稳定的 React 文本壳层。
+两项修复分别加入组合代次校验、取消过期 frame 和空编辑器 shell，完成测试、打包与安装后，
+用户仍然复现原症状。这证明最初修复处理了相邻风险，却没有覆盖用户的决定性触发条件。
+
+第三轮调查改用打包 Electron、真实 Chromium 原生输入和腾讯拼音事件链逐层缩小范围，最终确认：
+Composer 将模型中的换行直接渲染为 React 文本节点中的字面 `\n`。当这个 `\n` 位于正文末尾时，
+Chromium 没有建立稳定的末行光标盒。一次 `Shift+Enter` 已把 `123213213\n` 写入模型，但视觉和
+Accessibility tree 都无法可靠表现新行；下一次原生字符会被插入到终端 `\n` 之前，实际顺序变成
+`123213213n\n`。IME 的 marked text 因此不能稳定锚定到下一行，形成“第一次换行无效”和“首字母
+变英文”的同一条因果链。
+
+最终修复把模型换行渲染为原生 `<br data-editor-line-break>`，并在终端换行后增加一个不计入模型、
+可承载原生输入和 IME marked text 的零宽 caret host。浏览器先把字符写入该宿主，React 再把它
+安全收敛回结构化正文。组合代次防护继续保留，防止旧 frame 触碰下一轮 IME 会话。
+
+修复后的 Electron 回归得到 `123213213\nn`，字符位于 `<br>` 之后，编辑器实例和焦点均保持，
+没有 React DOM 异常。腾讯拼音真实键盘序列产生 `keyCode=229`、`isComposing=true` 和
+`compositionupdate("ni")`，并始终绑定在同一个下一行编辑器宿主。完整 80 个测试文件、560 项
+测试与 TypeScript 检查通过；daily macOS arm64 包完成签名、哈希和安装校验。
+
+本复盘不归咎个人。最初的状态机假设有截图、事件语义和真实代码缺陷支持；问题在于验证 seam
+只证明了“组合期不误处理按键”和“编辑器没有在合成中被旧 frame 重挂”，没有证明用户最在意的
+最终事实：一次换行后，真实 Chromium 和系统输入法会把第一个字符放到哪一行。
+
+## 事故元数据
+
+| 字段 | 值 |
+|---|---|
+| 发现方式 | 用户在真实 Camp、真实腾讯拼音下连续复现，并在两次安装修复后明确反馈“还是这样” |
+| 受影响路径 | Camp Composer、Structured Mention DOM 投影、光标映射、IME composition 与 Shift+Enter |
+| 触发条件 | 文本末尾插入模型换行，随后输入首个原生字符或开始中文组合 |
+| 用户可见症状 | Shift+Enter 看似要按两次；换行前后首个拼音字母表现为英文 |
+| 直接影响 | 中文消息编辑被打断，用户需要重复换行、删除英文首字母或重新开始输入 |
+| 数据完整性 | 未发现已发送 CampMessage 损坏；问题发生在发送前 Draft 与编辑器 DOM 同步阶段 |
+| 权限影响 | 无 |
+| 平台范围 | 在 macOS + 腾讯拼音 + Electron/Chromium 上确认；同类 contenteditable 终端换行风险不应假定只限该输入法 |
+| 事故状态 | 根因已修复并加入确定性 Electron 回归；跨系统输入法自动化继续跟踪 |
+
+## 分析范围与证据状态
+
+- 仓库：Rovai-ai；最初分析基线 `ab943c33bb1ee5fda5752e31ba461c19ef0734c9`。
+- 用户证据：原始症状描述、候选条截图、两次安装后再次复现的反馈。
+- 代码证据：`StructuredMentionComposer.tsx` 的 composition 生命周期、DOM/model 投影、逻辑选区
+  映射和 React ownership reset。
+- 自动化证据：`StructuredMentionComposer.test.ts` 的静态投影测试，以及
+  `accept-structured-mentions-ui.mjs --ime-newline-only` 的打包 Electron 回归。
+- 平台证据：Chromium DevTools Protocol 的原生 `Input.insertText`，以及 Computer Use 驱动的腾讯
+  拼音真实按键与 composition 事件记录。
+- 安装证据：`dist` 与 `/Applications/Rovai AI.app` 的 `app.asar` SHA-256 一致，arm64 和 deep
+  codesign 校验通过；运行中的旧进程没有被强行终止。
+- 限制：CI 不能稳定控制每台 macOS 主机的第三方输入法候选选择，因此系统输入法验证仍是受控
+  macOS 验收证据；确定性的字符落点由 Chromium 原生输入回归长期守护。
+
+## 关键结论与证据
+
+| 结论 | 状态 | 证据 | 限制或反证 |
+|---|---|---|---|
+| 一次 Shift+Enter 已写入模型换行 | 已确认 | 旧实现下 Draft 与序列化 DOM 均为 `123213213\n`，键盘事件被正确 `preventDefault` | Accessibility tree 没有可靠显示终端文本换行，因此用户看到“没换行” |
+| 终端字面 `\n` 不能作为稳定的下一行输入宿主 | 已确认 | 旧打包 App 中，原生输入后结果为 `123213213n\n`，编辑器仍聚焦且未先重挂 | 这不是业务模型顺序错误，而是 Chromium 对终端文本 LF 的原生插入位置 |
+| 第一次 Shift+Enter 与首字母英文是同一根因的连续表现 | 已确认 | 换行缺少末行光标盒，下一次 marked text/字符锚点回到 LF 之前；症状在每次末尾换行后重复 | 候选栏真实开启时，Enter/Shift+Enter 先归 IME 仍是正常平台行为 |
+| 旧 composition frame 是真实风险但不是最终根因 | 已确认 | `compositionend` 曾延迟一帧，旧 `compositionstart` 不取消它；代次修复后用户仍复现 | 代次防护仍有价值，不能因不是最终根因而回滚 |
+| 空编辑器 shell 是真实 ownership 风险但不足以解决本症状 | 已确认 | 空 DOM 原生输入可改变 React 子树；稳定 shell 修复后，数字末尾换行仍复现 | 用户能正常输入数字，决定性失败发生在终端换行后的下一个输入 |
+| 使用第二个 React-owned caret `<br>` 会引入删除冲突 | 已确认 | 浏览器输入时移除 caret `<br>`；React 随后再次删除它，触发 `NotFoundError: removeChild`，并短暂产生重复 `n` | 因此不能只把一个文本 LF 机械替换成两个由 React 管理的 BR |
+| 零宽 caret host 同时满足行框和 DOM 所有权边界 | 已确认 | 浏览器把 `n`/marked text 写入 host 而不移除宿主；模型读取忽略 sentinel、保留真实字符，React 安全收敛 | host 必须在长度、序列化、选区和 placeholder 逻辑中都按零长度处理 |
+| 修复后腾讯拼音从下一行开始真实 composition | 已确认 | `n/i` 事件为 `keyCode=229`、`isComposing=true`、`compositionupdate("ni")`；editor identity 始终为 1 | 候选最终选择受输入法状态影响，不作为确定性 CI 断言 |
+
+## 影响
+
+本次缺陷没有损坏已发送消息，也没有导致误发送。Composer 在 `isComposing` 时继续把 Enter、
+Shift+Enter 和候选控制权交给 IME，因此现有安全边界避免了“选字时发送消息”这一更严重后果。
+
+用户仍承受了明显的编辑成本：
+
+- 第一次 Shift+Enter 已改变 Draft，但没有提供可信的视觉换行反馈；
+- 第二次 Shift+Enter 才产生可见空行，使用户形成“必须按两次”的稳定认知；
+- 下一次拼音的第一个字符落在错误的逻辑/视觉位置，输入法组合被打断或以拉丁字母提交；
+- 问题在换行前后重复，让用户无法通过调整输入顺序稳定规避；
+- 两次“已修复并安装”后仍复现，降低了用户对验收结论的信任，也增加了重复退出和重启成本。
+
+## 发现与响应
+
+用户首先提供了三个可观察症状和截图。调查从 IME 状态机入手，因为第一次 Shift+Enter 时出现候选条，
+而代码也确实在 `compositionend` 后延迟执行 `syncNativeDom()`。第一轮修复为 composition reconciliation
+增加 generation、editor identity 和当前 `isComposing` 校验；第二轮补上空编辑器文本 shell，避免第一个
+原生输入替换无主 DOM。两轮都通过当时的单元测试、类型检查、打包和安装验证。
+
+用户两次反馈“还是这样”后，调查不再把三个症状拆成独立按键问题，也不再以 synthetic composition
+作为完成证据。新的最小反馈循环固定为：
+
+```text
+真实打包 Electron
+  -> 清空 Composer
+  -> 原生输入 123213213
+  -> 一次 Shift+Enter
+  -> 原生输入 n
+  -> 同时读取 DOM、Draft、焦点和 editor identity
+```
+
+旧实现稳定得到 `123213213n\n`。这排除了“安装包仍旧”“Shift+Enter handler 没运行”和“必须先发生
+host remount”等假设。随后用三个隔离 contenteditable 原型比较终端文本 LF、单个 BR、逻辑 BR +
+caret BR，确认行框能修正插入方向，但 React-owned caret BR 会被浏览器删除并造成 ownership crash。
+把 caret 宿主改成保留 DOM 身份的零宽 span 后，同一回归转绿。
+
+最后使用真实腾讯拼音执行数字、一次 Shift+Enter、`n`、`i`。事件流证明组合从 `<br>` 后的 caret host
+开始，旧 editor 始终存活。完成完整测试、daily package、签名/哈希校验和非终止安装后，才形成最终结论。
+
+## 时间线
+
+用户反馈与调查发生在 2026-08-26（Asia/Shanghai）。除构建和事件日志外，用户每次反馈的精确时间
+没有作为结构化事故事件持久化，因此下表保持阶段顺序，不补造分钟级时间。
+
+| 阶段 | 事件 |
+|---|---|
+| 初始报告 | 用户输入 `123213213` 后观察到 Shift+Enter 需两次、首拼音字母变英文，并提供候选条截图。 |
+| 第一轮调查 | 定位 `compositionend -> requestAnimationFrame(syncNativeDom)` 可跨下一轮 composition；加入取消与 generation 防护。 |
+| 第一次安装后 | 用户反馈“还是这样”，证明 stale frame 不是完整解释。 |
+| 第二轮调查 | 补充空编辑器稳定 shell、原生首字符和 composition ownership 验收。 |
+| 第二次安装后 | 用户再次反馈“还是这样”，触发重新定义最小反馈循环。 |
+| 决定性红测 | 旧打包 App 一次换行后，原生 `n` 得到 `123213213n\n`；字符位于终端 LF 之前。 |
+| 原型验证 | 原生 line box 修正落点；React-owned caret BR 被浏览器移除并触发 `removeChild` 冲突。 |
+| 最终修复 | 使用逻辑 `<br>` + 零宽 caret host；更新 DOM 读取、长度、选区、placeholder 与 ownership 判断。 |
+| 最终验收 | Electron 红测转绿；腾讯拼音产生真实 composition；560 项测试、类型检查、打包与安装门禁通过。 |
+
+## 技术根因
+
+### 模型换行被错误等同于浏览器行框
+
+结构化正文以字符串 `\n` 表示换行，这是合理的领域模型。但旧 Renderer 直接把整个
+`segment.text` 放入 React 文本节点，并依赖 `white-space: pre-wrap` 显示换行。这个策略对中间换行
+通常可见，却没有保证终端换行后存在可容纳 caret 和 IME marked text 的 DOM 位置。
+
+旧投影近似为：
+
+```html
+<span data-editor-segment="text">123213213\n</span>
+```
+
+逻辑选区可以声称位于 offset 10，Draft 也可以保存 `\n`，但 Chromium 的原生编辑算法仍要在 DOM
+节点边界选择插入点。终端文本 LF 没有独立节点和末行 host，下一字符最终写到 LF 之前。
+
+修复后的投影为：
+
+```html
+<span data-editor-segment="text">
+  123213213
+  <br data-editor-line-break="true">
+  <span data-editor-caret-host="true">&#x200B;</span>
+</span>
+```
+
+`<br>` 拥有一个逻辑字符长度；caret host 和 sentinel 长度为零。浏览器可以在下一行把原生输入写进
+host，`readStructuredContent()` 会去掉 sentinel、保留真实字符，再由 React 投影为普通文本。
+
+### DOM 所有权需要同时满足浏览器和 React
+
+第一次原型修复使用第二个 caret `<br>` 来撑起末行。它解决了插入方向，却违反了另一条边界：
+浏览器输入时会删除这个占位 BR，React 的旧 Fiber 仍认为它存在。下一次 commit 尝试再次删除同一节点，
+触发 `NotFoundError`，整个 Renderer root 可能清空。
+
+零宽 span 的关键不是视觉技巧，而是所有权协议：浏览器修改宿主内部文本，却保留 React-owned 宿主
+本身；React 随后可以安全删除或替换仍在父节点下的宿主。`editorDomMatchesReactProjection()` 也把
+caret host 视为可接受的 native mutation seam，而不是立即重挂整个 contenteditable。
+
+### IME 状态机缺陷放大了现象，但不是字符落点根因
+
+旧 `compositionend` frame 确实可能晚于下一轮 `compositionstart` 执行。若 DOM 不匹配，它会重挂 editor、
+恢复焦点和选区，进一步打断 IME。修复后的 frame 携带 generation 和 editor identity，新 composition
+会取消旧 frame，回调也会再次检查当前是否仍在组合。
+
+这项修复是必要防护，但用户的决定性红测不需要发生跨代 frame：单凭终端 LF 和下一次 Chromium 原生
+输入就能失败。因此 postmortem 将它归类为促成因素和独立缺陷，不把它继续称为最终根因。
+
+## 促成因素
+
+### 截图和真实代码缺陷共同强化了过早假设
+
+候选条说明 IME 正在处理第一次 Shift+Enter；代码又存在明显的 stale frame 窗口。两项证据使“编辑器
+在 composition 边界被重挂”成为高概率假设。这个假设值得修，但我们过早把“高概率且真实”升级成了
+“已经解释全部症状”。
+
+### 单元测试 seam 无法观察浏览器原生插入位置
+
+原有 `StructuredMentionComposer.test.ts` 主要使用 `renderToStaticMarkup` 和纯函数测试。它能证明静态
+结构、提交判断与 query 算法，不能挂载真实 contenteditable，也不能让 Chromium 决定字符插在终端 LF
+的哪一侧。
+
+### synthetic composition 证明了事件分支，没有证明平台行为
+
+早期 Electron 验收通过手工 dispatch `compositionstart/input/compositionend` 修改 DOM。它能覆盖 stale
+frame 和 ownership reset，却预先决定了 DOM 结果，因此绕过了浏览器最关键的 native editing algorithm。
+
+### “打包成功”与“症状闭环”被混为同一层证据
+
+类型检查、单测、签名、哈希和安装路径都正确证明新包被构建并安装；它们不证明新包修复了用户症状。
+安装证据曾帮助排除“用户仍运行旧磁盘包”，但不能替代原始复现转绿。
+
+### 第一次换行的视觉反馈与模型事实不一致
+
+Draft 已包含换行，而 Accessibility tree 和可见末行没有稳定反馈。若只读取模型，会误判 Shift+Enter
+已经完全正确；若只看截图，又会误判 handler 根本没有运行。必须同时观察模型、DOM 行框和原生插入点。
+
+## 既有防护为何没有阻止事故
+
+- `isComposing` 防护正确避免候选期间误换行或误发送，但不负责创建末行 caret box。
+- `white-space: pre-wrap` 能显示多数文本换行，但不为 contenteditable 的终端 LF 提供可编辑 DOM 语义。
+- ownership reset 能在浏览器包装或插入未知节点后重建 host，却不能安全处理已经被浏览器删除的
+  React-owned descendant。
+- 静态 Renderer 测试验证了字符串投影，却没有断言换行必须由原生 line box 表示。
+- Electron 验收覆盖了 mention、selection、clipboard、reply 与 synthetic IME，没有“终端换行后下一次
+  原生输入”的纵向切片。
+- 打包和安装门禁验证了产物真实性，没有也不应该推断交互缺陷已修复。
+
+## 不属于根因的事项
+
+- 不是用户需要按两次 Shift+Enter 的产品设计；无真实 composition 时，一次按键应产生一个换行。
+- 不是候选栏开启时 Composer 应抢走 Shift+Enter；组合期间按键继续归 IME。
+- 不是 Draft 丢失第一次换行；旧实现已经持久化 `\n`，缺口在 DOM 行框和下一次输入落点。
+- 不是旧安装包没有覆盖。最终调查前已比对运行路径、包体哈希和安装时间；决定性红测也直接在指定
+  打包 App 上复现。
+- 不是 Mention/Skill token 原子性本身破坏中文输入；本次最小复现只包含纯文本数字。
+- 不是腾讯拼音单独违反事件规范；Chromium 原生输入在不经过第三方候选选择时也能确定性复现错误顺序。
+
+## 解决与恢复
+
+本次完成以下修复：
+
+1. 使用原生 `<br data-editor-line-break>` 投影模型换行。
+2. 为终端换行增加零宽 `data-editor-caret-host`，并从结构化正文、逻辑长度和序列化中排除 sentinel。
+3. 更新 DOM selection offset/point 映射，让 BR 计为一个逻辑字符、caret host 计为零。
+4. 让 native input 写入 caret host 后安全收敛为结构化文本，并保持 editor identity 与焦点。
+5. 为 composition reconciliation 增加 generation、editor identity 和当前组合状态门禁；新 composition
+   取消上一轮 frame。
+6. 为真正空内容渲染稳定 shell，并更新 placeholder CSS，不再用 `:empty` 推断业务空状态。
+7. 新增 `--ime-newline-only` Electron 验收：一次 Shift+Enter 后执行 Chromium 原生输入，断言 DOM、
+   Draft、editor identity、focus 与错误集合。
+8. 使用真实腾讯拼音复跑原步骤，确认下一行从第一字母开始进入 composition。
+9. 完成 560 项测试、TypeScript 检查、daily macOS arm64 打包、签名/哈希验证和非终止安装。
+
+## 纠正措施
+
+状态反映本复盘发布时可用的证据。开放事项需要映射到当前维护计划；本复盘本身不创造新的产品合同。
+
+| ID | 措施 | 责任角色 | 优先级 | 状态 | 证据或目标 |
+|---|---|---|---|---|---|
+| CIME-01 | 用原生 line break + 零宽 caret host 修复终端换行输入落点 | Camp Renderer | P0 | 已完成 | `renderEditorText`、DOM 读取与逻辑选区实现 |
+| CIME-02 | 阻止 stale composition frame 跨入下一轮 IME 会话 | Camp Renderer | P0 | 已完成 | generation/editor/isComposing 门禁及单测 |
+| CIME-03 | 增加打包 Electron 的终端换行原生输入红绿回归 | Desktop Acceptance | P0 | 已完成 | `--ime-newline-only` 在旧包红、修复包绿 |
+| CIME-04 | 把“同一 editor、焦点保持、DOM 顺序、Draft 顺序、无 Renderer error”作为一个验收断言组 | Desktop Acceptance | P1 | 已完成 | `acceptImeNewlineRegression` |
+| CIME-05 | 为受支持 macOS 输入法维护人工验收矩阵：纯文本、数字、连续换行、token 两侧、候选提交与取消 | Desktop QA | P1 | 已计划 | 测试文档与发布前清单 |
+| CIME-06 | 评估可重复控制系统输入法的 macOS 专用自动化 runner，不把 synthetic composition 当作替代品 | Desktop QA | P2 | 已计划 | Probe 需记录 OS、输入法版本和候选状态边界 |
+| CIME-07 | 为 contenteditable 变更评审增加 DOM 所有权检查：浏览器可能删除哪些 React-owned 节点 | Frontend Architecture | P1 | 已计划 | Renderer review checklist |
+| CIME-08 | 在交互修复交付模板中区分 build/install 证据与原始用户症状转绿证据 | Engineering Process | P1 | 已计划 | PR 模板或开发指南后续改动 |
+
+## 复发判据
+
+出现以下任一情况即视为本事故复发：
+
+- 没有真实 composition 时，一次 Shift+Enter 不能产生且只产生一个可见换行；
+- 模型以换行结尾时，下一个原生字符落到该换行之前；
+- 数字、英文、换行或结构化 token 之后的第一个拼音键未进入系统 IME composition；
+- 浏览器输入会删除 React-owned caret 节点并引发 `removeChild`、重复字符或空白 Renderer root；
+- composition 期间 editor 被旧 frame 重挂、失焦或恢复到上一轮选区；
+- DOM、Draft 与可见正文对一次 composition commit 的计数不一致；或
+- 回归只 dispatch synthetic composition，而没有经过 Chromium 原生输入路径。
+
+候选栏真实开启时，第一次 Enter/Shift+Enter 被输入法用于确认候选本身不是复发；复发条件是 Composer
+在没有真实 composition 时仍需要第二次换行，或应用破坏了下一轮组合宿主。
+
+## 经验
+
+输入法缺陷至少跨越三种所有权：领域模型拥有逻辑正文，React 拥有声明式节点，浏览器和 IME 在组合期
+共同拥有可见 DOM 与 marked text。三者的字符串内容相同，不代表它们拥有相同的光标语义。
+
+调试这类问题时，“状态机正确”与“字符落点正确”必须分别证明。事件日志可以告诉我们按键属于谁，
+只有真实浏览器原生输入才能告诉我们字符最终站在哪里。最小反馈循环应从用户可见结果倒推：一次换行、
+一个首字符、一个 editor identity、一个 Draft 顺序。任何没有覆盖这四项的绿测，都不足以关闭同类事故。
+
+两次失败修复也提供了重要边界：修掉调查中发现的真实 bug 并不等于修掉报告中的 bug。每当用户说
+“还是这样”，应立即把原始症状重新设为唯一终止条件，保留已证实的旁支修复，但撤销对根因已经闭合的
+假设。
+
+## 参考资料
+
+- [Structured Mention Composer 实现](../../apps/desktop/src/renderer/src/StructuredMentionComposer.tsx)
+- [Structured Mention Composer 单元测试](../../apps/desktop/src/renderer/src/StructuredMentionComposer.test.ts)
+- [Structured Mention Electron UI 验收](../../scripts/accept-structured-mentions-ui.mjs)
+- [Composer 样式与 placeholder 业务空状态](../../apps/desktop/src/renderer/src/styles.css)
+- [桌面 UI 验收指南](../development/ui-acceptance.md)
+- [本地开发与 App 隔离流程](../development/local-workflow.md)

--- a/docs/postmortems/README.md
+++ b/docs/postmortems/README.md
@@ -1,7 +1,7 @@
 ---
 document_type: postmortem-index
 authority: incident-history
-last_updated: 2026-08-26
+last_updated: 2026-08-27
 ---
 
 # 事故复盘
@@ -40,3 +40,4 @@ last_updated: 2026-08-26
 | 2026-08-25 | [Codex 命令输出增量放大阻断 Camp 打开与恢复](2026-08-25-codex-command-output-delta-camp-open-amplification.md) | 已关闭；继续跟踪后续措施 |
 | 2026-08-26 | [Windows Codex Runtime 发现与验收隔离缺口](2026-08-26-windows-codex-runtime-discovery-and-acceptance-isolation.md) | 已关闭；继续跟踪后续措施 |
 | 2026-08-26 | [Gather 完成投递缺少公开因果展示，导致 A2A 调度误判](2026-08-26-gather-completion-causal-handoff-not-visible.md) | 事实调查已关闭；展示改进待跟踪 |
+| 2026-08-26 | [Camp Composer 行尾换行破坏中文输入法首字符组合](2026-08-26-composer-ime-trailing-newline-caret-host.md) | 已关闭；继续跟踪自动化覆盖 |

--- a/scripts/accept-structured-mentions-ui.mjs
+++ b/scripts/accept-structured-mentions-ui.mjs
@@ -38,6 +38,7 @@ const acceptanceHome = join(fixtureRoot, 'home')
 const debugPort = Number(process.env.ROVAI_STRUCTURED_MENTIONS_ACCEPT_DEBUG_PORT ?? 9491)
 const skillPickerOnly = cliArguments.includes('--skill-picker-only')
 const skillContextSmoke = cliArguments.includes('--skill-context-smoke')
+const imeNewlineOnly = cliArguments.includes('--ime-newline-only')
 const continuationOnly = cliArguments.includes('--continuation-only')
 const replyBackspaceOnly = cliArguments.includes('--reply-backspace-only')
 const databasePath = join(dataDir, 'rovai.sqlite')
@@ -133,6 +134,7 @@ let cleanupFailure = null
 let result = null
 
 try {
+  acceptance: {
   // Clipboard mutation is forbidden unless the complete macOS Pasteboard can be
   // archived first. The archive includes every item, flavor, and byte payload.
   clipboardArchive = await snapshotClipboard()
@@ -222,6 +224,19 @@ try {
   await waitForSelector(running.cdp, '#camp-message.structured-mention-editor')
   await waitForExpression(running.cdp,
     `document.querySelector('#camp-message')?.getAttribute('contenteditable') === 'true'`)
+  if (imeNewlineOnly) {
+    const imeNewlineInspection = await acceptImeNewlineRegression(running.cdp, campId)
+    result = {
+      acceptance: 'composer-ime-newline-ui',
+      appPath,
+      campId,
+      ...imeNewlineInspection,
+      clipboardItemCountBeforeTest: clipboardArchive.length,
+      clipboardRestored: false,
+      isolatedUserDataRemoved: false
+    }
+    break acceptance
+  }
   await focusEditorAtEnd(running.cdp)
   await running.cdp.send('Input.insertText', { text: '/' })
   await waitForExpression(running.cdp, `(() => {
@@ -698,6 +713,115 @@ try {
   await waitForValue(async () => request(running.cdp, 'camp.composerDraft.get', { campId }),
     (draft) => deepEqual(draft.content, []), 10_000)
 
+  // The first native character in an empty editor must stay inside the same
+  // contenteditable host. Remounting here resets the platform IME context, so
+  // the first Pinyin key after plain text can escape as a Latin character.
+  await evaluate(running.cdp, `(() => {
+    const editor = document.querySelector('#camp-message')
+    if (!(editor instanceof HTMLDivElement)) return false
+    window.__structuredMentionFirstInputEditor = editor
+    editor.focus()
+    const selection = window.getSelection()
+    const range = document.createRange()
+    range.selectNodeContents(editor)
+    range.collapse(false)
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+    return true
+  })()`)
+  await running.cdp.send('Input.insertText', { text: '1' })
+  await waitForExpression(running.cdp,
+    `document.querySelector('#camp-message')?.textContent === '1'`)
+  await evaluate(running.cdp,
+    `new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))`, true)
+  const firstNativeInputInspection = await evaluate(running.cdp, `(() => {
+    const editor = document.querySelector('#camp-message')
+    const selection = window.getSelection()
+    if (!(editor instanceof HTMLDivElement) || !selection?.anchorNode) return null
+    const beforeCaret = document.createRange()
+    beforeCaret.selectNodeContents(editor)
+    beforeCaret.setEnd(selection.anchorNode, selection.anchorOffset)
+    return {
+      stayedMounted: editor === window.__structuredMentionFirstInputEditor,
+      stayedFocused: document.activeElement === editor,
+      text: editor.textContent,
+      textSegmentCount: editor.querySelectorAll(':scope > [data-editor-segment="text"]').length,
+      caretOffset: beforeCaret.toString().length
+    }
+  })()`)
+  assert(
+    firstNativeInputInspection?.stayedMounted
+      && firstNativeInputInspection.stayedFocused
+      && firstNativeInputInspection.text === '1'
+      && firstNativeInputInspection.textSegmentCount === 1
+      && firstNativeInputInspection.caretOffset === 1,
+    `The first native character reset the IME editor host: ${JSON.stringify(firstNativeInputInspection)}`
+  )
+  await selectWholeEditor(running.cdp)
+  await pressKey(running.cdp, {
+    key: 'Backspace', code: 'Backspace', windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 51
+  })
+  await waitForValue(async () => request(running.cdp, 'camp.composerDraft.get', { campId }),
+    (draft) => deepEqual(draft.content, []), 10_000)
+
+  const firstNativeCompositionInspection = await evaluate(running.cdp, `(async () => {
+    const editor = document.querySelector('#camp-message')
+    const segment = editor?.querySelector(':scope > [data-editor-segment="text"]')
+    if (!(editor instanceof HTMLDivElement) || !(segment instanceof HTMLElement)) return null
+    editor.focus()
+    const selection = window.getSelection()
+    const initialRange = document.createRange()
+    initialRange.setStart(segment, 0)
+    initialRange.collapse(true)
+    selection?.removeAllRanges()
+    selection?.addRange(initialRange)
+    editor.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true, data: '' }))
+    const text = document.createTextNode('你')
+    segment.replaceChildren(text)
+    const committedRange = document.createRange()
+    committedRange.setStart(text, text.data.length)
+    committedRange.collapse(true)
+    selection?.removeAllRanges()
+    selection?.addRange(committedRange)
+    editor.dispatchEvent(new InputEvent('input', {
+      bubbles: true,
+      inputType: 'insertCompositionText',
+      data: '你',
+      isComposing: true
+    }))
+    editor.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: '你' }))
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+    const reconciledEditor = document.querySelector('#camp-message')
+    const reconciledSelection = window.getSelection()
+    if (!(reconciledEditor instanceof HTMLDivElement) || !reconciledSelection?.anchorNode) return null
+    const beforeCaret = document.createRange()
+    beforeCaret.selectNodeContents(reconciledEditor)
+    beforeCaret.setEnd(reconciledSelection.anchorNode, reconciledSelection.anchorOffset)
+    return {
+      stayedMounted: reconciledEditor === editor,
+      stayedFocused: document.activeElement === reconciledEditor,
+      text: reconciledEditor.textContent,
+      caretOffset: beforeCaret.toString().length
+    }
+  })()`, true)
+  assert(
+    firstNativeCompositionInspection?.stayedMounted
+      && firstNativeCompositionInspection.stayedFocused
+      && firstNativeCompositionInspection.text === '你'
+      && firstNativeCompositionInspection.caretOffset === 1,
+    `The first IME composition reset the editor host: ${JSON.stringify(firstNativeCompositionInspection)}`
+  )
+  await waitForValue(async () => request(running.cdp, 'camp.composerDraft.get', { campId }),
+    (draft) => deepEqual(draft.content, [{ kind: 'text', text: '你' }]), 10_000)
+  await selectWholeEditor(running.cdp)
+  await pressKey(running.cdp, {
+    key: 'Backspace', code: 'Backspace', windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 51
+  })
+  await waitForValue(async () => request(running.cdp, 'camp.composerDraft.get', { campId }),
+    (draft) => deepEqual(draft.content, []), 10_000)
+
+  await acceptImeNewlineRegression(running.cdp, campId)
+
   // A native contenteditable/IME edit may wrap a React-owned segment. The
   // Composer must replace the editor host instead of imperatively removing the
   // wrapper, otherwise the next controlled clear crashes React in removeChild
@@ -769,6 +893,117 @@ try {
   assert(!nativeOwnershipErrors.some((error) =>
     `${error.message}\n${error.error}`.includes('removeChild')),
     `Native DOM ownership still crashed React: ${JSON.stringify(nativeOwnershipErrors)}`)
+
+  // A completed composition is reconciled on the next animation frame. A new
+  // composition that starts first must cancel that old reconciliation instead
+  // of letting it remount the editor underneath the new IME session.
+  const overlappingCompositionInspection = await evaluate(running.cdp, `(async () => {
+    const editor = document.querySelector('#camp-message')
+    if (!(editor instanceof HTMLDivElement)) return null
+    editor.focus()
+    editor.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true, data: '' }))
+    const text = document.createTextNode('首')
+    editor.replaceChildren(text)
+    const range = document.createRange()
+    range.setStart(text, text.data.length)
+    range.collapse(true)
+    const selection = window.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+    editor.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: '首' }))
+    editor.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true, data: '' }))
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+    const stayedMountedDuringNextComposition = document.querySelector('#camp-message') === editor
+    const stayedFocusedDuringNextComposition = document.activeElement === editor
+    editor.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: '首' }))
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+    const reconciledEditor = document.querySelector('#camp-message')
+    return {
+      stayedMountedDuringNextComposition,
+      stayedFocusedDuringNextComposition,
+      reconciledAfterNextComposition: reconciledEditor !== editor,
+      reconciledText: reconciledEditor?.textContent ?? null,
+      focusedAfterReconciliation: document.activeElement === reconciledEditor
+    }
+  })()`, true)
+  assert(
+    overlappingCompositionInspection?.stayedMountedDuringNextComposition
+      && overlappingCompositionInspection.stayedFocusedDuringNextComposition
+      && overlappingCompositionInspection.reconciledAfterNextComposition
+      && overlappingCompositionInspection.reconciledText === '首'
+      && overlappingCompositionInspection.focusedAfterReconciliation,
+    `A stale composition frame crossed into the next IME session: ${JSON.stringify(overlappingCompositionInspection)}`
+  )
+  await waitForValue(async () => request(running.cdp, 'camp.composerDraft.get', { campId }),
+    (draft) => deepEqual(draft.content, [{ kind: 'text', text: '首' }]), 10_000)
+  await selectWholeEditor(running.cdp)
+  await pressKey(running.cdp, {
+    key: 'Backspace', code: 'Backspace', windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 51
+  })
+  await waitForValue(async () => request(running.cdp, 'camp.composerDraft.get', { campId }),
+    (draft) => deepEqual(draft.content, []), 10_000)
+
+  // If Shift+Enter arrives after compositionend but before its frame, settle
+  // the committed DOM first and apply exactly one newline to that fresh state.
+  const pendingCompositionShortcutInspection = await evaluate(running.cdp, `(async () => {
+    const editor = document.querySelector('#camp-message')
+    if (!(editor instanceof HTMLDivElement)) return null
+    editor.focus()
+    editor.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true, data: '' }))
+    const text = document.createTextNode('123213213')
+    editor.replaceChildren(text)
+    const range = document.createRange()
+    range.setStart(text, text.data.length)
+    range.collapse(true)
+    const selection = window.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+    editor.dispatchEvent(new CompositionEvent('compositionend', {
+      bubbles: true,
+      data: '123213213'
+    }))
+    const shortcut = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'Enter',
+      code: 'Enter',
+      shiftKey: true
+    })
+    editor.dispatchEvent(shortcut)
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+    const reconciledEditor = document.querySelector('#camp-message')
+    const readDomText = (node) => {
+      if (node.nodeType === Node.TEXT_NODE) return node.textContent ?? ''
+      if (!(node instanceof HTMLElement)) return ''
+      if (node.dataset.editorCaretHost === 'true') {
+        return (node.textContent ?? '').replaceAll('\\u200B', '')
+      }
+      if (node.tagName === 'BR') {
+        return node.dataset.editorCaretBreak === 'true'
+          || node.dataset.editorEmptyBreak === 'true' ? '' : '\\n'
+      }
+      return [...node.childNodes].map(readDomText).join('')
+    }
+    return {
+      defaultPrevented: shortcut.defaultPrevented,
+      text: reconciledEditor ? readDomText(reconciledEditor) : null,
+      focused: document.activeElement === reconciledEditor
+    }
+  })()`, true)
+  assert(
+    pendingCompositionShortcutInspection?.defaultPrevented
+      && pendingCompositionShortcutInspection.text === '123213213\n'
+      && pendingCompositionShortcutInspection.focused,
+    `Shift+Enter did not settle pending IME text before adding one newline: ${JSON.stringify(pendingCompositionShortcutInspection)}`
+  )
+  await waitForValue(async () => request(running.cdp, 'camp.composerDraft.get', { campId }),
+    (draft) => deepEqual(draft.content, [{ kind: 'text', text: '123213213\n' }]), 10_000)
+  await selectWholeEditor(running.cdp)
+  await pressKey(running.cdp, {
+    key: 'Backspace', code: 'Backspace', windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 51
+  })
+  await waitForValue(async () => request(running.cdp, 'camp.composerDraft.get', { campId }),
+    (draft) => deepEqual(draft.content, []), 10_000)
 
   await focusEditorAtEnd(running.cdp)
   await running.cdp.send('Input.insertText', { text: expectedContent[0].text })
@@ -1650,6 +1885,7 @@ try {
     isolatedUserDataRemoved: false
   }
   }
+  }
 } catch (error) {
   testFailure = error
 } finally {
@@ -1782,6 +2018,9 @@ async function removeDirectoryWithRetry(path) {
 async function launchApp(userDataDir, port, width, height) {
   const stderr = []
   const child = spawn(join(appPath, 'Contents', 'MacOS', 'Rovai AI'), [
+    ...(process.env.ROVAI_STRUCTURED_MENTIONS_ACCEPT_DISABLE_SANDBOX === '1'
+      ? ['--no-sandbox']
+      : []),
     `--remote-debugging-port=${port}`,
     `--user-data-dir=${userDataDir}`
   ], {
@@ -1881,6 +2120,135 @@ async function openCamp(cdp, campId) {
   })()`)
   assert(opened, `Could not open Camp ${campId}`)
   await waitForSelector(cdp, '.camp-workspace', 30_000)
+}
+
+async function acceptImeNewlineRegression(cdp, campId) {
+  await selectWholeEditor(cdp)
+  await pressKey(cdp, {
+    key: 'Backspace', code: 'Backspace', windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 51
+  })
+  await waitForValue(async () => request(cdp, 'camp.composerDraft.get', { campId }),
+    (draft) => deepEqual(draft.content, []), 10_000)
+
+  // A trailing model newline must have a real DOM line box. Chromium inserts
+  // the next native character before a terminal LF text character, which makes
+  // one Shift+Enter appear ineffective and breaks the next IME composition.
+  await focusEditorAtEnd(cdp)
+  await cdp.send('Input.insertText', { text: '123213213' })
+  await waitForValue(async () => request(cdp, 'camp.composerDraft.get', { campId }),
+    (draft) => deepEqual(draft.content, [{ kind: 'text', text: '123213213' }]), 10_000)
+  const trailingNewlineInspection = await evaluate(cdp, `(async () => {
+    const editor = document.querySelector('#camp-message')
+    if (!(editor instanceof HTMLDivElement)) return null
+    const shortcut = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'Enter',
+      code: 'Enter',
+      shiftKey: true
+    })
+    editor.dispatchEvent(shortcut)
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+    const reconciledEditor = document.querySelector('#camp-message')
+    window.__structuredMentionPostNewlineEditor = reconciledEditor
+    window.__structuredMentionImeErrors = []
+    window.__structuredMentionImeInputEvents = []
+    window.addEventListener('error', (event) => {
+      window.__structuredMentionImeErrors.push({
+        message: event.message,
+        error: event.error instanceof Error ? event.error.stack : null
+      })
+    })
+    for (const type of ['beforeinput', 'input']) {
+      document.addEventListener(type, (event) => {
+        window.__structuredMentionImeInputEvents.push({
+          type,
+          inputType: event.inputType,
+          data: event.data,
+          isComposing: event.isComposing,
+          defaultPrevented: event.defaultPrevented,
+          targetHtml: event.target instanceof HTMLElement ? event.target.innerHTML : null
+        })
+      })
+    }
+    const readDomText = (node) => {
+      if (node.nodeType === Node.TEXT_NODE) return node.textContent ?? ''
+      if (!(node instanceof HTMLElement)) return ''
+      if (node.dataset.editorCaretHost === 'true') {
+        return (node.textContent ?? '').replaceAll('\\u200B', '')
+      }
+      if (node.tagName === 'BR') {
+        return node.dataset.editorCaretBreak === 'true'
+          || node.dataset.editorEmptyBreak === 'true' ? '' : '\\n'
+      }
+      return [...node.childNodes].map(readDomText).join('')
+    }
+    return {
+      defaultPrevented: shortcut.defaultPrevented,
+      text: reconciledEditor ? readDomText(reconciledEditor) : null,
+      html: reconciledEditor?.innerHTML ?? null,
+      focused: document.activeElement === reconciledEditor
+    }
+  })()`, true)
+  assert(
+    trailingNewlineInspection?.defaultPrevented
+      && trailingNewlineInspection.text === '123213213\n'
+      && trailingNewlineInspection.focused,
+    `Shift+Enter did not create one trailing newline: ${JSON.stringify(trailingNewlineInspection)}`
+  )
+
+  await cdp.send('Input.insertText', { text: 'n' })
+  await evaluate(cdp,
+    `new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))`, true)
+  const postNewlineInputInspection = await evaluate(cdp, `(() => {
+    const editor = document.querySelector('#camp-message')
+    if (!(editor instanceof HTMLDivElement)) return {
+      text: null,
+      html: null,
+      stayedMounted: false,
+      focused: false,
+      errors: window.__structuredMentionImeErrors ?? [],
+      inputEvents: window.__structuredMentionImeInputEvents ?? [],
+      bodyText: document.body.innerText.slice(0, 500)
+    }
+    const readDomText = (node) => {
+      if (node.nodeType === Node.TEXT_NODE) return node.textContent ?? ''
+      if (!(node instanceof HTMLElement)) return ''
+      if (node.dataset.editorCaretHost === 'true') {
+        return (node.textContent ?? '').replaceAll('\\u200B', '')
+      }
+      if (node.tagName === 'BR') {
+        return node.dataset.editorCaretBreak === 'true'
+          || node.dataset.editorEmptyBreak === 'true' ? '' : '\\n'
+      }
+      return [...node.childNodes].map(readDomText).join('')
+    }
+    return {
+      text: readDomText(editor),
+      html: editor.innerHTML,
+      stayedMounted: editor === window.__structuredMentionPostNewlineEditor,
+      focused: document.activeElement === editor,
+      errors: window.__structuredMentionImeErrors ?? [],
+      inputEvents: window.__structuredMentionImeInputEvents ?? []
+    }
+  })()`)
+  assert(
+    postNewlineInputInspection?.text === '123213213\nn'
+      && postNewlineInputInspection.stayedMounted
+      && postNewlineInputInspection.focused,
+    `The first native character landed before the trailing newline: ${JSON.stringify(postNewlineInputInspection)}`
+  )
+  const draft = await waitForValue(async () => request(cdp, 'camp.composerDraft.get', { campId }),
+    (value) => deepEqual(value.content, [{ kind: 'text', text: '123213213\nn' }]), 10_000)
+
+  await selectWholeEditor(cdp)
+  await pressKey(cdp, {
+    key: 'Backspace', code: 'Backspace', windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 51
+  })
+  await waitForValue(async () => request(cdp, 'camp.composerDraft.get', { campId }),
+    (value) => deepEqual(value.content, []), 10_000)
+
+  return { trailingNewlineInspection, postNewlineInputInspection, draft }
 }
 
 async function focusEditorAtEnd(cdp) {
@@ -2047,7 +2415,12 @@ async function selectWholeEditor(cdp) {
     const selection = window.getSelection()
     selection?.removeAllRanges()
     selection?.addRange(range)
-    return selection?.toString() === editor.textContent
+    if (!selection || selection.rangeCount !== 1) return false
+    const selectedRange = selection.getRangeAt(0)
+    return selectedRange.startContainer === editor
+      && selectedRange.startOffset === 0
+      && selectedRange.endContainer === editor
+      && selectedRange.endOffset === editor.childNodes.length
   })()`)
   assert(selected, 'Could not select the whole Composer body')
 }


### PR DESCRIPTION
## Summary

- render structured model newlines as native line boxes and provide a zero-length caret host after a trailing newline
- keep native IME text, logical selection offsets, Draft serialization, placeholder state, and React DOM ownership consistent
- prevent stale `compositionend` reconciliation from crossing into the next composition generation
- add a focused packaged-Electron regression for one `Shift+Enter` followed by the first native character
- add a blameless postmortem covering the two incomplete fixes, the final root cause, and corrective actions

## Root cause

The Composer rendered a trailing model `\n` as a literal character inside a React text node. Chromium had no stable terminal line box, so the first native character was inserted before the newline (`123213213n\n`) and the IME marked-text host became unstable. A React-owned caret `<br>` was also unsafe because Chromium removed it before React reconciliation. The final projection uses a logical `<br>` plus a zero-width caret host that survives native editing and is excluded from the model.

## Validation

- `pnpm typecheck`
- `pnpm test` — 82 Vitest files / 584 tests passed; 220 Node tests passed, 1 skipped by design
- `DOCS_BASE_REF=a14c6b3ce9b1dce3f7e1029496f4578edd3d8857 pnpm docs:check:ci`
- `pnpm build:desktop`
- focused Electron regression: one Shift+Enter, then native `n` => `123213213\nn`, same editor, focused, no Renderer error
- real Tencent WeType sequence observed `keyCode=229`, `isComposing=true`, and `compositionupdate("ni")` on the same next-line host

## Postmortem

See `docs/postmortems/2026-08-26-composer-ime-trailing-newline-caret-host.md`.