### PR TITLE
docs(prototypes): add roster and tool grouping explorations

### DIFF
--- a/docs/prototypes/camp-member-management/PROJECT_DESIGN.md
+++ b/docs/prototypes/camp-member-management/PROJECT_DESIGN.md
@@ -1,0 +1,85 @@
+---
+document_type: ui-prototype-design
+authority: directional-input
+status: review-draft
+implementation_status: prototype
+target_surface: camp-member-management
+design_direction: porcelain-day-steel-night
+last_updated: 2026-08-25
+---
+
+# Camp 增减队员
+
+## 1. Product Context
+
+- **Product:** Rovai AI，一套证据优先的本地 Agent 协作桌面工作区。
+- **Target user:** 正在一个长期 Camp 中调整实际协作名册的用户。
+- **Target surface:** `CampWorkspace` 右侧 Inspector 的“队员”页签，以及受该动作影响的 Composer 路由状态。
+- **Primary job:** 在不混淆全局队员身份的前提下，把一个现有队员加入当前会话，或安全地把一个当前成员移出。
+- **Success:** 用户始终看清作用域、Lead 变化、Runtime 配置、未结工作与下一步；UI 不把 cancel request 伪装成可靠终态，也不允许有效 Camp 进入零成员状态。
+
+## 2. Existing UI Read
+
+- 保留 310px / compact 260px Inspector、sticky summary、现有队长 picker、头像、身份色和开放分隔列表；成员行内“Runtime · 状态”作为静态摘要，成员级操作统一进入右侧 `•••`。
+- 添加选择复用 `NewConversationDialog` 的头像、checkbox、Runtime readiness 与列表密度。
+- Dialog 使用 raised surface、strong boundary 和 3px Steel/Danger 顶边；普通列表不增加卡片墙或阴影。
+- Camp Header 继续只承载审批摘要和 Inspector 显隐，不新增执行入口或 `•••`。
+
+## 3. Interaction Model
+
+### 添加
+
+- 用户界面只有“添加队员”，不暴露首次加入、历史离开或 membership reactivation 的区别。
+- 非空 Camp 可以一次选择多位；Renderer 以稳定顺序提交独立幂等命令，并展示逐项结果。
+- 全部成功后关闭；部分失败保留 Dialog、成功事实和失败行，不回滚已经接受的命令。
+- Camp 创建与后续名册操作都保证至少一位队员，因此添加保持统一的多选交互，不设计“添加第一位队员”分支。
+
+### 移出
+
+- 每次只移出一位，确认前必须读取 Core 权威 impact preview。
+- Preview 明确下一任 Lead、释放 Task、Run cancel request 与 Delivery/Gather 收敛；只渲染计数大于零或确实发生的影响，不用“没有需要处理”的行填满确认框。
+- “历史继续保留”属于稳定产品事实，不在每次成员移出时重复展示；确认框只保留本次需要用户确认的变化。
+- cutover 成功后成员立即退出当前名册；未结 reconciliation 使用 Inspector 顶部持久状态轨，不依赖 Toast。
+- 版本冲突保留当前 Dialog 和焦点，刷新 preview 后才允许再次确认。
+- 最后一位队员的“移出当前会话”保留可见但不可执行，并就地说明“会话至少保留 1 位队员”；Core 提交边界仍重复校验该不变量。
+
+### 成员操作菜单
+
+- “Codex · 可用”等状态只表达当前事实，不再与右侧 `•••` 形成两个并列操作入口。
+- 菜单先放“查看/收起模型信息”，分隔线后再放“移出当前会话”；普通查看与危险动作保持清楚分区。
+- 本轮 HTML 同时提供三种入口供选择：横向三点常显、竖向三点常显、横向三点行内渐显。三者常态都不画边框，只在 hover、focus 或菜单展开时出现轻底色；当前推荐横向常显，最终选择待用户确认。
+- 模型信息仍在成员行下方展开，只显示当前模型、推理/思考强度和模型策略；不把 Runtime 配置编辑塞进 Camp Inspector。
+- 最后一位队员仍可从同一菜单查看 Runtime 详情；只有移出动作受名册不变量限制。
+
+## 4. Visual Direction
+
+- **Direction:** 在既有 Porcelain Day / Steel Night 内做安静、精确的操作增强，不创造新的视觉世界。
+- **Distinctive:** 作用域标签、条件式权威 impact preview 和 cutover/reconciliation 分层反馈。
+- **Quiet:** Runtime 元数据、历史 membership epoch 和内部命令编排不进入普通名册。
+- **Avoid:** 卡片墙、角色色状态、渐变、装饰性进度、全局 Header 菜单及第三方设计语言。
+
+## 5. Accessibility and State Matrix
+
+- 支持键盘、可见 `focus-visible`、Dialog focus trap/Esc/返回焦点和至少 28px 点击目标。
+- 状态通过文字、图标和稳定位置共同表达，不只靠颜色。
+- Day/Night 使用同一 DOM；支持 Loading、Submitting、Partial、Conflict、Error、Recovery、Runtime 展开和最后一位队员保护。
+- 评审覆盖 1440×920、1040×700、窄 Inspector、长中文角色名与 reduced motion。
+
+## 6. Production Mapping
+
+- Renderer：`CampWorkspace.tsx`、`styles.css`、相关 App/Renderer tests；
+- 可复用组件：`MemberAvatar`、现有 Camp Lead menu、New Conversation member picker、Radix Dialog/Menu；
+- Read model：当前 active roster、eligible global profiles、authoritative removal preview、reconciliation projection；
+- Core：逐项 add、remove cutover、exact-run fence、membership-version delivery admission 与持久化 reconciliation；
+- UI 合同：`DESIGN.md`、`docs/ui/components/conversation-workspace.md`、accessibility/theme matrix。
+
+## 7. Prototype Evaluation
+
+- 三种成员操作入口可在同一名册中切换比较，菜单内容和点击目标保持一致；
+- 添加、移出有影响、移出无在途、部分失败、版本冲突、收敛中、Runtime 展开和最后一位队员保护场景可重复切换；
+- 移出确认中，Run、Task、Delivery/Gather 与 Lead 只在实际受影响时出现；空影响不渲染占位行，也不渲染“继续保留”；
+- 普通路径中不出现“重新加入”或“永久移除”；
+- 移出 Dialog 不在 preview 完成前开放危险提交；
+- cutover 后名册、Lead、Composer 与 reconciliation 状态同步；
+- 有效交互路径不能把名册减到零；
+- Day/Night 与 1040px 宽度不出现横向页面溢出、截断主要操作或不可见焦点。

--- a/docs/prototypes/camp-member-management/README.md
+++ b/docs/prototypes/camp-member-management/README.md
@@ -1,0 +1,50 @@
+---
+document_type: ui-prototype-readme
+status: review-draft
+target_surface: camp-member-management
+last_updated: 2026-08-25
+---
+
+# Camp 增减队员交互稿
+
+这是 Camp 动态名册方案的独立 HTML 交互稿，用于在生产实现前比较三种成员操作入口，并评审当前会话中的添加、移出、
+并发冲突、异步收敛、Runtime 展开和最后一位队员保护。它不替代 Core、Architecture、Contract、当前版本范围或生产
+Renderer，也不证明相应能力已经实现。
+
+## 查看
+
+直接在浏览器打开 `index.html`，或从仓库根目录运行：
+
+```text
+python3 -m http.server 4173 --directory docs/prototypes/camp-member-management
+```
+
+然后访问 `http://127.0.0.1:4173/`。
+
+## 可评审状态
+
+- **普通名册：** 从 Camp Inspector 的“队员”页签添加或移出成员；
+- **添加多人：** 复用现有新对话成员选择语言，按独立幂等命令顺序提交；
+- **部分失败：** 已成功加入的人立即进入名册，失败项保留在 Dialog 内原位重试；
+- **移出队长：** Core preview 明确下一任队长、Task、Run 与 Delivery/Gather 的实际变化；
+- **移出无在途：** 没有实际影响时，确认框不显示 Run、Task、消息/Gather 空行；
+- **版本冲突：** 保留 Dialog，并要求刷新权威影响后再次确认；
+- **收敛中：** membership cutover 已生效，但 Run/Delivery 仍在可靠终态化；
+- **成员操作菜单：** 可切换横向常显、竖向常显与行内渐显三种无框入口；菜单统一承载“查看/收起模型信息”和“移出当前会话”，Runtime 状态只作摘要；
+- **条件式影响：** 只展示实际存在的执行、任务、消息/Gather 与队长变化，不展示“继续保留”；
+- **仅一位队员：** 移出动作保持可见但不可执行，并明确说明会话至少保留 1 位队员。
+
+原型顶部的场景条和主题按钮仅用于评审，不属于生产 Camp UI。
+
+## 已确认的术语
+
+- 普通用户只看到“添加队员”，不区分首次加入与底层 membership reactivation；
+- Camp 级离开统一叫“移出当前会话”；
+- Camp 始终至少保留一位队员，不提供零成员恢复路径；
+- “永久移除”只用于全局 AgentProfile removal；
+- “发送被受理”“收到停止请求”和“可靠终态已确认”保持三个不同事实。
+
+## 文件
+
+- `index.html`：自包含的 Day/Night 可点击原型；
+- `PROJECT_DESIGN.md`：已确认的交互 brief 与生产映射。

--- a/docs/prototypes/camp-member-management/index.html
+++ b/docs/prototypes/camp-member-management/index.html
@@ -1,0 +1,1524 @@
+<!doctype html>
+<html lang="zh-CN" data-theme="day">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Rovai AI · 队员操作入口与移出确认交互稿</title>
+  <style>
+    :root {
+      color-scheme: light;
+      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif;
+      font-synthesis: none;
+      text-rendering: optimizeLegibility;
+      --canvas: #eceeef;
+      --surface: #fbfbfa;
+      --surface-raised: #ffffff;
+      --surface-subtle: #f0f2f4;
+      --surface-muted: #e7eaed;
+      --surface-hover: #e8eaea;
+      --surface-sunken: #e4e8eb;
+      --conversation-surface: #ffffff;
+      --inspector-surface: #ffffff;
+      --topbar: #fbfbfa;
+      --input: #ffffff;
+      --ink: #171b20;
+      --muted: #616a73;
+      --faint: #6e7382;
+      --line: #dfe4e8;
+      --line-strong: #c7cfd6;
+      --control-line: #8b9389;
+      --rail: #f3f4f4;
+      --rail-ink: #626b72;
+      --rail-line: #dadde0;
+      --rail-logo: #526f88;
+      --brand: #526f88;
+      --brand-hover: #3d5874;
+      --brand-contrast: #ffffff;
+      --brand-soft: #e9eef3;
+      --brand-ink: #405f7e;
+      --success: #3e775c;
+      --success-soft: #e7f1ea;
+      --attention: #8a6226;
+      --attention-soft: #f8edda;
+      --danger: #a24c46;
+      --danger-soft: #f7e6e3;
+      --info: #416c86;
+      --info-soft: #e5eef3;
+      --neutral: #5f6678;
+      --neutral-soft: #ecefe9;
+      --focus: #526f88;
+      --focus-soft: rgba(82, 111, 136, 0.16);
+      --overlay: rgba(28, 32, 43, 0.42);
+      --shadow-float: 0 18px 56px rgba(38, 45, 58, 0.14);
+      --identity-1: #a65f4a;
+      --identity-2: #39777a;
+      --identity-3: #74628f;
+      --identity-4: #9a6a32;
+      --identity-5: #4f729b;
+      --identity-6: #8a5c75;
+      --identity-7: #547245;
+      --identity-8: #8c6146;
+      --rail-width: 270px;
+      --inspector-width: 310px;
+    }
+
+    :root[data-theme="night"] {
+      color-scheme: dark;
+      --canvas: #0d1114;
+      --surface: #151a1e;
+      --surface-raised: #1b2227;
+      --surface-subtle: #1a2024;
+      --surface-muted: #242d33;
+      --surface-hover: #1d252b;
+      --surface-sunken: #10161a;
+      --conversation-surface: #181d21;
+      --inspector-surface: #171d21;
+      --topbar: #151a1e;
+      --input: #1b2227;
+      --ink: #e7ecef;
+      --muted: #abb5bc;
+      --faint: #919da6;
+      --line: #333e46;
+      --line-strong: #53616b;
+      --control-line: #687b88;
+      --rail: #11161a;
+      --rail-ink: #a6b1b8;
+      --rail-line: #313b43;
+      --rail-logo: #b1c8d8;
+      --brand: #7897ae;
+      --brand-hover: #b1c8d8;
+      --brand-contrast: #091116;
+      --brand-soft: #22303a;
+      --brand-ink: #c0d4e1;
+      --success: #82b695;
+      --success-soft: #1a2b22;
+      --attention: #d2ac70;
+      --attention-soft: #302719;
+      --danger: #d6857f;
+      --danger-soft: #321e1d;
+      --info: #83afc9;
+      --info-soft: #182832;
+      --neutral: #abb5bc;
+      --neutral-soft: #242d33;
+      --focus: #8fb3cb;
+      --focus-soft: rgba(143, 179, 203, 0.18);
+      --overlay: rgba(0, 0, 0, 0.58);
+      --shadow-float: 0 22px 64px rgba(0, 0, 0, 0.42);
+      --identity-1: #c98572;
+      --identity-2: #70b0ae;
+      --identity-3: #a89ac8;
+      --identity-4: #d0a46c;
+      --identity-5: #80abd1;
+      --identity-6: #b37d9a;
+      --identity-7: #89a878;
+      --identity-8: #b58b68;
+    }
+
+    * { box-sizing: border-box; }
+    html, body { min-width: 0; min-height: 100%; margin: 0; }
+    body { padding: 18px; overflow-x: hidden; color: var(--ink); background: var(--canvas); }
+    button, input, textarea { color: inherit; font: inherit; }
+    button { border: 0; }
+    button:not(:disabled) { cursor: pointer; }
+    button:disabled { opacity: .52; cursor: default; }
+    button:active:not(:disabled) { transform: translateY(1px); }
+    :where(button, input, textarea, [role="tab"]):focus-visible {
+      outline: 2px solid var(--focus);
+      outline-offset: 2px;
+    }
+    ::selection { color: var(--ink); background: var(--brand-soft); }
+
+    .prototype-shell { width: min(1360px, 100%); margin: 0 auto; }
+    .prototype-heading {
+      display: flex;
+      align-items: flex-end;
+      justify-content: space-between;
+      gap: 24px;
+      margin: 0 2px 12px;
+    }
+    .prototype-kicker {
+      margin: 0 0 4px;
+      color: var(--brand-ink);
+      font: 720 9.5px/1.3 ui-monospace, SFMono-Regular, Menlo, monospace;
+      letter-spacing: .1em;
+      text-transform: uppercase;
+    }
+    .prototype-heading h1 { margin: 0; font-size: clamp(20px, 2.4vw, 28px); line-height: 1.15; letter-spacing: -.035em; }
+    .prototype-heading p:last-child { max-width: 720px; margin: 6px 0 0; color: var(--muted); font-size: 11.5px; line-height: 1.55; }
+    .review-actions { display: flex; flex: 0 0 auto; gap: 6px; }
+    .review-button,
+    .scenario-button {
+      min-height: 32px;
+      padding: 6px 9px;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      color: var(--muted);
+      background: var(--surface);
+      font-size: 10.5px;
+    }
+    .review-button:hover,
+    .scenario-button:hover { color: var(--ink); background: var(--surface-hover); }
+
+    .scenario-bar {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      margin-bottom: 10px;
+      padding: 5px;
+      overflow-x: auto;
+      border: 1px solid var(--line);
+      border-radius: 9px;
+      background: var(--surface);
+      scrollbar-width: thin;
+    }
+    .scenario-label {
+      flex: 0 0 auto;
+      padding: 0 6px 0 3px;
+      color: var(--faint);
+      font: 700 9px/1.3 ui-monospace, SFMono-Regular, Menlo, monospace;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+    }
+    .scenario-button { flex: 0 0 auto; border-color: transparent; background: transparent; }
+    .scenario-button[aria-pressed="true"] { border-color: var(--line); color: var(--brand-ink); background: var(--brand-soft); font-weight: 700; }
+
+    .variant-bar {
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr) minmax(240px, 360px);
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 10px;
+      padding: 7px 9px;
+      border: 1px solid var(--line);
+      border-radius: 9px;
+      background: var(--surface);
+    }
+    .variant-label {
+      color: var(--faint);
+      font: 700 9px/1.3 ui-monospace, SFMono-Regular, Menlo, monospace;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+    .variant-options { display: flex; min-width: 0; gap: 5px; }
+    .variant-choice {
+      display: grid;
+      min-width: 0;
+      min-height: 38px;
+      flex: 1 1 0;
+      grid-template-columns: 28px minmax(0, 1fr);
+      align-items: center;
+      gap: 7px;
+      padding: 4px 7px;
+      border: 1px solid transparent;
+      border-radius: 7px;
+      color: var(--muted);
+      background: transparent;
+      text-align: left;
+    }
+    .variant-choice:hover { color: var(--ink); background: var(--surface-hover); }
+    .variant-choice[aria-pressed="true"] { border-color: var(--line-strong); color: var(--ink); background: var(--brand-soft); }
+    .variant-choice-glyph { display: grid; width: 28px; height: 28px; place-items: center; border-radius: 6px; color: var(--faint); }
+    .variant-choice[aria-pressed="true"] .variant-choice-glyph { color: var(--brand-ink); }
+    .variant-choice-glyph svg { width: 16px; height: 16px; fill: currentColor; }
+    .variant-choice-copy { display: grid; min-width: 0; gap: 1px; }
+    .variant-choice-copy strong { overflow: hidden; font-size: 9.5px; text-overflow: ellipsis; white-space: nowrap; }
+    .variant-choice-copy small { overflow: hidden; color: var(--faint); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
+    .variant-note { margin: 0; color: var(--muted); font-size: 9px; line-height: 1.45; }
+    .variant-note strong { color: var(--brand-ink); }
+
+    .app-window {
+      display: grid;
+      height: min(720px, calc(100vh - 165px));
+      min-height: 590px;
+      grid-template-columns: var(--rail-width) minmax(0, 1fr);
+      overflow: hidden;
+      border: 1px solid var(--line-strong);
+      border-radius: 12px;
+      background: var(--surface);
+      box-shadow: 0 12px 36px rgba(35, 44, 51, .08);
+    }
+    :root[data-theme="night"] .app-window { box-shadow: 0 18px 48px rgba(0, 0, 0, .34); }
+
+    .app-rail {
+      display: grid;
+      min-width: 0;
+      grid-template-rows: auto auto minmax(0, 1fr) auto;
+      padding: 14px 10px 10px;
+      overflow: hidden;
+      border-right: 1px solid var(--rail-line);
+      color: var(--rail-ink);
+      background: var(--rail);
+    }
+    .brand-lockup { display: flex; align-items: center; gap: 10px; padding: 2px 8px 16px; color: var(--ink); }
+    .brand-lockup strong { font-size: 12px; letter-spacing: -.01em; }
+    .brand-mark { position: relative; width: 26px; height: 26px; flex: 0 0 26px; color: var(--rail-logo); }
+    .brand-mark::before {
+      position: absolute;
+      top: 2px;
+      left: 9px;
+      width: 8px;
+      height: 8px;
+      background: currentColor;
+      clip-path: polygon(50% 0, 62% 37%, 100% 50%, 62% 63%, 50% 100%, 38% 63%, 0 50%, 38% 37%);
+      content: "";
+    }
+    .brand-mark::after {
+      position: absolute;
+      right: 2px;
+      bottom: 3px;
+      left: 2px;
+      height: 9px;
+      border-top: 2px solid currentColor;
+      border-radius: 50% 50% 0 0;
+      content: "";
+    }
+    .rail-primary { display: grid; gap: 3px; padding-bottom: 12px; border-bottom: 1px solid var(--rail-line); }
+    .rail-item {
+      display: grid;
+      width: 100%;
+      min-height: 34px;
+      grid-template-columns: 22px minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 8px;
+      border-radius: 6px;
+      color: inherit;
+      background: transparent;
+      text-align: left;
+      font-size: 11px;
+    }
+    .rail-item:hover { color: var(--ink); background: var(--surface-hover); }
+    .rail-item.selected { color: var(--brand-ink); background: var(--brand-soft); font-weight: 680; }
+    .rail-icon { display: grid; width: 20px; height: 20px; place-items: center; color: var(--faint); font-size: 14px; }
+    .rail-projects { min-height: 0; padding: 13px 0 0; overflow: hidden; }
+    .rail-section-heading { display: flex; align-items: center; justify-content: space-between; padding: 0 8px 7px; color: var(--faint); font-size: 9.5px; font-weight: 720; letter-spacing: .04em; }
+    .rail-camp { position: relative; padding-left: 27px; }
+    .rail-camp::before { position: absolute; top: 8px; bottom: 8px; left: 12px; width: 2px; border-radius: 2px; background: var(--brand); content: ""; }
+    .rail-footer { display: flex; align-items: center; gap: 8px; padding: 9px 8px 2px; border-top: 1px solid var(--rail-line); color: var(--faint); font-size: 9px; }
+
+    .camp-shell { display: grid; min-width: 0; min-height: 0; grid-template-rows: 50px minmax(0, 1fr); }
+    .camp-header {
+      display: flex;
+      min-width: 0;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 0 14px 0 18px;
+      border-bottom: 1px solid var(--line);
+      background: var(--topbar);
+    }
+    .camp-title { display: grid; min-width: 0; gap: 1px; }
+    .camp-title strong { overflow: hidden; font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
+    .camp-title small { color: var(--faint); font-size: 9px; }
+    .camp-header-actions { display: flex; align-items: center; gap: 6px; }
+    .approval-summary { display: flex; min-height: 28px; align-items: center; gap: 6px; padding: 4px 8px; border-radius: 6px; color: var(--faint); background: transparent; font-size: 9.5px; }
+    .approval-summary i { width: 6px; height: 6px; border-radius: 50%; background: var(--neutral); }
+    .icon-button {
+      display: grid;
+      width: 30px;
+      height: 30px;
+      flex: 0 0 30px;
+      place-items: center;
+      border-radius: 6px;
+      color: var(--muted);
+      background: transparent;
+      font-size: 15px;
+    }
+    .icon-button:hover { color: var(--ink); background: var(--surface-hover); }
+
+    .camp-body { display: grid; min-width: 0; min-height: 0; grid-template-columns: minmax(0, 1fr) var(--inspector-width); }
+    .conversation {
+      display: grid;
+      min-width: 0;
+      min-height: 0;
+      grid-template-rows: minmax(0, 1fr) auto;
+      background: var(--conversation-surface);
+    }
+    .timeline { min-height: 0; overflow: auto; padding: 22px clamp(22px, 4vw, 52px) 16px; }
+    .message { position: relative; max-width: 76ch; margin: 0 auto; padding: 15px 0 17px 42px; border-bottom: 1px solid var(--line); }
+    .message:last-child { border-bottom: 0; }
+    .message-avatar { position: absolute; top: 15px; left: 0; }
+    .message-meta { display: flex; align-items: baseline; gap: 7px; margin-bottom: 5px; }
+    .message-meta strong { font-size: 11px; }
+    .message-meta time { color: var(--faint); font: 500 8.5px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .message p { margin: 0; color: var(--muted); font-size: 11.5px; line-height: 1.72; }
+    .message p + p { margin-top: 7px; }
+    .message-route { display: inline-flex; align-items: center; gap: 4px; margin-top: 8px; color: var(--faint); font-size: 9px; }
+
+    .composer { padding: 0 clamp(18px, 3.4vw, 42px) 14px; background: var(--conversation-surface); }
+    .composer-route {
+      display: flex;
+      width: min(1040px, 100%);
+      min-height: 31px;
+      align-items: center;
+      gap: 7px;
+      margin: 0 auto 4px;
+      padding: 0 3px;
+      color: var(--faint);
+      font-size: 9.5px;
+    }
+    .composer-route::before { width: 2px; height: 15px; flex: 0 0 2px; border-radius: 3px; background: var(--brand); content: ""; }
+    .composer-route.is-empty { color: var(--attention); }
+    .composer-route.is-empty::before { background: var(--attention); }
+    .composer-route button { margin-left: auto; padding: 3px 0; color: var(--brand-ink); background: transparent; font-size: 9.5px; font-weight: 680; }
+    .composer-box {
+      display: grid;
+      width: min(1040px, 100%);
+      min-height: 82px;
+      grid-template-rows: minmax(0, 1fr) auto;
+      gap: 4px;
+      margin: 0 auto;
+      padding: 9px;
+      border: 1px solid var(--control-line);
+      border-radius: 8px;
+      background: var(--input);
+    }
+    .composer-box:focus-within { border-color: var(--brand); box-shadow: 0 0 0 3px var(--focus-soft); }
+    .composer-box textarea { width: 100%; min-height: 38px; resize: none; border: 0; outline: 0; color: var(--ink); background: transparent; font-size: 11.5px; line-height: 1.55; }
+    .composer-box textarea::placeholder { color: var(--faint); }
+    .composer-footer { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+    .composer-tools { display: flex; gap: 3px; }
+    .composer-tools button { width: 28px; height: 28px; border-radius: 5px; color: var(--faint); background: transparent; }
+    .send-button { min-width: 62px; min-height: 30px; padding: 5px 10px; border-radius: 6px; color: var(--brand-contrast); background: var(--brand); font-size: 10.5px; font-weight: 700; }
+    .send-button:hover:not(:disabled) { background: var(--brand-hover); }
+
+    .inspector {
+      display: grid;
+      min-width: 0;
+      min-height: 0;
+      grid-template-rows: 43px minmax(0, 1fr);
+      border-left: 1px solid var(--line-strong);
+      background: var(--inspector-surface);
+    }
+    .inspector-tabs { display: flex; align-items: end; gap: 2px; padding: 0 10px; border-bottom: 1px solid var(--line); }
+    .inspector-tab {
+      position: relative;
+      display: inline-flex;
+      min-width: 70px;
+      min-height: 39px;
+      align-items: center;
+      justify-content: center;
+      gap: 5px;
+      color: var(--faint);
+      background: transparent;
+      font-size: 10.5px;
+    }
+    .inspector-tab[aria-selected="true"] { color: var(--ink); font-weight: 700; }
+    .inspector-tab[aria-selected="true"]::after { position: absolute; right: 8px; bottom: -1px; left: 8px; height: 2px; border-radius: 2px 2px 0 0; background: var(--brand); content: ""; }
+    .inspector-tab small { color: var(--faint); font-size: 8.5px; }
+    .inspector-panel { min-height: 0; overflow: auto; }
+    .tasks-placeholder { display: grid; height: 100%; place-content: center; gap: 6px; padding: 24px; color: var(--faint); text-align: center; }
+    .tasks-placeholder strong { color: var(--muted); font-size: 11.5px; }
+    .tasks-placeholder span { max-width: 220px; font-size: 9.5px; line-height: 1.5; }
+
+    .members-summary {
+      position: sticky;
+      z-index: 5;
+      top: 0;
+      padding: 12px;
+      border-bottom: 1px solid var(--line);
+      background: color-mix(in srgb, var(--surface-subtle) 96%, transparent);
+      backdrop-filter: blur(10px);
+    }
+    .members-summary-line { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: start; gap: 8px; margin-bottom: 8px; }
+    .members-summary-title { display: grid; min-width: 0; gap: 2px; }
+    .members-summary-title strong { font-size: 12px; }
+    .members-summary-title small { color: var(--faint); font-size: 9.5px; }
+    .members-summary-actions { display: flex; align-items: center; gap: 5px; }
+    .scope-label { padding: 3px 6px; border-radius: 999px; color: var(--brand-ink); background: var(--brand-soft); font-size: 7.5px; font-weight: 780; white-space: nowrap; }
+    .add-member-button {
+      display: inline-flex;
+      min-height: 28px;
+      align-items: center;
+      gap: 4px;
+      padding: 4px 7px;
+      border: 1px solid color-mix(in srgb, var(--brand) 38%, var(--line));
+      border-radius: 6px;
+      color: var(--brand-ink);
+      background: var(--surface);
+      font-size: 9px;
+      font-weight: 720;
+      white-space: nowrap;
+    }
+    .add-member-button:hover { border-color: var(--brand); background: var(--brand-soft); }
+
+    .lead-picker-wrap { position: relative; }
+    .lead-picker {
+      display: grid;
+      width: 100%;
+      min-height: 44px;
+      grid-template-columns: 28px minmax(0, 1fr) 14px;
+      align-items: center;
+      gap: 8px;
+      padding: 7px 8px;
+      border: 1px solid color-mix(in srgb, var(--brand) 34%, var(--line));
+      border-radius: 7px;
+      color: var(--ink);
+      background: var(--surface);
+      text-align: left;
+    }
+    .lead-picker:hover:not(:disabled), .lead-picker[aria-expanded="true"] { border-color: var(--brand); background: var(--brand-soft); }
+    .lead-copy { display: grid; min-width: 0; gap: 2px; }
+    .lead-copy strong, .lead-copy small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .lead-copy strong { font-size: 10.5px; }
+    .lead-copy small { color: var(--faint); font-size: 8.5px; }
+    .chevron { width: 10px; height: 10px; color: var(--faint); transition: transform 140ms ease; }
+    [aria-expanded="true"] > .chevron { transform: rotate(180deg); }
+    .lead-menu,
+    .member-menu {
+      position: absolute;
+      z-index: 15;
+      display: none;
+      padding: 4px;
+      border: 1px solid var(--line-strong);
+      border-radius: 7px;
+      color: var(--ink);
+      background: var(--surface-raised);
+      box-shadow: var(--shadow-float);
+    }
+    .lead-menu.open, .member-menu.open { display: grid; }
+    .lead-menu { top: calc(100% + 5px); right: 0; left: 0; }
+    .lead-menu-label { padding: 5px 7px 7px; border-bottom: 1px solid var(--line); color: var(--faint); font-size: 8.5px; font-weight: 750; }
+    .lead-option { display: grid; min-height: 40px; grid-template-columns: 28px minmax(0, 1fr) 16px; align-items: center; gap: 7px; padding: 5px 7px; border-radius: 5px; background: transparent; text-align: left; }
+    .lead-option:hover, .lead-option.selected { color: var(--brand-ink); background: var(--brand-soft); }
+    .lead-option-copy { display: grid; min-width: 0; gap: 2px; }
+    .lead-option-copy strong, .lead-option-copy small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .lead-option-copy strong { font-size: 10px; }
+    .lead-option-copy small { color: var(--faint); font-size: 8px; }
+    .lead-check { color: var(--brand); font-size: 10px; font-weight: 800; }
+
+    .reconciliation {
+      display: grid;
+      grid-template-columns: 18px minmax(0, 1fr) auto;
+      gap: 7px;
+      margin: 9px 12px 3px;
+      padding: 8px 9px;
+      border-left: 3px solid var(--info);
+      color: var(--info);
+      background: var(--info-soft);
+    }
+    .reconciliation.attention { border-left-color: var(--attention); color: var(--attention); background: var(--attention-soft); }
+    .reconciliation.success { border-left-color: var(--success); color: var(--success); background: var(--success-soft); }
+    .reconciliation-mark { font-size: 13px; line-height: 1.3; }
+    .reconciliation-copy { display: grid; min-width: 0; gap: 2px; }
+    .reconciliation-copy strong { font-size: 9.5px; }
+    .reconciliation-copy span { color: color-mix(in srgb, currentColor 82%, var(--ink)); font-size: 8.5px; line-height: 1.45; }
+    .reconciliation button { align-self: start; padding: 2px 0; color: currentColor; background: transparent; font-size: 8.5px; font-weight: 700; white-space: nowrap; }
+    .reconciliation-detail { grid-column: 2 / -1; padding-top: 5px; border-top: 1px solid color-mix(in srgb, currentColor 28%, transparent); color: color-mix(in srgb, currentColor 85%, var(--ink)); font-size: 8.5px; line-height: 1.5; }
+
+    .member-list { padding: 4px 12px 22px; }
+    .member-row {
+      position: relative;
+      display: grid;
+      min-width: 0;
+      grid-template-columns: 34px minmax(0, 1fr) auto 28px;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 0;
+      border-bottom: 1px solid var(--line);
+    }
+    .member-avatar-wrap { position: relative; display: block; width: 32px; height: 32px; }
+    .avatar {
+      display: grid;
+      width: 32px;
+      height: 32px;
+      place-items: center;
+      border: 2px solid var(--avatar-color, var(--identity-1));
+      border-radius: 50%;
+      color: var(--avatar-color, var(--identity-1));
+      background: color-mix(in srgb, var(--avatar-color, var(--identity-1)) 10%, var(--surface));
+      font-size: 10px;
+      font-weight: 760;
+    }
+    .avatar.small { width: 28px; height: 28px; font-size: 9px; }
+    .presence-dot { position: absolute; right: -2px; bottom: -2px; width: 9px; height: 9px; border: 2px solid var(--inspector-surface); border-radius: 50%; background: var(--success); }
+    .presence-dot.away { background: var(--neutral); }
+    .member-copy { display: grid; min-width: 0; gap: 3px; }
+    .member-name { display: flex; min-width: 0; align-items: center; gap: 5px; }
+    .member-name strong { overflow: hidden; font-size: 10.5px; text-overflow: ellipsis; white-space: nowrap; }
+    .lead-badge { flex: 0 0 auto; padding: 2px 5px; border-radius: 999px; color: var(--brand-ink); background: var(--brand-soft); font-size: 7px; font-weight: 800; }
+    .member-copy > small { overflow: hidden; color: var(--faint); font-size: 8.5px; text-overflow: ellipsis; white-space: nowrap; }
+    .member-state { display: grid; min-width: 0; justify-items: end; gap: 3px; }
+    .member-state strong { color: var(--success); font-size: 8.5px; }
+    .member-state.away strong { color: var(--faint); }
+    .runtime-label { max-width: 112px; overflow: hidden; color: var(--faint); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
+    .runtime-label.ready { color: var(--success); }
+    .runtime-label.attention { color: var(--attention); }
+    .runtime-detail {
+      display: grid;
+      min-width: 0;
+      grid-column: 2 / -1;
+      grid-template-columns: minmax(0, 1fr);
+      gap: 5px;
+      margin: 1px 0 2px;
+      padding: 8px 9px;
+      border-left: 2px solid var(--line-strong);
+      color: var(--muted);
+      background: var(--surface-subtle);
+    }
+    .runtime-detail > div { display: grid; min-width: 0; grid-template-columns: 58px minmax(0, 1fr); gap: 7px; }
+    .runtime-detail dt, .runtime-detail dd { min-width: 0; margin: 0; font-size: 8.5px; line-height: 1.4; }
+    .runtime-detail dt { color: var(--faint); }
+    .runtime-detail dd { overflow-wrap: anywhere; color: var(--ink); font-weight: 650; }
+    .member-menu-wrap { position: relative; }
+    .member-action { display: grid; width: 28px; height: 28px; place-items: center; padding: 0; border: 0; border-radius: 6px; color: var(--faint); background: transparent; }
+    .member-action svg { width: 16px; height: 16px; fill: currentColor; }
+    .member-action:hover, .member-action[aria-expanded="true"] { color: var(--ink); background: var(--surface-hover); }
+    body[data-action-style="hover"] .member-action { opacity: .24; transition: opacity 140ms ease, color 140ms ease, background 140ms ease; }
+    body[data-action-style="hover"] .member-row:hover .member-action,
+    body[data-action-style="hover"] .member-row:focus-within .member-action,
+    body[data-action-style="hover"] .member-action[aria-expanded="true"] { opacity: 1; }
+    .member-menu { top: 30px; right: 0; width: 168px; }
+    .member-menu button { display: grid; min-height: 34px; gap: 2px; padding: 7px 8px; border-radius: 5px; color: var(--ink); background: transparent; text-align: left; font-size: 9.5px; }
+    .member-menu button:hover:not([aria-disabled="true"]) { background: var(--surface-hover); }
+    .member-menu button[data-remove-id] { color: var(--danger); }
+    .member-menu button[data-remove-id]:hover { color: var(--danger); background: var(--danger-soft); }
+    .member-menu button[aria-disabled="true"] { color: var(--faint); cursor: default; }
+    .member-menu button small { color: currentColor; font-size: 8px; font-weight: 500; line-height: 1.4; }
+    .member-menu-separator { height: 1px; margin: 4px; background: var(--line); }
+    .roster-invariant-error { margin: 12px; padding: 10px; border-left: 3px solid var(--danger); color: var(--danger); background: var(--danger-soft); font-size: 9px; line-height: 1.5; }
+    .primary-button,
+    .danger-button,
+    .quiet-button {
+      min-height: 32px;
+      padding: 6px 11px;
+      border-radius: 6px;
+      font-size: 10.5px;
+      font-weight: 700;
+    }
+    .primary-button { color: var(--brand-contrast); background: var(--brand); }
+    .primary-button:hover:not(:disabled) { background: var(--brand-hover); }
+    .danger-button { color: #fff; background: var(--danger); }
+    :root[data-theme="night"] .danger-button { color: #160d0c; }
+    .danger-button:hover:not(:disabled) { filter: brightness(.92); }
+    .quiet-button { border: 1px solid var(--line-strong); color: var(--muted); background: var(--surface); }
+    .quiet-button:hover:not(:disabled) { color: var(--ink); background: var(--surface-hover); }
+
+    dialog {
+      max-width: none;
+      max-height: none;
+      padding: 0;
+      border: 0;
+      color: var(--ink);
+      background: transparent;
+    }
+    dialog::backdrop { background: var(--overlay); backdrop-filter: blur(2px); }
+    .dialog-card {
+      display: grid;
+      width: min(560px, calc(100vw - 40px));
+      max-height: min(690px, calc(100vh - 40px));
+      grid-template-rows: auto minmax(0, 1fr) auto;
+      overflow: hidden;
+      border: 1px solid var(--line-strong);
+      border-top: 3px solid var(--brand);
+      border-radius: 12px;
+      background: var(--surface-raised);
+      box-shadow: var(--shadow-float);
+    }
+    .dialog-card.danger { width: min(520px, calc(100vw - 40px)); border-top-color: var(--danger); }
+    .dialog-header { display: grid; grid-template-columns: minmax(0, 1fr) 30px; gap: 14px; padding: 17px 18px 14px; border-bottom: 1px solid var(--line); }
+    .dialog-eyebrow { margin: 0 0 4px; color: var(--brand-ink); font: 720 8.5px/1.3 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .1em; }
+    .danger .dialog-eyebrow { color: var(--danger); }
+    .dialog-header h2 { margin: 0; font-size: 17px; line-height: 1.25; letter-spacing: -.025em; }
+    .dialog-header p:last-child { margin: 5px 0 0; color: var(--muted); font-size: 10.5px; line-height: 1.5; }
+    .dialog-close { width: 30px; height: 30px; border-radius: 6px; color: var(--faint); background: transparent; font-size: 17px; }
+    .dialog-close:hover { color: var(--ink); background: var(--surface-hover); }
+    .dialog-body { min-height: 0; padding: 14px 18px 16px; overflow: auto; }
+    .dialog-footer { display: flex; min-height: 58px; align-items: center; justify-content: space-between; gap: 12px; padding: 10px 18px; border-top: 1px solid var(--line); background: var(--surface-subtle); }
+    .dialog-footer-copy { color: var(--faint); font-size: 9.5px; line-height: 1.4; }
+    .dialog-footer-actions { display: flex; gap: 7px; margin-left: auto; }
+
+    .search-field { position: relative; display: grid; grid-template-columns: 18px minmax(0, 1fr); align-items: center; gap: 6px; margin-bottom: 10px; padding: 0 9px; border: 1px solid var(--control-line); border-radius: 7px; background: var(--input); }
+    .search-field:focus-within { border-color: var(--brand); box-shadow: 0 0 0 2px var(--focus-soft); }
+    .search-field span { color: var(--faint); font-size: 13px; }
+    .search-field input { height: 36px; min-width: 0; border: 0; outline: 0; background: transparent; font-size: 11px; }
+    .candidate-caption { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 0 3px 7px; color: var(--faint); font-size: 9px; }
+    .candidate-caption strong { color: var(--muted); font-weight: 680; }
+    .candidate-list { border-top: 1px solid var(--line); }
+    .candidate-entry { border-bottom: 1px solid var(--line); }
+    .candidate-row {
+      display: grid;
+      min-height: 58px;
+      grid-template-columns: 18px 34px minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 9px;
+      padding: 7px 5px;
+      border-radius: 0;
+    }
+    .candidate-row:hover { background: var(--surface-hover); }
+    .candidate-row input { width: 16px; height: 16px; margin: 0; accent-color: var(--brand); }
+    .candidate-copy { display: grid; min-width: 0; gap: 3px; }
+    .candidate-copy strong { display: flex; min-width: 0; align-items: baseline; gap: 7px; font-size: 11px; }
+    .candidate-copy strong small { overflow: hidden; color: var(--muted); font-size: 9px; font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
+    .candidate-copy > small { overflow: hidden; color: var(--faint); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
+    .runtime-state { display: inline-flex; align-items: center; gap: 5px; color: var(--attention); font-size: 8.5px; white-space: nowrap; }
+    .runtime-state.ready { color: var(--success); }
+    .runtime-state i { width: 7px; height: 7px; border-radius: 50%; background: currentColor; }
+    .candidate-error { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin: -2px 5px 7px 66px; color: var(--danger); font-size: 8.5px; }
+    .candidate-error button { padding: 2px 0; color: var(--danger); background: transparent; font-weight: 720; }
+    .dialog-alert { margin-bottom: 10px; padding: 8px 10px; border-left: 3px solid var(--attention); color: var(--attention); background: var(--attention-soft); font-size: 9.5px; line-height: 1.5; }
+    .dialog-alert.danger-alert { border-left-color: var(--danger); color: var(--danger); background: var(--danger-soft); }
+    .candidate-empty { display: grid; min-height: 190px; place-content: center; justify-items: center; gap: 7px; padding: 24px; text-align: center; }
+    .candidate-empty strong { font-size: 11.5px; }
+    .candidate-empty p { max-width: 340px; margin: 0; color: var(--faint); font-size: 9.5px; line-height: 1.5; }
+    .candidate-empty button { margin-top: 3px; padding: 4px 0; color: var(--brand-ink); background: transparent; font-size: 9.5px; font-weight: 700; }
+
+    .preview-loading { display: grid; gap: 9px; padding: 4px 0; }
+    .skeleton { height: 36px; border-radius: 6px; background: var(--surface-muted); animation: skeleton 1.2s ease-in-out infinite alternate; }
+    .skeleton.short { width: 72%; }
+    @keyframes skeleton { to { opacity: .55; } }
+    .impact-list { display: grid; margin: 0; padding: 0; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); list-style: none; }
+    .impact-item { display: grid; min-height: 48px; grid-template-columns: 18px minmax(0, 1fr); align-items: start; column-gap: 10px; padding: 10px 2px; border-bottom: 1px solid var(--line); }
+    .impact-item:last-child { border-bottom: 0; }
+    .impact-mark { display: flex; width: 18px; height: 18px; align-items: center; justify-content: center; margin: 0; color: var(--attention); }
+    .impact-mark.neutral { color: var(--brand-ink); }
+    .impact-mark svg { width: 16px; height: 16px; fill: none; stroke: currentColor; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1.7; }
+    .impact-copy { display: grid; gap: 2px; }
+    .impact-copy strong { font-size: 10.5px; line-height: 18px; }
+    .impact-copy span { color: var(--faint); font-size: 9.5px; line-height: 1.5; }
+    .dialog-footer-copy:empty { display: none; }
+
+    .toast {
+      position: fixed;
+      z-index: 100;
+      right: 20px;
+      bottom: 20px;
+      display: flex;
+      min-width: 230px;
+      max-width: min(360px, calc(100vw - 40px));
+      align-items: center;
+      gap: 8px;
+      padding: 10px 12px;
+      border: 1px solid var(--line-strong);
+      border-left: 3px solid var(--success);
+      border-radius: 8px;
+      color: var(--ink);
+      background: var(--surface-raised);
+      box-shadow: var(--shadow-float);
+      font-size: 10px;
+      opacity: 0;
+      transform: translateY(8px);
+      pointer-events: none;
+      transition: opacity 150ms ease, transform 150ms ease;
+    }
+    .toast.visible { opacity: 1; transform: translateY(0); }
+    .toast i { color: var(--success); font-style: normal; font-weight: 800; }
+
+    .visually-hidden { position: absolute !important; width: 1px !important; height: 1px !important; padding: 0 !important; overflow: hidden !important; clip: rect(0, 0, 0, 0) !important; white-space: nowrap !important; border: 0 !important; }
+    [hidden] { display: none !important; }
+
+    @media (max-width: 1180px) {
+      :root { --inspector-width: 260px; }
+      .member-row { grid-template-columns: 32px minmax(0, 1fr) 28px; }
+      .member-state { grid-column: 2; grid-row: 2; display: flex; align-items: center; justify-content: space-between; gap: 7px; }
+      .member-menu-wrap { grid-column: 3; grid-row: 1 / span 2; }
+      .members-summary-actions { align-items: flex-end; flex-direction: column; }
+    }
+
+    @media (max-width: 1100px) {
+      body { padding: 0; }
+      .prototype-heading { display: none; }
+      .variant-bar { margin: 0; border-width: 0 0 1px; border-radius: 0; }
+      .scenario-bar { margin: 0; border-width: 0 0 1px; border-radius: 0; }
+      .app-window { height: calc(100vh - 100px); min-height: 540px; border-width: 0; border-radius: 0; }
+    }
+
+    @media (max-width: 860px) {
+      .app-window { grid-template-columns: minmax(0, 1fr); }
+      .app-rail, .conversation { display: none; }
+      .camp-body { grid-template-columns: minmax(0, 1fr); }
+      .inspector { border-left: 0; }
+      .members-summary-actions { align-items: center; flex-direction: row; }
+    }
+
+    @media (max-width: 560px) {
+      .variant-bar { grid-template-columns: minmax(0, 1fr); gap: 6px; }
+      .variant-label { display: none; }
+      .variant-note { padding: 0 3px; }
+      .variant-choice { min-height: 34px; padding: 3px 5px; }
+      .variant-choice-copy small { display: none; }
+      .scenario-label { display: none; }
+      .scenario-button { min-height: 30px; padding: 5px 7px; }
+      .dialog-card, .dialog-card.danger { width: calc(100vw - 16px); max-height: calc(100vh - 16px); }
+      .dialog-header, .dialog-body, .dialog-footer { padding-right: 12px; padding-left: 12px; }
+      .dialog-footer { align-items: flex-start; flex-direction: column; }
+      .dialog-footer-actions { width: 100%; margin-left: 0; }
+      .dialog-footer-actions button { flex: 1 1 0; }
+      .candidate-row { grid-template-columns: 18px 32px minmax(0, 1fr); }
+      .runtime-state { grid-column: 3; justify-self: start; }
+      .candidate-error { margin-left: 59px; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { scroll-behavior: auto !important; animation-duration: .01ms !important; animation-iteration-count: 1 !important; transition-duration: .01ms !important; }
+    }
+    @media (hover: none) {
+      body[data-action-style="hover"] .member-action { opacity: .74; }
+    }
+  </style>
+</head>
+<body data-action-style="horizontal">
+  <main class="prototype-shell">
+    <header class="prototype-heading">
+      <div>
+        <p class="prototype-kicker">Camp roster · interaction review</p>
+        <h1>队员操作入口与移出确认</h1>
+        <p>本轮只比较成员行操作入口，并验证“有影响才显示”的移出确认信息。</p>
+      </div>
+      <div class="review-actions">
+        <button class="review-button" id="theme-toggle" type="button">切换 Steel Night</button>
+        <button class="review-button" id="reset-prototype" type="button">重置原型</button>
+      </div>
+    </header>
+
+    <section class="variant-bar" aria-label="成员操作入口方案">
+      <span class="variant-label">入口方案</span>
+      <div class="variant-options">
+        <button class="variant-choice" type="button" data-variant="horizontal" aria-pressed="true">
+          <span class="variant-choice-glyph" aria-hidden="true"><svg viewBox="0 0 16 16"><circle cx="3" cy="8" r="1.35"/><circle cx="8" cy="8" r="1.35"/><circle cx="13" cy="8" r="1.35"/></svg></span>
+          <span class="variant-choice-copy"><strong>A · 横向常显</strong><small>无框，最接近现有习惯</small></span>
+        </button>
+        <button class="variant-choice" type="button" data-variant="vertical" aria-pressed="false">
+          <span class="variant-choice-glyph" aria-hidden="true"><svg viewBox="0 0 16 16"><circle cx="8" cy="3" r="1.35"/><circle cx="8" cy="8" r="1.35"/><circle cx="8" cy="13" r="1.35"/></svg></span>
+          <span class="variant-choice-copy"><strong>B · 竖向常显</strong><small>更窄，偏表格操作语义</small></span>
+        </button>
+        <button class="variant-choice" type="button" data-variant="hover" aria-pressed="false">
+          <span class="variant-choice-glyph" aria-hidden="true"><svg viewBox="0 0 16 16"><circle cx="3" cy="8" r="1.35"/><circle cx="8" cy="8" r="1.35"/><circle cx="13" cy="8" r="1.35"/></svg></span>
+          <span class="variant-choice-copy"><strong>C · 行内渐显</strong><small>最安静，悬停或聚焦时显现</small></span>
+        </button>
+      </div>
+      <p class="variant-note" id="variant-note"><strong>推荐 A：</strong>常态没有边框，只有 hover、键盘聚焦或菜单展开时出现轻底色；可发现性与安静程度最平衡。</p>
+    </section>
+
+    <nav class="scenario-bar" aria-label="原型场景">
+      <span class="scenario-label">场景</span>
+      <button class="scenario-button" type="button" data-scenario="normal" aria-pressed="true">正常名册</button>
+      <button class="scenario-button" type="button" data-scenario="add" aria-pressed="false">添加多人</button>
+      <button class="scenario-button" type="button" data-scenario="partial" aria-pressed="false">部分失败</button>
+      <button class="scenario-button" type="button" data-scenario="remove-lead" aria-pressed="false">移出队长</button>
+      <button class="scenario-button" type="button" data-scenario="remove-clean" aria-pressed="false">移出无在途</button>
+      <button class="scenario-button" type="button" data-scenario="conflict" aria-pressed="false">版本冲突</button>
+      <button class="scenario-button" type="button" data-scenario="reconciling" aria-pressed="false">收敛中</button>
+      <button class="scenario-button" type="button" data-scenario="no-candidates" aria-pressed="false">无候选</button>
+      <button class="scenario-button" type="button" data-scenario="last-member" aria-pressed="false">仅一位队员</button>
+    </nav>
+
+    <section class="app-window" aria-label="Rovai AI Camp 队员管理原型">
+      <aside class="app-rail" aria-label="应用导航">
+        <div class="brand-lockup"><span class="brand-mark" aria-hidden="true"></span><strong>Rovai AI</strong></div>
+        <nav class="rail-primary" aria-label="主要页面">
+          <button class="rail-item" type="button"><span class="rail-icon">✦</span><span>快速对话</span></button>
+          <button class="rail-item" type="button"><span class="rail-icon">♙</span><span>队员</span></button>
+          <button class="rail-item" type="button"><span class="rail-icon">◇</span><span>记忆</span></button>
+        </nav>
+        <div class="rail-projects">
+          <div class="rail-section-heading"><span>项目</span><span>＋</span></div>
+          <button class="rail-item" type="button"><span class="rail-icon">⌘</span><span>rovai-ai</span><span>⌄</span></button>
+          <button class="rail-item rail-camp selected" type="button"><span></span><span>动态名册方案</span></button>
+          <button class="rail-item rail-camp" type="button"><span></span><span>Runtime 调试记录</span></button>
+        </div>
+        <div class="rail-footer"><span>●</span><span>Core 已连接 · 本地</span></div>
+      </aside>
+
+      <section class="camp-shell">
+        <header class="camp-header">
+          <div class="camp-title"><strong>动态名册方案</strong><small>Quick Chat · 当前会话</small></div>
+          <div class="camp-header-actions">
+            <button class="approval-summary" type="button"><i aria-hidden="true"></i><span>暂无待审批</span></button>
+            <button class="icon-button" type="button" aria-label="隐藏 Inspector">◫</button>
+          </div>
+        </header>
+
+        <div class="camp-body">
+          <main class="conversation">
+            <div class="timeline" aria-label="Camp 消息">
+              <article class="message">
+                <span class="message-avatar avatar small" style="--avatar-color: var(--identity-4)" aria-hidden="true">你</span>
+                <div class="message-meta"><strong>你</strong><time>10:24</time></div>
+                <p>看看这个方案里 Camp 动态增减队员的交互应该怎么做，先保持现有工作区的视觉语言。</p>
+              </article>
+              <article class="message">
+                <span class="message-avatar avatar small" style="--avatar-color: var(--identity-1)" aria-hidden="true">爱</span>
+                <div class="message-meta"><strong>爱丽丝</strong><time>10:26</time></div>
+                <p>我会把当前名册放在 Inspector 内处理：添加是普通结构操作；移出则先展示 Core 权威影响，再区分名册 cutover 和后续可靠收敛。</p>
+                <p>普通用户只看到“添加队员”，不需要理解底层是否复用了历史 membership。</p>
+                <span class="message-route">发送给 @奥黛丽</span>
+              </article>
+              <article class="message">
+                <span class="message-avatar avatar small" style="--avatar-color: var(--identity-6)" aria-hidden="true">奥</span>
+                <div class="message-meta"><strong>奥黛丽</strong><time>10:29</time></div>
+                <p>交互稿会保留现有队长选择器与 Runtime 摘要；查看模型信息和移出会话统一收进成员操作菜单。</p>
+              </article>
+            </div>
+            <section class="composer" aria-label="消息编辑器">
+              <div class="composer-route" id="composer-route"><span id="composer-route-copy">默认由队长 · 爱丽丝接收</span></div>
+              <div class="composer-box">
+                <label class="visually-hidden" for="composer-input">发送消息</label>
+                <textarea id="composer-input" placeholder="发送消息，使用 @ 指定队员…"></textarea>
+                <div class="composer-footer">
+                  <div class="composer-tools"><button type="button" aria-label="添加附件">＋</button><button type="button" aria-label="添加 Mention">＠</button></div>
+                  <button class="send-button" id="send-button" type="button">发送</button>
+                </div>
+              </div>
+            </section>
+          </main>
+
+          <aside class="inspector" aria-label="Camp Inspector">
+            <div class="inspector-tabs" role="tablist" aria-label="Inspector 页面">
+              <button class="inspector-tab" id="tasks-tab" type="button" role="tab" tabindex="-1" aria-selected="false" aria-controls="tasks-panel">任务 <small>2</small></button>
+              <button class="inspector-tab" id="members-tab" type="button" role="tab" tabindex="0" aria-selected="true" aria-controls="members-panel">队员 <small id="member-tab-count">3</small></button>
+            </div>
+            <section class="inspector-panel" id="tasks-panel" role="tabpanel" aria-labelledby="tasks-tab" hidden>
+              <div class="tasks-placeholder"><strong>任务责任面</strong><span>本原型只评审队员名册；任务页保持现有结构。</span></div>
+            </section>
+            <section class="inspector-panel" id="members-panel" role="tabpanel" aria-labelledby="members-tab">
+              <div class="members-summary">
+                <div class="members-summary-line">
+                  <div class="members-summary-title"><strong>协作队员</strong><small id="member-summary-count">3 位在队</small></div>
+                  <div class="members-summary-actions"><span class="scope-label">当前会话</span><button class="add-member-button" id="open-add-dialog" type="button"><span aria-hidden="true">＋</span> 添加</button></div>
+                </div>
+                <div class="lead-picker-wrap">
+                  <button class="lead-picker" id="lead-picker" type="button" aria-haspopup="menu" aria-expanded="false">
+                    <span id="lead-avatar"></span>
+                    <span class="lead-copy"><strong id="lead-name">队长 · 爱丽丝</strong><small id="lead-role">五号街卖花女</small></span>
+                    <svg class="chevron" aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><path d="m4 6 4 4 4-4"/></svg>
+                  </button>
+                  <div class="lead-menu" id="lead-menu" role="menu" aria-label="更换队长"></div>
+                </div>
+              </div>
+              <div id="reconciliation-host"></div>
+              <div id="member-content"></div>
+            </section>
+          </aside>
+        </div>
+      </section>
+    </section>
+  </main>
+
+  <dialog id="add-dialog" aria-labelledby="add-dialog-title">
+    <div class="dialog-card">
+      <header class="dialog-header">
+        <div><p class="dialog-eyebrow">CAMP ROSTER</p><h2 id="add-dialog-title">添加队员</h2><p id="add-dialog-description">加入「动态名册方案」；不会改变队员的长期配置。</p></div>
+        <button class="dialog-close" id="close-add-dialog" type="button" aria-label="关闭添加队员">×</button>
+      </header>
+      <div class="dialog-body">
+        <div class="dialog-alert" id="add-result-summary" role="status" hidden></div>
+        <label class="search-field"><span aria-hidden="true">⌕</span><input id="candidate-search" type="search" placeholder="搜索队员…" autocomplete="off"></label>
+        <div class="candidate-caption"><strong id="candidate-mode-label">可添加队员</strong><span id="candidate-count"></span></div>
+        <div class="candidate-list" id="candidate-list"></div>
+      </div>
+      <footer class="dialog-footer">
+        <span class="dialog-footer-copy" id="add-footer-copy">仅显示当前在队、尚未加入本会话的队员</span>
+        <div class="dialog-footer-actions"><button class="quiet-button" id="cancel-add" type="button">取消</button><button class="primary-button" id="confirm-add" type="button" disabled>添加队员</button></div>
+      </footer>
+    </div>
+  </dialog>
+
+  <dialog id="remove-dialog" aria-labelledby="remove-dialog-title">
+    <div class="dialog-card danger">
+      <header class="dialog-header">
+        <div><p class="dialog-eyebrow">CURRENT CAMP</p><h2 id="remove-dialog-title">移出当前会话？</h2><p id="remove-dialog-description">只影响当前会话，不会永久移除这位队员。</p></div>
+        <button class="dialog-close" id="close-remove-dialog" type="button" aria-label="关闭移出确认">×</button>
+      </header>
+      <div class="dialog-body" id="remove-dialog-body">
+        <div class="dialog-alert danger-alert" id="remove-conflict" role="alert" hidden>名册已发生变化。请刷新权威影响后再确认，本次没有移出任何队员。</div>
+        <div class="preview-loading" id="preview-loading" aria-label="正在读取移出影响"><div class="skeleton"></div><div class="skeleton"></div><div class="skeleton short"></div></div>
+        <div id="preview-content" hidden><ul class="impact-list" id="impact-list"></ul></div>
+      </div>
+      <footer class="dialog-footer">
+        <span class="dialog-footer-copy" id="remove-footer-copy">正在读取 Core 权威影响…</span>
+        <div class="dialog-footer-actions"><button class="quiet-button" id="cancel-remove" type="button">取消</button><button class="danger-button" id="confirm-remove" type="button" disabled>移出当前会话</button></div>
+      </footer>
+    </div>
+  </dialog>
+
+  <div class="toast" id="toast" role="status" aria-live="polite"><i>✓</i><span id="toast-copy"></span></div>
+
+  <script>
+    const profiles = [
+      { id: 'agent_6', name: '爱丽丝', initial: '爱', role: '五号街卖花女', presence: 'present', runtime: 'Codex · 可用', runtimeTone: 'ready', runtimeDetails: { model: 'gpt-5.3-codex', effortLabel: '推理强度', effort: '高', strategy: '固定模型' }, color: 'var(--identity-1)', tasks: 2, runs: 1, deliveries: 1, gathers: 1, unknown: true },
+      { id: 'agent_7', name: '雾切响子', initial: '雾', role: '超高校级的侦探', presence: 'present', runtime: 'Codex · 可用', runtimeTone: 'ready', runtimeDetails: { model: 'gpt-5.3-codex', effortLabel: '推理强度', effort: '高', strategy: '固定模型' }, color: 'var(--identity-2)', tasks: 3, runs: 1, deliveries: 2, gathers: 0, unknown: false },
+      { id: 'agent_8', name: '药师寺惠', initial: '惠', role: '机兵驾驶员 · 咲良高校学生', presence: 'away', runtime: 'Codex · 可用', runtimeTone: 'ready', runtimeDetails: { model: 'gpt-5.3-codex', effortLabel: '推理强度', effort: '中', strategy: '固定模型' }, color: 'var(--identity-3)', tasks: 0, runs: 0, deliveries: 0, gathers: 0, unknown: false },
+      { id: 'agent_9', name: '奥黛丽', initial: '奥', role: '正义小姐 · 观众途径', presence: 'present', runtime: 'Codex · 可用', runtimeTone: 'ready', runtimeDetails: { model: 'gpt-5.3-codex', effortLabel: '推理强度', effort: '高', strategy: '固定模型' }, color: 'var(--identity-6)', tasks: 0, runs: 0, deliveries: 0, gathers: 0, unknown: false },
+      { id: 'agent_10', name: '克莱恩', initial: '克', role: '愚者', presence: 'present', runtime: 'Claude · 可用', runtimeTone: 'ready', runtimeDetails: { model: 'claude-opus-4-1', effortLabel: '思考强度', effort: '高', strategy: '固定模型' }, color: 'var(--identity-4)', tasks: 0, runs: 0, deliveries: 0, gathers: 0, unknown: false },
+      { id: 'agent_11', name: '苏茜', initial: '苏', role: '心理学研究员', presence: 'present', runtime: 'Agent 运行时需配置', runtimeTone: 'attention', runtimeDetails: null, color: 'var(--identity-7)', tasks: 0, runs: 0, deliveries: 0, gathers: 0, unknown: false }
+    ];
+
+    const initialMemberIds = ['agent_6', 'agent_7', 'agent_8'];
+    let memberIds = [...initialMemberIds];
+    let leadId = 'agent_6';
+    let addSelection = new Set();
+    let candidateErrors = new Map();
+    let addBusy = false;
+    let nextAddOutcome = 'success';
+    let removeTargetId = null;
+    let removeBusy = false;
+    let removeOutcome = 'success';
+    let conflictVisible = false;
+    let reconciliation = null;
+    let reconciliationExpanded = false;
+    let reconciliationTimer = null;
+    let previewTimer = null;
+    let toastTimer = null;
+    let expandedRuntimeIds = new Set();
+    let activeScenario = 'normal';
+    let actionVariant = 'horizontal';
+
+    const actionVariantCopy = {
+      horizontal: '<strong>推荐 A：</strong>常态没有边框，只有 hover、键盘聚焦或菜单展开时出现轻底色；可发现性与安静程度最平衡。',
+      vertical: '<strong>方案 B：</strong>同样无框，竖向三点更窄、更像表格行操作；优点是利落，风险是会让列表稍偏管理后台。',
+      hover: '<strong>方案 C：</strong>横向三点在行内低强度渐显，视觉最安静；触控设备会保持可见，但桌面初次使用的可发现性略弱。'
+    };
+
+    const byId = (id) => profiles.find(profile => profile.id === id);
+    const activeProfiles = () => memberIds.map(byId).filter(Boolean);
+    const eligibleProfiles = () => profiles.filter(profile => profile.presence === 'present' && !memberIds.includes(profile.id));
+    const presentMembers = () => activeProfiles().filter(profile => profile.presence === 'present');
+    const avatar = (profile, small = false) => `<span class="avatar${small ? ' small' : ''}" style="--avatar-color: ${profile.color}" aria-hidden="true">${profile.initial}</span>`;
+    const delay = (milliseconds) => new Promise(resolve => setTimeout(resolve, milliseconds));
+
+    function moreGlyph(variant = actionVariant) {
+      if (variant === 'vertical') {
+        return '<svg viewBox="0 0 16 16" aria-hidden="true"><circle cx="8" cy="3" r="1.35"/><circle cx="8" cy="8" r="1.35"/><circle cx="8" cy="13" r="1.35"/></svg>';
+      }
+      return '<svg viewBox="0 0 16 16" aria-hidden="true"><circle cx="3" cy="8" r="1.35"/><circle cx="8" cy="8" r="1.35"/><circle cx="13" cy="8" r="1.35"/></svg>';
+    }
+
+    function setActionVariant(variant) {
+      actionVariant = variant;
+      document.body.dataset.actionStyle = variant;
+      document.querySelectorAll('[data-variant]').forEach(button => {
+        button.setAttribute('aria-pressed', String(button.dataset.variant === variant));
+      });
+      document.getElementById('variant-note').innerHTML = actionVariantCopy[variant];
+      closeMemberMenus();
+      renderMembers();
+    }
+
+    function impactGlyph(name) {
+      const paths = {
+        run: '<path d="m9.6 1.8-5.2 7h3.5l-.8 6.1 5.2-7H8.8Z"/>',
+        task: '<rect x="2.2" y="2.2" width="11.6" height="11.6" rx="2"/><path d="m4.8 8 2 2 4.4-4.5"/>',
+        message: '<path d="M2.2 3.2h11.6v8H7.5l-3.3 2.6v-2.6h-2Z"/><path d="M5 6.2h6M5 8.5h4"/>',
+        lead: '<circle cx="8" cy="5" r="2.5"/><path d="M3.2 13.8c.5-2.8 2.1-4.2 4.8-4.2s4.3 1.4 4.8 4.2"/>'
+      };
+      return `<svg viewBox="0 0 16 16" aria-hidden="true">${paths[name]}</svg>`;
+    }
+
+    function setScenario(name) {
+      activeScenario = name;
+      document.querySelectorAll('.scenario-button').forEach(button => {
+        button.setAttribute('aria-pressed', String(button.dataset.scenario === name));
+      });
+    }
+
+    function closeAllOverlays() {
+      clearTimeout(previewTimer);
+      document.getElementById('lead-menu').classList.remove('open');
+      document.getElementById('lead-picker').setAttribute('aria-expanded', 'false');
+      document.querySelectorAll('.member-menu.open').forEach(menu => menu.classList.remove('open'));
+      document.querySelectorAll('.member-action[aria-expanded="true"]').forEach(button => button.setAttribute('aria-expanded', 'false'));
+      ['add-dialog', 'remove-dialog'].forEach(id => {
+        const dialog = document.getElementById(id);
+        if (dialog.open) dialog.close();
+      });
+    }
+
+    function resetState({ keepScenario = false } = {}) {
+      closeAllOverlays();
+      clearTimeout(reconciliationTimer);
+      memberIds = [...initialMemberIds];
+      leadId = 'agent_6';
+      addSelection = new Set();
+      candidateErrors = new Map();
+      addBusy = false;
+      nextAddOutcome = 'success';
+      removeTargetId = null;
+      removeBusy = false;
+      removeOutcome = 'success';
+      conflictVisible = false;
+      reconciliation = null;
+      reconciliationExpanded = false;
+      expandedRuntimeIds = new Set();
+      if (!keepScenario) setScenario('normal');
+      renderAll();
+    }
+
+    function renderAll() {
+      renderMembers();
+      renderLead();
+      renderComposer();
+      renderReconciliation();
+    }
+
+    function renderLead() {
+      const picker = document.getElementById('lead-picker');
+      const lead = byId(leadId);
+      const eligible = presentMembers();
+      picker.disabled = eligible.length < 2;
+      document.getElementById('lead-avatar').innerHTML = lead ? avatar(lead, true) : '<span class="avatar small" aria-hidden="true">—</span>';
+      document.getElementById('lead-name').textContent = `队长 · ${lead?.name ?? '未设置'}`;
+      document.getElementById('lead-role').textContent = lead?.role ?? '名册状态暂不可用';
+      const menu = document.getElementById('lead-menu');
+      menu.innerHTML = `<div class="lead-menu-label">选择队长</div>${eligible.map(profile => `
+        <button class="lead-option${profile.id === leadId ? ' selected' : ''}" type="button" role="menuitemradio" aria-checked="${profile.id === leadId}" data-lead-id="${profile.id}">
+          ${avatar(profile, true)}
+          <span class="lead-option-copy"><strong>${profile.name}</strong><small>${profile.role} · 在队</small></span>
+          <span class="lead-check">${profile.id === leadId ? '✓' : ''}</span>
+        </button>`).join('')}`;
+      menu.querySelectorAll('[data-lead-id]').forEach(button => button.addEventListener('click', () => {
+        leadId = button.dataset.leadId;
+        menu.classList.remove('open');
+        picker.setAttribute('aria-expanded', 'false');
+        renderAll();
+        showToast(`已将队长更换为${byId(leadId).name}`);
+      }));
+    }
+
+    function renderMembers() {
+      const members = activeProfiles();
+      const presentCount = members.filter(profile => profile.presence === 'present').length;
+      const awayCount = members.length - presentCount;
+      document.getElementById('member-tab-count').textContent = String(members.length);
+      document.getElementById('member-summary-count').textContent = `${presentCount} 位在队${awayCount ? ` · ${awayCount} 位暂离` : ''}`;
+      const host = document.getElementById('member-content');
+      if (members.length === 0) {
+        host.innerHTML = '<p class="roster-invariant-error" role="alert">名册状态暂不可用：当前会话必须至少保留一位队员。请刷新后重试。</p>';
+        return;
+      }
+      host.innerHTML = `<div class="member-list" role="list" aria-label="会话队员列表">${members.map(profile => {
+        const present = profile.presence === 'present';
+        const runtimeOpen = expandedRuntimeIds.has(profile.id);
+        const runtimeDetailsId = `member-runtime-${profile.id}`;
+        const lastMember = members.length === 1;
+        return `
+          <article class="member-row" role="listitem">
+            <span class="member-avatar-wrap">${avatar(profile)}<i class="presence-dot${present ? '' : ' away'}" aria-hidden="true"></i></span>
+            <span class="member-copy">
+              <span class="member-name"><strong>${profile.name}</strong>${profile.id === leadId ? '<small class="lead-badge">队长</small>' : ''}</span>
+              <small>${profile.role}</small>
+            </span>
+            <span class="member-state${present ? '' : ' away'}"><strong>${present ? '在队' : '暂离'}</strong><small class="runtime-label ${profile.runtimeTone}">${profile.runtime}</small></span>
+            <span class="member-menu-wrap">
+              <button class="member-action" type="button" aria-label="${profile.name}的当前会话操作" aria-haspopup="menu" aria-expanded="false" data-member-action="${profile.id}">${moreGlyph()}</button>
+              <span class="member-menu" id="member-menu-${profile.id}" role="menu">${profile.runtimeDetails
+                ? `<button type="button" role="menuitem" data-runtime-menu="${profile.id}">${runtimeOpen ? '收起模型信息' : '查看模型信息'}</button><span class="member-menu-separator" role="separator"></span>`
+                : ''}${lastMember
+                ? `<button type="button" role="menuitem" aria-disabled="true" data-remove-disabled="${profile.id}"><span>移出当前会话</span><small>会话至少保留 1 位队员</small></button>`
+                : `<button type="button" role="menuitem" data-remove-id="${profile.id}">移出当前会话</button>`}</span>
+            </span>
+            ${profile.runtimeDetails && runtimeOpen ? `<dl class="runtime-detail" id="${runtimeDetailsId}" aria-label="${profile.name}的当前模型配置"><div><dt>模型</dt><dd>${profile.runtimeDetails.model}</dd></div><div><dt>${profile.runtimeDetails.effortLabel}</dt><dd>${profile.runtimeDetails.effort}</dd></div><div><dt>模型策略</dt><dd>${profile.runtimeDetails.strategy}</dd></div></dl>` : ''}
+          </article>`;
+      }).join('')}</div>`;
+      host.querySelectorAll('[data-runtime-menu]').forEach(button => button.addEventListener('click', () => {
+        const id = button.dataset.runtimeMenu;
+        if (expandedRuntimeIds.has(id)) expandedRuntimeIds.delete(id);
+        else expandedRuntimeIds.add(id);
+        renderMembers();
+        requestAnimationFrame(() => host.querySelector(`[data-member-action="${id}"]`)?.focus());
+      }));
+      host.querySelectorAll('[data-member-action]').forEach(button => button.addEventListener('click', event => {
+        event.stopPropagation();
+        const targetMenu = document.getElementById(`member-menu-${button.dataset.memberAction}`);
+        const opening = !targetMenu.classList.contains('open');
+        document.querySelectorAll('.member-menu.open').forEach(menu => menu.classList.remove('open'));
+        document.querySelectorAll('.member-action[aria-expanded="true"]').forEach(item => item.setAttribute('aria-expanded', 'false'));
+        targetMenu.classList.toggle('open', opening);
+        button.setAttribute('aria-expanded', String(opening));
+      }));
+      host.querySelectorAll('[data-remove-id]').forEach(button => button.addEventListener('click', () => openRemoveDialog(button.dataset.removeId)));
+      host.querySelectorAll('[data-remove-disabled]').forEach(button => button.addEventListener('click', () => showToast('当前会话至少保留 1 位队员')));
+    }
+
+    function renderComposer() {
+      const routeCopy = document.getElementById('composer-route-copy');
+      const input = document.getElementById('composer-input');
+      const send = document.getElementById('send-button');
+      routeCopy.textContent = leadId ? `默认由队长 · ${byId(leadId).name}接收` : '名册状态暂不可用';
+      input.disabled = !leadId;
+      input.placeholder = leadId ? '发送消息，使用 @ 指定队员…' : '请刷新名册状态后重试…';
+      send.disabled = !leadId;
+    }
+
+    function renderReconciliation() {
+      const host = document.getElementById('reconciliation-host');
+      if (!reconciliation) {
+        host.innerHTML = '';
+        return;
+      }
+      const state = reconciliation.state;
+      const tone = reconciliation.unknown ? 'attention' : state === 'settled' ? 'success' : '';
+      const title = state === 'settled' ? `${reconciliation.name}的移出操作已收敛` : '名册已更新，后台仍在收敛';
+      const copy = state === 'settled'
+        ? '相关运行与投递已取得可靠终态。'
+        : `${reconciliation.runs} 个运行正在停止 · ${reconciliation.deliveries} 个投递正在终态化`;
+      host.innerHTML = `
+        <section class="reconciliation ${tone}" role="status" aria-label="移出操作状态">
+          <span class="reconciliation-mark" aria-hidden="true">${state === 'settled' ? '✓' : '↻'}</span>
+          <span class="reconciliation-copy"><strong>${title}</strong><span>${copy}</span></span>
+          <button type="button" id="toggle-reconciliation" aria-expanded="${reconciliationExpanded}">${reconciliationExpanded ? '收起' : '查看影响'}</button>
+          ${reconciliationExpanded ? `<span class="reconciliation-detail">${reconciliation.unknown ? '部分外部操作可能已经发生，当前仍需确认。' : '公开消息、运行证据和历史均已保留；旧工作不会因再次添加而恢复。'}</span>` : ''}
+        </section>`;
+      document.getElementById('toggle-reconciliation').addEventListener('click', () => {
+        reconciliationExpanded = !reconciliationExpanded;
+        renderReconciliation();
+      });
+    }
+
+    function openAddDialog() {
+      closeMemberMenus();
+      addSelection = new Set();
+      candidateErrors = new Map();
+      addBusy = false;
+      document.getElementById('candidate-search').value = '';
+      document.getElementById('add-result-summary').hidden = true;
+      renderCandidateList();
+      document.getElementById('add-dialog').showModal();
+      requestAnimationFrame(() => document.getElementById('candidate-search').focus());
+    }
+
+    function renderCandidateList() {
+      const query = document.getElementById('candidate-search').value.trim().toLocaleLowerCase('zh-CN');
+      const candidates = eligibleProfiles();
+      const filtered = candidates.filter(profile => `${profile.name} ${profile.role} ${profile.runtime}`.toLocaleLowerCase('zh-CN').includes(query));
+      document.getElementById('add-dialog-title').textContent = '添加队员';
+      document.getElementById('add-dialog-description').textContent = '加入「动态名册方案」；不会改变队员的长期配置。';
+      document.getElementById('candidate-mode-label').textContent = '可添加队员';
+      document.getElementById('candidate-count').textContent = `${candidates.length} 位可选`;
+      const list = document.getElementById('candidate-list');
+      if (candidates.length === 0) {
+        list.innerHTML = `<div class="candidate-empty"><strong>所有在队队员都已加入当前会话</strong><p>暂离或永久移除的队员不会出现在这里。</p><button type="button" id="go-to-members">前往队员页</button></div>`;
+        document.getElementById('go-to-members').addEventListener('click', () => showToast('原型：将导航到全局队员页'));
+      } else if (filtered.length === 0) {
+        list.innerHTML = `<div class="candidate-empty"><strong>没有匹配的队员</strong><p>换一个名称、角色或 Agent 运行时关键词试试。</p></div>`;
+      } else {
+        list.innerHTML = filtered.map(profile => `
+          <div class="candidate-entry">
+            <label class="candidate-row">
+              <input type="checkbox" name="candidate" value="${profile.id}" ${addSelection.has(profile.id) ? 'checked' : ''} ${addBusy ? 'disabled' : ''}>
+              ${avatar(profile)}
+              <span class="candidate-copy"><strong>${profile.name}<small>${profile.role}</small></strong><small>${profile.runtime}</small></span>
+              <span class="runtime-state ${profile.runtimeTone}"><i aria-hidden="true"></i>${profile.runtimeTone === 'ready' ? '可用' : '需配置'}</span>
+            </label>
+            ${candidateErrors.has(profile.id) ? `<div class="candidate-error"><span>${candidateErrors.get(profile.id)}</span><button type="button" data-retry-candidate="${profile.id}">重试</button></div>` : ''}
+          </div>`).join('');
+        list.querySelectorAll('input[name="candidate"]').forEach(input => input.addEventListener('change', () => {
+          if (input.checked) addSelection.add(input.value);
+          else addSelection.delete(input.value);
+          candidateErrors.delete(input.value);
+          renderCandidateList();
+        }));
+        list.querySelectorAll('[data-retry-candidate]').forEach(button => button.addEventListener('click', event => {
+          event.preventDefault();
+          addSelection.add(button.dataset.retryCandidate);
+          candidateErrors.delete(button.dataset.retryCandidate);
+          nextAddOutcome = 'success';
+          renderCandidateList();
+        }));
+      }
+      const confirm = document.getElementById('confirm-add');
+      confirm.disabled = addBusy || addSelection.size === 0;
+      confirm.textContent = addBusy ? confirm.textContent : addSelection.size > 0 ? `添加 ${addSelection.size} 位队员` : '添加队员';
+      document.getElementById('add-footer-copy').textContent = '仅显示当前在队、尚未加入本会话的队员';
+    }
+
+    async function submitAdd() {
+      if (addBusy || addSelection.size === 0) return;
+      addBusy = true;
+      const selected = [...addSelection].filter(id => eligibleProfiles().some(profile => profile.id === id));
+      const failures = [];
+      let accepted = 0;
+      for (let index = 0; index < selected.length; index += 1) {
+        const confirm = document.getElementById('confirm-add');
+        confirm.textContent = `正在添加 ${index + 1} / ${selected.length}…`;
+        renderCandidateList();
+        await delay(430);
+        const id = selected[index];
+        const shouldFail = nextAddOutcome === 'partial' && index === selected.length - 1;
+        if (shouldFail) {
+          failures.push(id);
+          candidateErrors.set(id, '名册版本已变化，请使用新请求重试。');
+        } else {
+          memberIds.push(id);
+          addSelection.delete(id);
+          accepted += 1;
+          renderAll();
+        }
+      }
+      addBusy = false;
+      nextAddOutcome = 'success';
+      if (failures.length === 0) {
+        document.getElementById('add-dialog').close();
+        requestAnimationFrame(() => document.getElementById('open-add-dialog').focus());
+        showToast(`已添加 ${accepted} 位队员`);
+      } else {
+        addSelection = new Set(failures);
+        const summary = document.getElementById('add-result-summary');
+        summary.textContent = `已添加 ${accepted} 位，${failures.length} 位未添加。成功结果已保留。`;
+        summary.hidden = false;
+        renderCandidateList();
+      }
+    }
+
+    function openRemoveDialog(id, forcedOutcome = null) {
+      closeMemberMenus();
+      if (memberIds.length <= 1) {
+        showToast('当前会话至少保留 1 位队员');
+        return;
+      }
+      clearTimeout(previewTimer);
+      removeTargetId = id;
+      removeBusy = false;
+      conflictVisible = false;
+      if (forcedOutcome) removeOutcome = forcedOutcome;
+      const profile = byId(id);
+      document.getElementById('remove-dialog-title').textContent = `移出「${profile.name}」？`;
+      document.getElementById('remove-dialog-description').textContent = `只影响当前会话：移出后，${profile.name}将不再接收这里的新工作。`;
+      const conflict = document.getElementById('remove-conflict');
+      conflict.textContent = '名册已发生变化。请刷新权威影响后再确认，本次没有移出任何队员。';
+      conflict.hidden = true;
+      document.getElementById('remove-dialog-body').hidden = false;
+      document.getElementById('preview-loading').hidden = false;
+      document.getElementById('preview-content').hidden = true;
+      document.getElementById('remove-footer-copy').textContent = '正在读取 Core 权威影响…';
+      const confirm = document.getElementById('confirm-remove');
+      confirm.disabled = true;
+      confirm.textContent = '移出当前会话';
+      document.getElementById('remove-dialog').showModal();
+      previewTimer = setTimeout(() => renderRemovePreview(profile), 520);
+    }
+
+    function renderRemovePreview(profile) {
+      const others = presentMembers().filter(member => member.id !== profile.id);
+      const successor = others[0] ?? null;
+      const impacts = [];
+      if (profile.runs > 0) {
+        impacts.push({ icon: 'run', title: '已开始的执行', detail: `${profile.runs} 个执行将停止接收新写入，并在后台收拢。` });
+      }
+      if (profile.tasks > 0) {
+        impacts.push({ icon: 'task', title: '未完成任务', detail: `${profile.tasks} 个任务将释放负责人，回到待分配状态。` });
+      }
+      if (profile.deliveries + profile.gathers > 0) {
+        impacts.push({ icon: 'message', title: '消息与 Gather', detail: `${profile.deliveries} 个投递、${profile.gathers} 个 Gather 项将正式结算。` });
+      }
+      if (profile.id === leadId) {
+        impacts.push({ icon: 'lead', title: '队长职责', detail: successor ? `将交给${successor.name}。` : '剩余队员都处于暂离状态，会话将暂时没有队长。', tone: 'neutral' });
+      }
+      document.getElementById('impact-list').innerHTML = impacts.map(impact => `
+        <li class="impact-item"><span class="impact-mark ${impact.tone ?? ''}">${impactGlyph(impact.icon)}</span><span class="impact-copy"><strong>${impact.title}</strong><span>${impact.detail}</span></span></li>`).join('');
+      document.getElementById('preview-loading').hidden = true;
+      document.getElementById('preview-content').hidden = impacts.length === 0;
+      document.getElementById('remove-dialog-body').hidden = impacts.length === 0;
+      document.getElementById('remove-footer-copy').textContent = '提交后立即阻止该队员的新消息与工具写入。';
+      const confirm = document.getElementById('confirm-remove');
+      confirm.classList.remove('primary-button');
+      confirm.classList.add('danger-button');
+      confirm.disabled = profile.id === leadId && !successor;
+      if (confirm.disabled) document.getElementById('remove-footer-copy').textContent = '需要先指定一位可接任的在队成员';
+    }
+
+    async function submitRemove() {
+      if (removeBusy || !removeTargetId) return;
+      if (memberIds.length <= 1) {
+        document.getElementById('remove-dialog-body').hidden = false;
+        document.getElementById('remove-conflict').textContent = '名册已发生变化。当前会话至少保留 1 位队员，本次没有移出任何人。';
+        document.getElementById('remove-conflict').hidden = false;
+        document.getElementById('confirm-remove').disabled = true;
+        document.getElementById('remove-footer-copy').textContent = '请关闭并核对当前名册';
+        return;
+      }
+      if (removeOutcome === 'conflict' && !conflictVisible) {
+        conflictVisible = true;
+        document.getElementById('remove-dialog-body').hidden = false;
+        document.getElementById('remove-conflict').hidden = false;
+        const confirm = document.getElementById('confirm-remove');
+        confirm.classList.remove('danger-button');
+        confirm.classList.add('primary-button');
+        confirm.textContent = '刷新影响';
+        document.getElementById('remove-footer-copy').textContent = '本次没有移出任何队员';
+        return;
+      }
+      if (conflictVisible) {
+        conflictVisible = false;
+        removeOutcome = 'success';
+        document.getElementById('remove-dialog-body').hidden = false;
+        document.getElementById('remove-conflict').hidden = true;
+        document.getElementById('preview-loading').hidden = false;
+        document.getElementById('preview-content').hidden = true;
+        document.getElementById('confirm-remove').disabled = true;
+        document.getElementById('confirm-remove').textContent = '移出当前会话';
+        document.getElementById('remove-footer-copy').textContent = '正在刷新 Core 权威影响…';
+        previewTimer = setTimeout(() => renderRemovePreview(byId(removeTargetId)), 520);
+        return;
+      }
+      removeBusy = true;
+      const confirm = document.getElementById('confirm-remove');
+      confirm.disabled = true;
+      confirm.textContent = '正在移出…';
+      document.getElementById('cancel-remove').disabled = true;
+      document.getElementById('close-remove-dialog').disabled = true;
+      await delay(720);
+      if (memberIds.length <= 1) {
+        removeBusy = false;
+        document.getElementById('remove-dialog-body').hidden = false;
+        document.getElementById('cancel-remove').disabled = false;
+        document.getElementById('close-remove-dialog').disabled = false;
+        document.getElementById('remove-conflict').textContent = '名册已发生变化。当前会话至少保留 1 位队员，本次没有移出任何人。';
+        document.getElementById('remove-conflict').hidden = false;
+        document.getElementById('remove-footer-copy').textContent = '请关闭并核对当前名册';
+        return;
+      }
+      const profile = byId(removeTargetId);
+      memberIds = memberIds.filter(id => id !== removeTargetId);
+      expandedRuntimeIds.delete(removeTargetId);
+      if (leadId === removeTargetId) leadId = presentMembers()[0]?.id ?? null;
+      const hasPending = profile.runs > 0 || profile.deliveries > 0 || profile.gathers > 0;
+      reconciliation = hasPending ? { name: profile.name, runs: profile.runs, deliveries: profile.deliveries, unknown: profile.unknown, state: 'pending', hold: false } : null;
+      reconciliationExpanded = false;
+      removeTargetId = null;
+      removeBusy = false;
+      document.getElementById('cancel-remove').disabled = false;
+      document.getElementById('close-remove-dialog').disabled = false;
+      document.getElementById('remove-dialog').close();
+      renderAll();
+      requestAnimationFrame(() => document.getElementById('open-add-dialog').focus());
+      if (hasPending) startReconciliationTimer();
+      else showToast(`已从当前会话移出${profile.name}`);
+    }
+
+    function startReconciliationTimer() {
+      clearTimeout(reconciliationTimer);
+      if (!reconciliation || reconciliation.hold || reconciliation.unknown) return;
+      reconciliationTimer = setTimeout(() => {
+        if (!reconciliation) return;
+        reconciliation.state = 'settled';
+        renderReconciliation();
+        showToast(`${reconciliation.name}的移出操作已完成`);
+      }, 3600);
+    }
+
+    function closeMemberMenus() {
+      document.querySelectorAll('.member-menu.open').forEach(menu => menu.classList.remove('open'));
+      document.querySelectorAll('.member-action[aria-expanded="true"]').forEach(button => button.setAttribute('aria-expanded', 'false'));
+    }
+
+    function showToast(message) {
+      clearTimeout(toastTimer);
+      document.getElementById('toast-copy').textContent = message;
+      const toast = document.getElementById('toast');
+      toast.classList.add('visible');
+      toastTimer = setTimeout(() => toast.classList.remove('visible'), 2600);
+    }
+
+    function runScenario(name) {
+      resetState({ keepScenario: true });
+      setScenario(name);
+      if (name === 'normal') return;
+      if (name === 'add' || name === 'partial') {
+        nextAddOutcome = name === 'partial' ? 'partial' : 'success';
+        openAddDialog();
+        addSelection = new Set(['agent_9', 'agent_10']);
+        renderCandidateList();
+        return;
+      }
+      if (name === 'remove-lead' || name === 'conflict') {
+        removeOutcome = name === 'conflict' ? 'conflict' : 'success';
+        openRemoveDialog('agent_6');
+        return;
+      }
+      if (name === 'remove-clean') {
+        openRemoveDialog('agent_8');
+        return;
+      }
+      if (name === 'reconciling') {
+        memberIds = memberIds.filter(id => id !== 'agent_7');
+        reconciliation = { name: '雾切响子', runs: 1, deliveries: 2, unknown: false, state: 'pending', hold: true };
+        renderAll();
+        return;
+      }
+      if (name === 'no-candidates') {
+        memberIds = profiles.map(profile => profile.id);
+        leadId = 'agent_6';
+        renderAll();
+        openAddDialog();
+        return;
+      }
+      if (name === 'last-member') {
+        memberIds = ['agent_6'];
+        leadId = 'agent_6';
+        expandedRuntimeIds = new Set();
+        renderAll();
+        requestAnimationFrame(() => {
+          const action = document.querySelector('[data-member-action="agent_6"]');
+          action?.click();
+          action?.focus();
+        });
+      }
+    }
+
+    document.getElementById('theme-toggle').addEventListener('click', () => {
+      const next = document.documentElement.dataset.theme === 'night' ? 'day' : 'night';
+      document.documentElement.dataset.theme = next;
+      document.getElementById('theme-toggle').textContent = next === 'night' ? '切换 Porcelain Day' : '切换 Steel Night';
+    });
+    document.getElementById('reset-prototype').addEventListener('click', () => resetState());
+    document.querySelectorAll('[data-variant]').forEach(button => button.addEventListener('click', () => setActionVariant(button.dataset.variant)));
+    document.querySelectorAll('.scenario-button').forEach(button => button.addEventListener('click', () => runScenario(button.dataset.scenario)));
+    document.getElementById('open-add-dialog').addEventListener('click', openAddDialog);
+    document.getElementById('candidate-search').addEventListener('input', renderCandidateList);
+    document.getElementById('confirm-add').addEventListener('click', submitAdd);
+    document.getElementById('cancel-add').addEventListener('click', () => !addBusy && document.getElementById('add-dialog').close());
+    document.getElementById('close-add-dialog').addEventListener('click', () => !addBusy && document.getElementById('add-dialog').close());
+    document.getElementById('confirm-remove').addEventListener('click', submitRemove);
+    document.getElementById('cancel-remove').addEventListener('click', () => !removeBusy && document.getElementById('remove-dialog').close());
+    document.getElementById('close-remove-dialog').addEventListener('click', () => !removeBusy && document.getElementById('remove-dialog').close());
+    document.getElementById('lead-picker').addEventListener('click', event => {
+      event.stopPropagation();
+      const menu = document.getElementById('lead-menu');
+      const opening = !menu.classList.contains('open');
+      menu.classList.toggle('open', opening);
+      event.currentTarget.setAttribute('aria-expanded', String(opening));
+    });
+    function selectInspectorTab(name, focus = false) {
+      const tasksSelected = name === 'tasks';
+      const tasksTab = document.getElementById('tasks-tab');
+      const membersTab = document.getElementById('members-tab');
+      tasksTab.setAttribute('aria-selected', String(tasksSelected));
+      membersTab.setAttribute('aria-selected', String(!tasksSelected));
+      tasksTab.tabIndex = tasksSelected ? 0 : -1;
+      membersTab.tabIndex = tasksSelected ? -1 : 0;
+      document.getElementById('tasks-panel').hidden = !tasksSelected;
+      document.getElementById('members-panel').hidden = tasksSelected;
+      if (focus) (tasksSelected ? tasksTab : membersTab).focus();
+    }
+    document.getElementById('tasks-tab').addEventListener('click', () => selectInspectorTab('tasks'));
+    document.getElementById('members-tab').addEventListener('click', () => selectInspectorTab('members'));
+    document.querySelector('.inspector-tabs').addEventListener('keydown', event => {
+      if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+      event.preventDefault();
+      const goToTasks = event.key === 'ArrowLeft' || event.key === 'Home';
+      selectInspectorTab(goToTasks ? 'tasks' : 'members', true);
+    });
+    document.addEventListener('click', event => {
+      if (!event.target.closest('.member-menu-wrap')) closeMemberMenus();
+      if (!event.target.closest('.lead-picker-wrap')) {
+        document.getElementById('lead-menu').classList.remove('open');
+        document.getElementById('lead-picker').setAttribute('aria-expanded', 'false');
+      }
+    });
+    document.addEventListener('keydown', event => {
+      if (event.key === 'Escape') {
+        closeMemberMenus();
+        document.getElementById('lead-menu').classList.remove('open');
+        document.getElementById('lead-picker').setAttribute('aria-expanded', 'false');
+      }
+    });
+    ['add-dialog', 'remove-dialog'].forEach(id => document.getElementById(id).addEventListener('cancel', event => {
+      if ((id === 'add-dialog' && addBusy) || (id === 'remove-dialog' && removeBusy)) event.preventDefault();
+    }));
+
+    renderAll();
+  </script>
+</body>
+</html>

--- a/docs/prototypes/execution-tool-grouping/PROJECT_DESIGN.md
+++ b/docs/prototypes/execution-tool-grouping/PROJECT_DESIGN.md
@@ -1,0 +1,83 @@
+---
+document_type: prototype-design-input
+status: design-review
+last_updated: 2026-08-25
+---
+
+# 连续 Tool 聚合设计输入
+
+## Job and mode
+
+Operate 模式。用户在长时间 AgentRun 中首先要确认“现在正在做什么、有没有异常”，只有审计或排错时
+才需要查看全部 Tool 和单条完整结果。聚合必须降低默认信息密度，同时保留准确 chronology、状态、
+公开证据与既有恢复动作。
+
+## 还原基线
+
+本稿把生产 Renderer 视为母版，只替换连续 Tool 段的呈现节点：
+
+- App Shell 保持 `270px rail / 50px top row / flexible workspace`；
+- 底部 placement 保留右侧普通 Inspector，主列依次承载会话、Run Pulse、同一个 ExecutionDrawer 与 Composer；
+- 右侧 placement 从底部移除 Run Pulse 和 Drawer，在既有 `310px / compact 260px` Inspector 中增加首个
+  “执行”Tab，并移动同一个 Drawer DOM；
+- Drawer header、Agent 入口、Run stage、Tool 四轨、证据 surface、Day/Night 与状态色均沿用生产结构；
+- 评审控制条属于原型外壳，不进入生产 Renderer。
+
+## 三个方案
+
+| 方案 | 活动态 | 终态 | 取舍 |
+| --- | --- | --- | --- |
+| A 当前操作（推荐） | `执行中 · {currentCommand}`，末尾低强调度显示已完成数量 | `已执行 N 项操作 · 全部成功/1 项失败` | 与现有单条 Tool 四轨最接近；底部和窄 Inspector 都能先读到当前命令 |
+| B 状态账本 | 第一行状态与计数，第二行完整视觉省略命令 | 第二行显示真实 Tool 类型构成 | 进度与构成更明确，但每组更高、长 Run 中更占空间 |
+| C 最近轨迹 | 第一行当前命令，第二行最近三项轨迹 | 最近轨迹保留到组关闭前 | 监督感最强；在 Inspector 中最吵，适合作为比较上限而非默认 |
+
+推荐 A。它把用户最关心的当前动作放在唯一标题轨，状态点与 disclosure 仍处于生产四轨位置；计数是
+辅助信息，310px Inspector 中可以先隐藏计数而不牺牲当前命令。
+
+## Grouping semantics
+
+- 输入是既有 `ExecutionProgressItem[]` 有序 Renderer 投影。
+- 每个最大连续 `kind=tool` 序列派生一个 `ToolActivityGroup` 展示节点。
+- narration、plan、diagnostic、公开 failure、recovery blocker 和 Run 边界终止当前组。
+- 派生组 key 由首尾 canonical Tool key 组成；不生成 Core ID，不合并 Tool lifecycle。
+- 活动态选择最后一条 `running` 或 `waiting` Tool；没有非终态 Tool 时按真实 outcome 汇总。
+
+## Interaction contract
+
+- Tool 组默认关闭；summary 点击或键盘激活后展开该组全部 Tool 行。
+- 每条 Tool 仍保持 `16px 类型图标 / minmax(0, 1fr) 标题 / 16px 状态 / 20px disclosure`。
+- 展开组不批量展开或读取结果；单条 Tool disclosure 仍是第二层，完整结果按既有边界按需出现。
+- 用户手动打开组后，新 Tool 只原位追加并更新 summary，不自动折叠、不抢焦点。
+- Run 终态不自动关闭用户已经打开的组。
+- 组内存在 running / waiting Tool 时，组 summary 承担活动反馈，不在下面重复“正在处理”。
+- 组结束而父 Run 继续时，通用处理行重新出现。
+- 位置切换移动同一个 Drawer DOM，保留组、Tool 与结果 disclosure；结果 Escape 返回精确 Tool summary。
+
+## 状态文案
+
+| 状态 | A 方案主文案 | 辅助信息 |
+| --- | --- | --- |
+| running | `执行中 · {currentTitle}` | `{completedCount} 项已完成` |
+| waiting | `等待审批 · {currentTitle}` | `{completedCount} 项已完成` |
+| completed | `已执行 {totalCount} 项操作` | `全部成功` |
+| failed | `已执行 {totalCount} 项操作` | `{failedCount} 项失败` |
+| stopped | `已执行 {totalCount} 项操作` | `{stoppedCount} 项已停止` |
+| recorded | `已记录 {totalCount} 项操作` | 不推断成功 |
+
+纯 Shell 组在生产实现时可以将终态收束为“运行了 N 条指令”，混合域继续使用“已执行 N 项操作”。
+
+## Layout, accessibility and performance
+
+- 底部 A 保持一行；Inspector 优先保留状态与当前命令，低优先计数可以隐藏。
+- 状态同时使用文字、颜色与非颜色形状；summary 使用原生 `details/summary` 名称计算。
+- 独立 polite live region 只播报新事件和模式变化，不把整组 summary 设为 live。
+- 结果区保持具名 `role=region`、键盘滚动与 Escape 返回语义。
+- 关闭组时其完整结果不参与可见布局；若用户展开组与超长结果后仍发生换位卡顿，再单独评估分块结果查看器。
+
+## Anti-goals
+
+- 不创建新 Core Process、Evidence schema、Tool identity 或持久化分组。
+- 不跨叙述、计划、诊断、Recovery、AgentRun 或队员合并。
+- 不用组展开代替 Tool 结果二次展开。
+- 不把失败、停止、等待审批或仅记录统一包装成“完成”。
+- 不借原型重做 App Shell、Inspector、Drawer 或 Rovai AI 视觉世界。

--- a/docs/prototypes/execution-tool-grouping/README.md
+++ b/docs/prototypes/execution-tool-grouping/README.md
@@ -1,0 +1,51 @@
+---
+document_type: ui-prototype-readme
+status: design-review
+last_updated: 2026-08-25
+---
+
+# 执行台连续 Tool 聚合交互稿
+
+这是一份生产实现前的高还原度 HTML 交互稿。它以当前 Camp Workspace、Inspector、Run Pulse、
+ExecutionDrawer、Run stage 与 Tool 四轨为母版，只比较“最大连续 Tool 序列”如何收束为一条可展开摘要。
+
+## 查看
+
+直接打开 `index.html`，或从仓库根目录运行：
+
+```text
+python3 -m http.server 4173 --directory docs/prototypes/execution-tool-grouping
+```
+
+然后访问 `http://127.0.0.1:4173/`。
+
+## 可评审交互
+
+- 切换 A 当前操作、B 状态账本、C 最近轨迹；
+- 切换运行中、全部完成、存在失败与等待审批；
+- 点击“推进一步”，观察当前命令和计数原位更新；
+- 在底部与右侧之间移动同一个 ExecutionDrawer；
+- 切换 Porcelain Day / Steel Night；
+- 点击连续 Tool 组查看全部 Tool 行，再单独展开某条 Tool 的完整公开结果；
+- 在结果区按 Escape 返回对应 Tool summary；
+- 收起 Drawer 后，从奥黛丽的 Agent 过程入口重新打开。
+
+## 评审重点
+
+1. **A 是否足够**：折叠时能否立刻回答“现在在做什么”，终态能否诚实表达成功与异常。
+2. **展开层级是否自然**：组 summary → 全部 Tool 行 → 单条完整结果三层是否符合审计心智。
+3. **右侧是否仍可扫读**：310px / compact 260px Inspector 是否优先保留当前命令和状态。
+4. **位置切换是否可信**：底部仍保留普通 Inspector；右侧只在既有 Inspector 增加“执行”Tab，不生成第二套执行台。
+
+## 冻结边界
+
+- 分组只发生在 Renderer，并且只聚合同一 Run 内最大连续 Tool 序列；
+- narration、plan、diagnostic、公开 failure 与 recovery blocker 会切断组；
+- 展开组不批量读取或挂载完整结果；
+- 失败、停止、等待审批和仅记录不能被“已完成”掩盖；
+- 示例数据仅用于交互评审，不代表 Runtime 或 Core 能力。
+
+## 文件
+
+- `index.html`：自包含、高还原、双主题、底部/右侧可切换的交互稿；
+- `PROJECT_DESIGN.md`：方案比较、生产映射、状态文案与交互边界。

--- a/docs/prototypes/execution-tool-grouping/index.html
+++ b/docs/prototypes/execution-tool-grouping/index.html
@@ -1,0 +1,1579 @@
+<!doctype html>
+<html lang="zh-CN" data-theme="day">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Rovai AI · 连续 Tool 聚合交互稿</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --canvas: #eceeef;
+      --surface: #fbfbfa;
+      --surface-raised: #ffffff;
+      --surface-subtle: #f0f2f4;
+      --surface-muted: #e7eaed;
+      --surface-selected: #e9ecee;
+      --surface-hover: #e8eaea;
+      --surface-sunken: #e4e8eb;
+      --conversation-surface: #ffffff;
+      --inspector-surface: #ffffff;
+      --conversation-inspector-line: #c7cfd6;
+      --ink: #171b20;
+      --muted: #616a73;
+      --faint: #6e7382;
+      --line: #dfe4e8;
+      --line-strong: #c7cfd6;
+      --control-line: #8b9389;
+      --rail: #f3f4f4;
+      --rail-ink: #626b72;
+      --rail-line: #dadde0;
+      --rail-logo: #526f88;
+      --brand: #526f88;
+      --brand-hover: #3d5874;
+      --brand-soft: #e9eef3;
+      --brand-ink: #405f7e;
+      --ember: #d3a45f;
+      --success: #3e775c;
+      --success-soft: #e7f1ea;
+      --attention: #8a6226;
+      --attention-soft: #f8edda;
+      --danger: #a24c46;
+      --danger-soft: #f7e6e3;
+      --info: #416c86;
+      --info-soft: #e5eef3;
+      --neutral: #5f6678;
+      --neutral-soft: #ecefe9;
+      --focus: #526f88;
+      --focus-soft: rgba(82, 111, 136, .16);
+      --identity-1: #a65f4a;
+      --identity-2: #39777a;
+      --identity-3: #74628f;
+      --identity-4: #9a6a32;
+      --evidence-canvas: #f4f6f3;
+      --evidence-ink: #252a36;
+      --evidence-muted: #5f6678;
+      --evidence-line: #d5dad3;
+      --shadow-float: 0 18px 56px rgba(38, 45, 58, .14);
+      --rail-width: 270px;
+      --inspector-width: 310px;
+      --sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", "PingFang SC", "Segoe UI", sans-serif;
+      --mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    }
+
+    :root[data-theme="night"] {
+      color-scheme: dark;
+      --canvas: #0d1114;
+      --surface: #151a1e;
+      --surface-raised: #1b2227;
+      --surface-subtle: #1a2024;
+      --surface-muted: #242d33;
+      --surface-selected: #222c33;
+      --surface-hover: #1d252b;
+      --surface-sunken: #10161a;
+      --conversation-surface: #181d21;
+      --inspector-surface: #171d21;
+      --conversation-inspector-line: #53616b;
+      --ink: #e7ecef;
+      --muted: #abb5bc;
+      --faint: #919da6;
+      --line: #333e46;
+      --line-strong: #53616b;
+      --control-line: #687b88;
+      --rail: #11161a;
+      --rail-ink: #a6b1b8;
+      --rail-line: #313b43;
+      --rail-logo: #b1c8d8;
+      --brand: #7897ae;
+      --brand-hover: #b1c8d8;
+      --brand-soft: #22303a;
+      --brand-ink: #c0d4e1;
+      --ember: #d2aa72;
+      --success: #82b695;
+      --success-soft: #1a2b22;
+      --attention: #d2ac70;
+      --attention-soft: #302719;
+      --danger: #d6857f;
+      --danger-soft: #321e1d;
+      --info: #83afc9;
+      --info-soft: #182832;
+      --neutral: #abb5bc;
+      --neutral-soft: #242d33;
+      --focus: #8fb3cb;
+      --focus-soft: rgba(143, 179, 203, .18);
+      --identity-1: #c98572;
+      --identity-2: #70b0ae;
+      --identity-3: #a89ac8;
+      --identity-4: #d0a46c;
+      --evidence-canvas: #12191d;
+      --evidence-ink: #dce4e9;
+      --evidence-muted: #9eabb3;
+      --evidence-line: #35424a;
+      --shadow-float: 0 22px 64px rgba(0, 0, 0, .42);
+    }
+
+    * { box-sizing: border-box; }
+    [hidden] { display: none !important; }
+    html, body { width: 100%; height: 100%; min-width: 320px; margin: 0; }
+    body {
+      display: flex;
+      overflow: hidden;
+      flex-direction: column;
+      color: var(--ink);
+      background: var(--canvas);
+      font-family: var(--sans);
+      font-size: 13px;
+      line-height: 1.6;
+      text-rendering: optimizeLegibility;
+    }
+    button, input { color: inherit; font: inherit; }
+    button:active:not(:disabled) { transform: translateY(1px); }
+    :where(button, summary, [tabindex]):focus-visible {
+      outline: 2px solid var(--focus);
+      outline-offset: 2px;
+    }
+    ::selection { color: var(--ink); background: var(--focus-soft); }
+    * { scrollbar-color: var(--control-line) transparent; scrollbar-width: thin; }
+    code, pre { font-family: var(--mono); }
+    .sr-only {
+      position: absolute !important;
+      width: 1px !important;
+      height: 1px !important;
+      margin: -1px !important;
+      overflow: hidden !important;
+      clip: rect(0, 0, 0, 0) !important;
+      white-space: nowrap !important;
+    }
+    .icon {
+      display: block;
+      width: 100%;
+      height: 100%;
+      fill: none;
+      stroke: currentColor;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-width: 1.45;
+      vector-effect: non-scaling-stroke;
+    }
+
+    .prototype-bar {
+      position: relative;
+      z-index: 20;
+      display: flex;
+      min-height: 54px;
+      flex: 0 0 auto;
+      align-items: center;
+      gap: 14px;
+      padding: 7px 14px;
+      border-bottom: 1px solid var(--line-strong);
+      background: var(--surface-raised);
+    }
+    .prototype-heading {
+      display: grid;
+      min-width: 208px;
+      gap: 1px;
+    }
+    .prototype-heading strong { font-size: 12.5px; letter-spacing: -.01em; }
+    .prototype-heading span { color: var(--faint); font-size: 9.5px; line-height: 1.35; }
+    .prototype-controls {
+      display: flex;
+      min-width: 0;
+      flex: 1 1 auto;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 7px;
+    }
+    .prototype-field { display: inline-flex; align-items: center; gap: 5px; }
+    .prototype-field > span { color: var(--faint); font-size: 9.5px; white-space: nowrap; }
+    .segments {
+      display: inline-flex;
+      min-height: 30px;
+      align-items: center;
+      gap: 2px;
+      padding: 2px;
+      border: 1px solid var(--line-strong);
+      border-radius: 6px;
+      background: var(--surface-subtle);
+    }
+    .segments button, .advance-button {
+      min-height: 24px;
+      border: 0;
+      border-radius: 5px;
+      background: transparent;
+      cursor: pointer;
+      font-size: 10px;
+      font-weight: 680;
+      white-space: nowrap;
+    }
+    .segments button { padding: 0 7px; color: var(--muted); }
+    .segments button:hover { color: var(--ink); background: var(--surface-hover); }
+    .segments button[aria-pressed="true"] {
+      color: var(--brand-ink);
+      background: var(--surface-raised);
+      box-shadow: 0 1px 2px rgba(22, 30, 38, .08);
+    }
+    .segments button[data-variant="a"][aria-pressed="true"]::after {
+      display: inline-block;
+      width: 5px;
+      height: 5px;
+      margin-left: 5px;
+      border-radius: 50%;
+      background: var(--success);
+      content: "";
+      vertical-align: 1px;
+    }
+    .advance-button {
+      min-height: 30px;
+      padding: 0 9px;
+      color: var(--brand-ink);
+      background: var(--brand-soft);
+    }
+    .advance-button:hover:not(:disabled) { color: var(--brand-hover); }
+    .advance-button:disabled { color: var(--faint); cursor: default; opacity: .64; }
+
+    .prototype-stage { min-height: 0; flex: 1 1 auto; padding: 10px; }
+    .app-shell {
+      display: grid;
+      width: min(1500px, 100%);
+      height: 100%;
+      min-width: 0;
+      min-height: 0;
+      margin: 0 auto;
+      overflow: hidden;
+      grid-template-columns: var(--rail-width) minmax(0, 1fr);
+      grid-template-rows: 50px minmax(0, 1fr);
+      border: 1px solid var(--line-strong);
+      border-radius: 10px;
+      background: var(--conversation-surface);
+      box-shadow: var(--shadow-float);
+    }
+
+    .rail {
+      display: flex;
+      min-width: 0;
+      grid-column: 1;
+      grid-row: 1 / -1;
+      flex-direction: column;
+      border-right: 1px solid var(--rail-line);
+      color: var(--rail-ink);
+      background: var(--rail);
+    }
+    .rail-brand {
+      display: flex;
+      min-height: 50px;
+      align-items: center;
+      gap: 9px;
+      padding: 0 14px;
+      border-bottom: 1px solid var(--rail-line);
+    }
+    .traffic-lights { display: flex; align-items: center; gap: 5px; margin-right: 2px; }
+    .traffic-lights i { width: 8px; height: 8px; border-radius: 50%; background: var(--line-strong); }
+    .traffic-lights i:first-child { background: #e0645b; }
+    .traffic-lights i:nth-child(2) { background: #dca646; }
+    .traffic-lights i:nth-child(3) { background: #58a66c; }
+    .brand-mark { position: relative; width: 22px; height: 22px; flex: 0 0 22px; color: var(--rail-logo); }
+    .brand-mark .ember { fill: var(--ember); stroke: none; }
+    .rail-brand strong { min-width: 0; overflow: hidden; color: var(--ink); font-size: 12.5px; text-overflow: ellipsis; white-space: nowrap; }
+    .rail-body { min-height: 0; flex: 1 1 auto; overflow: auto; padding: 12px 9px; }
+    .rail-section { margin: 11px 9px 5px; color: var(--faint); font-size: 9.5px; font-weight: 740; letter-spacing: .06em; }
+    .rail-row {
+      position: relative;
+      display: flex;
+      min-height: 33px;
+      align-items: center;
+      gap: 9px;
+      padding: 0 9px;
+      border-radius: 6px;
+      color: var(--rail-ink);
+      font-size: 12px;
+    }
+    .rail-row svg { width: 15px; height: 15px; flex: 0 0 15px; }
+    .rail-row.is-selected { color: var(--brand-ink); background: var(--surface-selected); }
+    .rail-row.is-current::before {
+      position: absolute;
+      top: 6px;
+      bottom: 6px;
+      left: -9px;
+      width: 2px;
+      background: var(--brand);
+      content: "";
+    }
+    .rail-camp-dot { width: 6px; height: 6px; flex: 0 0 6px; border-radius: 50%; background: var(--identity-2); }
+    .rail-settings { margin: auto 9px 9px; border-top: 1px solid var(--rail-line); padding-top: 8px; }
+
+    .topbar {
+      display: flex;
+      min-width: 0;
+      grid-column: 2;
+      grid-row: 1;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 0 15px 0 18px;
+      border-bottom: 1px solid var(--line);
+      background: var(--surface);
+    }
+    .breadcrumbs { display: flex; min-width: 0; align-items: center; gap: 7px; }
+    .breadcrumbs span { color: var(--faint); font-size: 10.5px; }
+    .breadcrumbs strong { overflow: hidden; font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
+    .topbar-actions { display: flex; align-items: center; gap: 7px; }
+    .quiet-icon-button {
+      display: grid;
+      width: 28px;
+      height: 28px;
+      place-items: center;
+      border: 0;
+      border-radius: 6px;
+      color: var(--muted);
+      background: transparent;
+      cursor: pointer;
+    }
+    .quiet-icon-button:hover { color: var(--ink); background: var(--surface-hover); }
+    .quiet-icon-button svg { width: 16px; height: 16px; }
+    .approval-summary { color: var(--faint); font-size: 9.5px; }
+
+    .workspace {
+      display: grid;
+      min-width: 0;
+      min-height: 0;
+      grid-column: 2;
+      grid-row: 2;
+      grid-template-columns: minmax(0, 1fr) var(--inspector-width);
+      grid-template-rows: minmax(0, 1fr) auto;
+    }
+    .timeline-pane {
+      display: flex;
+      min-width: 0;
+      min-height: 0;
+      grid-column: 1;
+      grid-row: 1;
+      overflow: hidden;
+      flex-direction: column;
+      background: var(--conversation-surface);
+    }
+    .conversation-stage { position: relative; min-height: 0; flex: 1 1 auto; overflow: hidden; }
+    .conversation-tools {
+      position: absolute;
+      z-index: 3;
+      top: 9px;
+      right: 12px;
+      display: inline-flex;
+      gap: 2px;
+      padding: 2px;
+      border: 1px solid var(--line-strong);
+      border-radius: 7px;
+      background: var(--surface-raised);
+      box-shadow: var(--shadow-float);
+    }
+    .conversation-tools button {
+      min-height: 25px;
+      padding: 0 7px;
+      border: 0;
+      border-radius: 5px;
+      color: var(--muted);
+      background: transparent;
+      cursor: pointer;
+      font-size: 9.5px;
+      font-weight: 680;
+    }
+    .conversation-tools button[aria-pressed="true"] { color: var(--brand-ink); background: var(--brand-soft); }
+    .conversation-scroll { height: 100%; overflow: auto; padding: 24px 34px 30px; }
+    .conversation-track { display: grid; width: min(76ch, 100%); margin: 0 auto; gap: 24px; }
+    .day-divider { display: flex; align-items: center; gap: 12px; color: var(--faint); font: 9.5px/1.3 var(--mono); }
+    .day-divider::before, .day-divider::after { height: 1px; flex: 1 1 auto; background: var(--line); content: ""; }
+    .message { display: grid; min-width: 0; grid-template-columns: 28px minmax(0, 1fr); gap: 9px; }
+    .message-avatar {
+      display: grid;
+      width: 28px;
+      height: 28px;
+      place-items: center;
+      border: 1px solid color-mix(in srgb, var(--identity-2) 55%, var(--line));
+      border-radius: 50%;
+      color: var(--identity-2);
+      background: color-mix(in srgb, var(--identity-2) 8%, var(--surface-raised));
+      font-size: 10px;
+      font-weight: 760;
+    }
+    .message-body { min-width: 0; }
+    .message-meta { display: flex; align-items: baseline; gap: 7px; margin-bottom: 4px; }
+    .message-meta strong { font-size: 11.5px; }
+    .message-meta span, .message-meta time { color: var(--faint); font-size: 9.5px; }
+    .message p { max-width: 76ch; margin: 0; font-size: 12px; line-height: 1.68; }
+    .message-user { margin-left: auto; }
+    .message-user .message-avatar { color: var(--brand-ink); border-color: var(--brand); }
+    .message-user p { padding: 8px 10px; border-radius: 9px; background: var(--surface-subtle); }
+    .world-placeholder {
+      display: grid;
+      height: 100%;
+      place-items: center;
+      color: var(--faint);
+      background: var(--surface-subtle);
+      text-align: center;
+      font-size: 11px;
+    }
+
+    .composer-controls {
+      min-width: 0;
+      grid-column: 1;
+      grid-row: 2;
+      padding: 8px 16px 10px;
+      border-top: 1px solid var(--line);
+      background: var(--conversation-surface);
+    }
+    .composer-track { width: min(1040px, 100%); margin: 0 auto; }
+    .composer-route { min-height: 20px; padding-left: 2px; color: var(--faint); font-size: 9.5px; }
+    .composer-box {
+      display: grid;
+      min-height: 72px;
+      grid-template-rows: minmax(34px, 1fr) auto;
+      padding: 8px 9px 7px;
+      border: 1px solid var(--control-line);
+      border-radius: 10px;
+      background: var(--surface-raised);
+    }
+    .composer-placeholder { color: var(--faint); font-size: 11.5px; }
+    .composer-actions { display: flex; align-items: center; justify-content: space-between; }
+    .composer-actions svg { width: 16px; height: 16px; color: var(--muted); }
+    .send-button {
+      min-height: 28px;
+      padding: 0 11px;
+      border: 0;
+      border-radius: 6px;
+      color: #fff;
+      background: var(--brand);
+      font-size: 10.5px;
+      font-weight: 720;
+    }
+    :root[data-theme="night"] .send-button { color: #091116; }
+
+    .inspector {
+      display: flex;
+      min-width: 0;
+      min-height: 0;
+      grid-column: 2;
+      grid-row: 1 / span 2;
+      overflow: hidden;
+      flex-direction: column;
+      border-left: 1px solid var(--conversation-inspector-line);
+      background: var(--inspector-surface);
+    }
+    .inspector-tabs {
+      display: flex;
+      flex: 0 0 auto;
+      min-height: 38px;
+      align-items: stretch;
+      border-bottom: 1px solid var(--line);
+    }
+    .inspector-tabs button {
+      position: relative;
+      flex: 1 1 0;
+      border: 0;
+      color: var(--muted);
+      background: transparent;
+      cursor: pointer;
+      font-size: 10.5px;
+      font-weight: 680;
+    }
+    .inspector-tabs button small { margin-left: 3px; color: var(--faint); font-size: 8.5px; }
+    .inspector-tabs button[aria-selected="true"] { color: var(--ink); }
+    .inspector-tabs button[aria-selected="true"]::after {
+      position: absolute;
+      right: 8px;
+      bottom: 0;
+      left: 8px;
+      height: 2px;
+      background: var(--brand);
+      content: "";
+    }
+    .inspector-content { min-height: 0; flex: 1 1 auto; overflow: hidden; }
+    .inspector-panel { height: 100%; min-height: 0; overflow: auto; }
+    .task-panel { padding: 12px 11px; }
+    .panel-heading { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 9px; }
+    .panel-heading strong { font-size: 11.5px; }
+    .panel-heading span { color: var(--faint); font-size: 9px; }
+    .task-row {
+      display: grid;
+      min-height: 54px;
+      grid-template-columns: 10px minmax(0, 1fr);
+      gap: 8px;
+      padding: 8px 4px;
+      border-bottom: 1px solid var(--line);
+    }
+    .task-state { width: 7px; height: 7px; margin-top: 5px; border-radius: 50%; background: var(--attention); }
+    .task-row.is-complete .task-state { background: var(--success); }
+    .task-copy { display: grid; min-width: 0; gap: 2px; }
+    .task-copy strong { overflow: hidden; font-size: 10.5px; text-overflow: ellipsis; white-space: nowrap; }
+    .task-copy span { color: var(--faint); font-size: 9px; }
+    .member-panel { padding: 12px 11px; }
+    .member-row {
+      display: grid;
+      min-height: 48px;
+      grid-template-columns: 26px minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 8px;
+      border-bottom: 1px solid var(--line);
+    }
+    .member-avatar {
+      display: grid;
+      width: 26px;
+      height: 26px;
+      place-items: center;
+      border: 1px solid color-mix(in srgb, var(--member-color, var(--identity-2)) 55%, var(--line));
+      border-radius: 50%;
+      color: var(--member-color, var(--identity-2));
+      background: color-mix(in srgb, var(--member-color, var(--identity-2)) 8%, var(--surface-raised));
+      font-size: 9px;
+      font-weight: 760;
+    }
+    .member-copy { display: grid; min-width: 0; line-height: 1.35; }
+    .member-copy strong { overflow: hidden; font-size: 10.5px; text-overflow: ellipsis; white-space: nowrap; }
+    .member-copy span { color: var(--faint); font-size: 8.5px; }
+    .online-state { color: var(--success); font-size: 8.5px; }
+    .inspector-execution { display: flex; overflow: hidden; flex-direction: column; }
+    .inspector-meta {
+      flex: 0 0 auto;
+      overflow: hidden;
+      padding: 7px 10px;
+      border-top: 1px solid var(--line);
+      color: var(--faint);
+      font: 8.5px/1.35 var(--mono);
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .run-pulse {
+      display: grid;
+      min-height: 54px;
+      flex: 0 0 auto;
+      grid-template-columns: auto minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 10px;
+      padding: 8px 14px;
+      border-top: 2px solid var(--line-strong);
+      color: var(--muted);
+      background: var(--surface);
+      font-size: 10.5px;
+    }
+    .app-shell[data-placement="right"] #bottom-run-pulse { display: none; }
+    .run-pulse-heading { display: grid; min-width: 0; gap: 0; white-space: nowrap; }
+    .run-pulse-title { display: flex; align-items: center; gap: 6px; }
+    .run-pulse-title svg { width: 17px; height: 16px; color: var(--brand); }
+    .run-pulse-title strong { color: var(--brand-ink); font-size: 10px; letter-spacing: .05em; }
+    .run-pulse-heading small { margin-left: 23px; color: var(--faint); font: 8.5px/1.3 var(--mono); }
+    .run-pulse-list { display: flex; min-width: 0; gap: 5px; margin: 0; overflow: auto; padding: 0; list-style: none; }
+    .agent-chip {
+      display: grid;
+      min-width: 128px;
+      max-width: 180px;
+      min-height: 38px;
+      grid-template-columns: 24px minmax(0, 1fr) 12px;
+      align-items: center;
+      gap: 7px;
+      padding: 4px 7px;
+      border: 1px solid var(--line);
+      border-radius: 7px;
+      color: var(--ink);
+      background: var(--surface-raised);
+      text-align: left;
+      cursor: pointer;
+    }
+    .agent-chip.is-selected { border-color: var(--brand); background: var(--brand-soft); }
+    .agent-chip .member-avatar { width: 24px; height: 24px; }
+    .agent-chip strong { overflow: hidden; font-size: 10.5px; text-overflow: ellipsis; white-space: nowrap; }
+    .agent-chip-state { position: relative; display: grid; width: 12px; height: 24px; place-items: center; color: var(--success); }
+    .agent-chip-state::before { width: 7px; height: 7px; border: 1px solid currentColor; border-radius: 50%; background: currentColor; content: ""; }
+    .agent-chip-state.is-running { color: var(--info); }
+    .agent-chip-state.is-running::after {
+      position: absolute;
+      width: 11px;
+      height: 11px;
+      border: 1px solid currentColor;
+      border-radius: 50%;
+      content: "";
+      opacity: .38;
+    }
+    .agent-chip-state.is-waiting { color: var(--attention); }
+    .agent-chip-state.is-waiting::before { background: transparent; }
+    .placement-button {
+      display: inline-flex;
+      min-height: 30px;
+      align-items: center;
+      gap: 5px;
+      padding: 0 7px;
+      border: 0;
+      border-radius: 6px;
+      color: var(--muted);
+      background: transparent;
+      cursor: pointer;
+      font-size: 9.5px;
+      font-weight: 680;
+      white-space: nowrap;
+    }
+    .placement-button:hover { color: var(--ink); background: var(--surface-hover); }
+    .placement-button svg { width: 16px; height: 16px; }
+
+    .run-pulse-inspector {
+      min-height: 0;
+      grid-template-columns: minmax(0, 1fr) auto;
+      grid-template-rows: auto auto;
+      gap: 5px 8px;
+      padding: 7px 8px 6px;
+      border-top: 0;
+      border-bottom: 1px solid var(--line);
+      background: var(--inspector-surface);
+    }
+    .run-pulse-inspector .run-pulse-list {
+      display: grid;
+      max-height: 104px;
+      grid-column: 1 / -1;
+      grid-row: 2;
+      gap: 2px;
+      overflow-y: auto;
+    }
+    .run-pulse-inspector .agent-chip {
+      width: 100%;
+      min-width: 0;
+      max-width: none;
+      min-height: 36px;
+      border-color: transparent;
+      background: transparent;
+    }
+    .run-pulse-inspector .agent-chip.is-selected { border-color: var(--control-line); background: var(--brand-soft); }
+
+    .execution-drawer-host { min-width: 0; min-height: 0; }
+    .execution-drawer-host-bottom { display: contents; }
+    .execution-drawer-host-inspector { min-height: 0; flex: 1 1 auto; overflow: hidden; }
+    .execution-drawer {
+      position: relative;
+      display: grid;
+      min-width: 0;
+      min-height: 0;
+      max-height: min(320px, 38vh);
+      flex: 0 0 auto;
+      grid-template-rows: auto minmax(0, 1fr);
+      overflow: hidden;
+      border-top: 1px solid var(--line);
+      color: var(--ink);
+      background: var(--surface);
+    }
+    .execution-drawer.is-collapsed { display: none; }
+    .execution-resize-handle {
+      position: absolute;
+      z-index: 4;
+      top: 0;
+      right: 0;
+      left: 0;
+      height: 9px;
+    }
+    .execution-resize-handle::after {
+      position: absolute;
+      top: 2px;
+      left: 50%;
+      width: 34px;
+      height: 2px;
+      border-radius: 999px;
+      background: var(--control-line);
+      content: "";
+      opacity: .7;
+      transform: translateX(-50%);
+    }
+    .execution-drawer[data-placement="right"] {
+      height: 100%;
+      max-height: none;
+      border-top: 0;
+    }
+    .execution-drawer[data-placement="right"] .execution-resize-handle { display: none; }
+    .execution-drawer-header {
+      display: flex;
+      min-width: 0;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      padding: 11px 14px 8px;
+      border-bottom: 1px solid var(--line);
+      background: color-mix(in srgb, var(--surface) 96%, var(--brand-soft));
+    }
+    .execution-drawer-agent { display: flex; min-width: 0; align-items: center; gap: 8px; }
+    .execution-drawer-agent-copy { display: grid; min-width: 0; gap: 1px; }
+    .execution-title-line { display: flex; min-width: 0; align-items: baseline; gap: 7px; }
+    .execution-title-line h2 { overflow: hidden; margin: 0; font-size: 11.5px; text-overflow: ellipsis; white-space: nowrap; }
+    .execution-model { min-width: 0; overflow: hidden; color: var(--brand-ink); font: 600 9px/1.35 var(--mono); text-overflow: ellipsis; white-space: nowrap; }
+    .execution-drawer-agent-copy p { margin: 0; color: var(--faint); font-size: 8.5px; line-height: 1.4; }
+    .execution-actions { display: flex; flex: 0 0 auto; align-items: center; gap: 5px; }
+    .quiet-button {
+      min-height: 28px;
+      min-width: 44px;
+      padding: 0 8px;
+      border: 1px solid var(--control-line);
+      border-radius: 6px;
+      color: var(--muted);
+      background: transparent;
+      cursor: pointer;
+      font-size: 9.5px;
+      font-weight: 680;
+    }
+    .quiet-button:hover { color: var(--ink); background: var(--surface-hover); }
+    .quiet-button.danger { color: var(--danger); border-color: color-mix(in srgb, var(--danger) 56%, var(--line)); }
+    .execution-drawer-body { min-height: 0; overflow: auto; padding: 11px 14px 16px; overscroll-behavior: contain; }
+    .execution-process-timeline { position: relative; display: grid; margin: 0; padding: 0; list-style: none; }
+    .execution-process-timeline::before { position: absolute; top: 13px; bottom: 17px; left: 6px; width: 1px; background: var(--line-strong); content: ""; }
+    .execution-process-stage { position: relative; display: grid; min-width: 0; grid-template-columns: 14px minmax(0, 1fr); gap: 9px; padding-bottom: 12px; }
+    .execution-process-node {
+      position: relative;
+      z-index: 1;
+      display: grid;
+      width: 13px;
+      height: 13px;
+      margin-top: 4px;
+      place-items: center;
+      border: 2px solid var(--info);
+      border-radius: 50%;
+      background: var(--info-soft);
+    }
+    .execution-process-node::after { width: 4px; height: 4px; border-radius: 50%; background: var(--info); content: ""; }
+    .execution-process-card { min-width: 0; padding: 9px 10px; border: 1px solid color-mix(in srgb, var(--info) 50%, var(--line)); border-radius: 8px; background: color-mix(in srgb, var(--surface-raised) 88%, var(--info-soft)); }
+    .run-boundary { display: grid; min-width: 0; gap: 4px; }
+    .run-time-row { display: flex; min-width: 0; align-items: center; flex-wrap: wrap; gap: 5px 7px; }
+    .run-time-row time { color: var(--ink); font: 700 9.5px/1.35 var(--mono); }
+    .run-state { color: var(--info); font-size: 8.5px; font-weight: 750; }
+    .current-run-badge { padding: 1px 5px; border-radius: 999px; color: var(--info); background: var(--info-soft); font-size: 8.5px; font-weight: 790; }
+    .run-meta { display: flex; min-width: 0; flex-wrap: wrap; gap: 3px 7px; color: var(--faint); font-size: 8.5px; }
+    .run-meta code { color: var(--evidence-muted); font-size: 8.5px; }
+    .process-content { display: grid; min-width: 0; gap: 13px; padding-top: 10px; }
+    .process-copy { max-width: 76ch; margin: 0; font-size: 11.5px; line-height: 1.62; }
+
+    .tool-group { min-width: 0; }
+    .tool-group > summary { list-style: none; cursor: pointer; }
+    .tool-group > summary::-webkit-details-marker { display: none; }
+    .tool-group > summary::marker { content: ""; }
+    .tool-group > summary:hover { color: var(--ink); background: var(--surface-hover); }
+    .tool-group-summary {
+      display: grid;
+      min-width: 0;
+      min-height: 28px;
+      grid-template-columns: 16px minmax(0, 1fr) 16px 20px;
+      align-items: center;
+      column-gap: 8px;
+      padding: 2px;
+      border-radius: 6px;
+      color: var(--muted);
+    }
+    .group-icon, .tool-icon { display: grid; width: 16px; height: 24px; place-items: center; color: var(--muted); }
+    .group-icon svg, .tool-icon svg { width: 16px; height: 16px; }
+    .group-copy { min-width: 0; overflow: hidden; }
+    .group-line { display: flex; min-width: 0; align-items: baseline; gap: 5px; overflow: hidden; white-space: nowrap; }
+    .group-line strong { flex: 0 0 auto; color: var(--ink); font-size: 10.5px; font-weight: 670; }
+    .group-line code {
+      min-width: 0;
+      overflow: hidden;
+      color: var(--evidence-muted);
+      font-size: 9.5px;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .group-count { flex: 0 0 auto; color: var(--faint); font-size: 9px; }
+    .group-count.is-danger { color: var(--danger); font-weight: 680; }
+    .group-secondary { display: block; min-width: 0; overflow: hidden; color: var(--faint); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
+    .group-secondary code { color: var(--evidence-muted); font-size: 9px; }
+    .group-state, .tool-state {
+      position: relative;
+      display: grid;
+      width: 16px;
+      height: 24px;
+      place-items: center;
+      color: var(--muted);
+    }
+    .group-state::before, .tool-state::before { width: 7px; height: 7px; border-radius: 50%; background: currentColor; content: ""; }
+    .group-state.is-running, .tool-state.is-running { color: var(--info); }
+    .group-state.is-running::after {
+      position: absolute;
+      width: 11px;
+      height: 11px;
+      border: 1px solid currentColor;
+      border-radius: 50%;
+      content: "";
+      opacity: .36;
+    }
+    .group-state.is-completed, .tool-state.is-completed { color: var(--success); }
+    .group-state.is-failed, .tool-state.is-failed, .tool-state.is-stopped { color: var(--danger); }
+    .group-state.is-failed::before, .tool-state.is-failed::before, .tool-state.is-stopped::before { border-radius: 1px; transform: rotate(45deg); }
+    .group-state.is-waiting, .tool-state.is-waiting { color: var(--attention); }
+    .group-state.is-waiting::before, .tool-state.is-waiting::before { box-sizing: border-box; border: 1px solid currentColor; background: transparent; }
+    .group-disclosure, .tool-disclosure {
+      display: grid;
+      width: 20px;
+      height: 20px;
+      place-items: center;
+      border-radius: 5px;
+      color: var(--faint);
+    }
+    .group-disclosure svg, .tool-disclosure svg { width: 14px; height: 14px; transition: transform 120ms ease; }
+    .tool-group[open] > summary .group-disclosure svg, .tool-call[open] > summary .tool-disclosure svg { transform: rotate(180deg); }
+    .tool-group > summary:hover .group-disclosure, .tool-call > summary:hover .tool-disclosure { color: var(--ink); background: var(--surface-muted); }
+    .tool-group-summary.variant-b { min-height: 42px; }
+    .tool-group-summary.variant-b .group-copy { display: grid; gap: 1px; }
+    .tool-group-summary.variant-c { min-height: 46px; }
+    .tool-group-summary.variant-c .group-copy { display: grid; gap: 2px; }
+    .trace-row { display: flex; min-width: 0; align-items: center; gap: 4px; overflow: hidden; white-space: nowrap; }
+    .trace-step { display: inline-flex; min-width: 0; align-items: center; gap: 3px; color: var(--faint); font-size: 8.5px; }
+    .trace-step::before { width: 4px; height: 4px; flex: 0 0 4px; border-radius: 50%; background: var(--success); content: ""; }
+    .trace-step.is-running::before { background: var(--info); }
+    .trace-step.is-failed::before { border-radius: 1px; background: var(--danger); transform: rotate(45deg); }
+    .trace-step.is-waiting::before { box-sizing: border-box; border: 1px solid var(--attention); background: transparent; }
+    .trace-label { max-width: 12ch; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .trace-divider { color: var(--line-strong); font-size: 8.5px; }
+
+    .tool-group-items {
+      position: relative;
+      display: grid;
+      gap: 1px;
+      margin: 3px 0 4px 23px;
+      padding: 4px 0 4px 8px;
+      border-left: 1px solid var(--line);
+    }
+    .tool-call { min-width: 0; }
+    .tool-call > summary { list-style: none; cursor: pointer; }
+    .tool-call > summary::-webkit-details-marker { display: none; }
+    .tool-call > summary::marker { content: ""; }
+    .tool-call-summary {
+      display: grid;
+      min-width: 0;
+      min-height: 24px;
+      grid-template-columns: 16px minmax(0, 1fr) 16px 20px;
+      align-items: center;
+      column-gap: 8px;
+      padding: 1px 2px;
+      border-radius: 5px;
+      color: var(--muted);
+    }
+    .tool-call-summary:hover { color: var(--ink); background: var(--surface-hover); }
+    .tool-title { min-width: 0; overflow: hidden; color: var(--muted); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
+    .tool-call[data-domain="shell"] .tool-title { color: var(--evidence-muted); font: 9.5px/1.4 var(--mono); }
+    .tool-detail { min-width: 0; margin: 5px 0 8px 24px; padding-right: 36px; }
+    .tool-result {
+      box-sizing: border-box;
+      width: 100%;
+      max-width: 100%;
+      max-height: min(180px, 28vh);
+      margin: 0;
+      overflow: auto;
+      overscroll-behavior: contain;
+      padding: 8px 9px;
+      border: 1px solid var(--evidence-line);
+      border-radius: 5px;
+      color: var(--evidence-muted);
+      background: var(--evidence-canvas);
+      font: 9.5px/1.5 var(--mono);
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+    }
+    .tool-result:focus-visible { border-color: var(--focus); }
+    .processing-row { display: flex; min-height: 24px; align-items: center; gap: 8px; color: var(--muted); font-size: 10.5px; }
+    .processing-spinner {
+      width: 11px;
+      height: 11px;
+      flex: 0 0 11px;
+      border: 1.5px solid var(--line-strong);
+      border-top-color: var(--info);
+      border-radius: 50%;
+      animation: spin 900ms linear infinite;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    .execution-drawer[data-placement="right"] .execution-drawer-header { align-items: flex-start; padding: 9px 10px 8px; }
+    .execution-drawer[data-placement="right"] .execution-drawer-agent { align-items: flex-start; }
+    .execution-drawer[data-placement="right"] .execution-title-line { display: grid; gap: 0; }
+    .execution-drawer[data-placement="right"] .execution-model { max-width: 160px; }
+    .execution-drawer[data-placement="right"] .execution-drawer-agent-copy p { font-size: 8.5px; }
+    .execution-drawer[data-placement="right"] .quiet-button { min-width: 34px; min-height: 26px; padding: 0 6px; }
+    .execution-drawer[data-placement="right"] .execution-drawer-body { padding: 9px 9px 14px; }
+    .execution-drawer[data-placement="right"] .execution-process-card { padding: 8px; }
+    .execution-drawer[data-placement="right"] .group-count { display: none; }
+    .execution-drawer[data-placement="right"] .tool-group-items { margin-left: 16px; padding-left: 5px; }
+    .execution-drawer[data-placement="right"] .tool-detail { padding-right: 2px; }
+
+    @media (max-width: 1260px) {
+      .prototype-heading span, .prototype-field > span { display: none; }
+      .prototype-heading { min-width: 150px; }
+      .prototype-controls { gap: 5px; }
+      .segments button { padding-inline: 6px; }
+    }
+    @media (max-width: 1100px) {
+      :root { --inspector-width: 260px; }
+      .prototype-stage { padding: 0; }
+      .app-shell { border-right: 0; border-left: 0; border-radius: 0; box-shadow: none; }
+      .prototype-heading { display: none; }
+      .prototype-controls { justify-content: center; }
+      .conversation-scroll { padding-right: 22px; padding-left: 22px; }
+      .placement-button span { display: none; }
+      .run-pulse-heading small { display: none; }
+      .execution-drawer { max-height: min(270px, 38vh); }
+      .execution-drawer-header, .execution-drawer-body { padding-right: 10px; padding-left: 10px; }
+    }
+    @media (max-width: 820px) {
+      :root { --rail-width: 58px; --inspector-width: 260px; }
+      .prototype-bar { align-items: flex-start; overflow-x: auto; }
+      .prototype-controls { width: max-content; flex: 0 0 auto; justify-content: flex-start; }
+      .rail-brand { justify-content: center; padding: 0; }
+      .traffic-lights, .rail-brand strong, .rail-section, .rail-row span, .rail-settings { display: none; }
+      .brand-mark { display: block; }
+      .rail-body { padding: 10px 7px; }
+      .rail-row { justify-content: center; padding: 0; }
+      .rail-row.is-current::before { left: -7px; }
+      .breadcrumbs span { display: none; }
+      .conversation-scroll { padding-inline: 16px; }
+    }
+    @media (max-width: 610px) {
+      :root { --rail-width: 0px; --inspector-width: 220px; }
+      .rail { display: none; }
+      .topbar, .workspace { grid-column: 1 / -1; }
+      .workspace { grid-template-columns: minmax(0, 1fr) var(--inspector-width); }
+      .app-shell { grid-template-columns: minmax(0, 1fr); }
+      .run-pulse { padding-inline: 9px; }
+      .run-pulse-heading { display: none; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        scroll-behavior: auto !important;
+        animation-duration: .001ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: .001ms !important;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header class="prototype-bar">
+    <div class="prototype-heading">
+      <strong>连续 Tool 聚合 · 高还原交互稿</strong>
+      <span>只替换连续 Tool 的呈现层；执行台、Inspector 与证据层级沿用生产结构。</span>
+    </div>
+    <div class="prototype-controls" aria-label="交互稿控制">
+      <div class="prototype-field">
+        <span>方案</span>
+        <div class="segments" role="group" aria-label="聚合方案">
+          <button type="button" data-variant="a" aria-pressed="true" title="A · 当前操作，推荐">A 当前操作</button>
+          <button type="button" data-variant="b" aria-pressed="false" title="B · 状态账本">B 状态账本</button>
+          <button type="button" data-variant="c" aria-pressed="false" title="C · 最近轨迹">C 最近轨迹</button>
+        </div>
+      </div>
+      <div class="prototype-field">
+        <span>位置</span>
+        <div class="segments" role="group" aria-label="执行台位置">
+          <button type="button" data-placement="bottom" aria-pressed="true">底部</button>
+          <button type="button" data-placement="right" aria-pressed="false">右侧</button>
+        </div>
+      </div>
+      <div class="prototype-field">
+        <span>状态</span>
+        <div class="segments" role="group" aria-label="聚合状态">
+          <button type="button" data-state="running" aria-pressed="true">进行中</button>
+          <button type="button" data-state="completed" aria-pressed="false">完成</button>
+          <button type="button" data-state="failed" aria-pressed="false">失败</button>
+          <button type="button" data-state="waiting" aria-pressed="false">待审批</button>
+        </div>
+      </div>
+      <button class="advance-button" id="advance-button" type="button">推进一步</button>
+      <div class="prototype-field">
+        <span>主题</span>
+        <div class="segments" role="group" aria-label="主题">
+          <button type="button" data-theme="day" aria-pressed="true">日间</button>
+          <button type="button" data-theme="night" aria-pressed="false">夜间</button>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main class="prototype-stage">
+    <section class="app-shell" id="app-shell" data-placement="bottom" aria-label="Rovai AI Camp 工作区原型">
+      <aside class="rail" aria-label="主导航">
+        <div class="rail-brand">
+          <span class="traffic-lights" aria-hidden="true"><i></i><i></i><i></i></span>
+          <span class="brand-mark" aria-hidden="true">
+            <svg class="icon" viewBox="0 0 28 28"><path d="M14 3.5c.8 4.5 2.4 6.1 6.8 6.9-4.4.8-6 2.4-6.8 6.9-.8-4.5-2.4-6.1-6.8-6.9 4.4-.8 6-2.4 6.8-6.9Z"/><path d="M4.5 21.5c2.8-2 5.9-3 9.5-3s6.7 1 9.5 3"/><circle class="ember" cx="14" cy="18.5" r="1.25"/></svg>
+          </span>
+          <strong>Rovai AI</strong>
+        </div>
+        <div class="rail-body">
+          <div class="rail-row"><svg class="icon" viewBox="0 0 18 18" aria-hidden="true"><path d="M3 9h12M9 3v12"/></svg><span>新对话</span></div>
+          <div class="rail-row"><svg class="icon" viewBox="0 0 18 18" aria-hidden="true"><circle cx="6.2" cy="6" r="2.2"/><circle cx="12.2" cy="6.6" r="1.7"/><path d="M2.7 14c.5-2.7 1.8-4 3.8-4s3.4 1.3 3.9 4M10.2 10.4c1.7 0 2.8 1 3.2 3"/></svg><span>队员</span></div>
+          <div class="rail-row"><svg class="icon" viewBox="0 0 18 18" aria-hidden="true"><path d="M5 3.2h8v11.6H5zM7 6.2h4M7 9h4M7 11.8h2.4"/></svg><span>记忆</span></div>
+          <div class="rail-section">项目</div>
+          <div class="rail-row"><svg class="icon" viewBox="0 0 18 18" aria-hidden="true"><path d="M2.8 5.5h12.4v8.7H2.8zM5.2 5.5V3.8h5.2l1.5 1.7"/></svg><span>rovai-ai</span></div>
+          <div class="rail-section">Camp</div>
+          <div class="rail-row is-selected"><svg class="icon" viewBox="0 0 18 18" aria-hidden="true"><path d="M3 4.2h12v9.6H3zM6 7h6M6 10h4"/></svg><span>快速对话</span></div>
+          <div class="rail-row"><span class="rail-camp-dot" aria-hidden="true"></span><span>篝火会议</span></div>
+          <div class="rail-row is-current"><span class="rail-camp-dot" aria-hidden="true"></span><span>执行台体验优化</span></div>
+        </div>
+        <div class="rail-settings">
+          <div class="rail-row"><svg class="icon" viewBox="0 0 18 18" aria-hidden="true"><circle cx="9" cy="9" r="2.3"/><path d="M9 2.5v1.3M9 14.2v1.3M2.5 9h1.3M14.2 9h1.3M4.4 4.4l.9.9M12.7 12.7l.9.9M13.6 4.4l-.9.9M5.3 12.7l-.9.9"/></svg><span>设置</span></div>
+        </div>
+      </aside>
+
+      <header class="topbar">
+        <div class="breadcrumbs"><span>rovai-ai</span><span>›</span><strong>执行台体验优化</strong></div>
+        <div class="topbar-actions">
+          <span class="approval-summary" id="approval-summary">无待审批事项</span>
+          <button class="quiet-icon-button" type="button" aria-label="隐藏会话详情" title="隐藏会话详情">
+            <svg class="icon" viewBox="0 0 18 18" aria-hidden="true"><path d="M3 3.5h12v11H3zM11 3.5v11"/></svg>
+          </button>
+        </div>
+      </header>
+
+      <section class="workspace">
+        <section class="timeline-pane" aria-label="Camp 会话">
+          <div class="conversation-stage">
+            <div class="conversation-tools" role="group" aria-label="会话区视图">
+              <button type="button" data-conversation-view="conversation" aria-pressed="true">会话</button>
+              <button type="button" data-conversation-view="world" aria-pressed="false">地图</button>
+            </div>
+            <div class="conversation-scroll" id="conversation-view">
+              <div class="conversation-track">
+                <div class="day-divider">8月25日 周二 · DAY 1</div>
+                <article class="message message-user">
+                  <span class="message-avatar" aria-hidden="true">你</span>
+                  <div class="message-body">
+                    <div class="message-meta"><strong>你</strong><time>20:04</time></div>
+                    <p>先做连续工具聚合，给我两到三种交互选择，并沿用项目现有 UI 规范。</p>
+                  </div>
+                </article>
+                <article class="message">
+                  <span class="message-avatar" aria-hidden="true">奥</span>
+                  <div class="message-body">
+                    <div class="message-meta"><strong>奥黛丽</strong><span>Codex CLI</span><time>20:05</time></div>
+                    <p>我会保持 AgentRun、Tool identity 与完整公开证据不变，只把同一 Run 内最大连续的 Tool 收成一条可展开摘要。日常先看当前操作，审计时再逐层展开。</p>
+                  </div>
+                </article>
+              </div>
+            </div>
+            <div class="world-placeholder" id="world-view" hidden>
+              <span>世界地图保持原有 surface；本交互稿只评审执行台。</span>
+            </div>
+          </div>
+
+          <div class="run-pulse" id="bottom-run-pulse">
+            <div class="run-pulse-heading">
+              <div class="run-pulse-title">
+                <svg class="icon" viewBox="0 0 18 18" aria-hidden="true"><path d="M2 9h3l1.5-4 3 8 2.4-6 2 4 1.3-2H16"/></svg>
+                <strong>执行台</strong>
+              </div>
+              <small>2 位队员</small>
+            </div>
+            <ul class="run-pulse-list">
+              <li>
+                <button class="agent-chip is-selected" type="button" data-open-drawer>
+                  <span class="member-avatar" style="--member-color:var(--identity-2)" aria-hidden="true">奥</span>
+                  <strong>奥黛丽</strong>
+                  <span class="agent-chip-state is-running" role="img" aria-label="执行中" title="执行中"></span>
+                </button>
+              </li>
+              <li>
+                <button class="agent-chip" type="button">
+                  <span class="member-avatar" style="--member-color:var(--identity-3)" aria-hidden="true">雾</span>
+                  <strong>雾切响子</strong>
+                  <span class="agent-chip-state" role="img" aria-label="已完成" title="已完成"></span>
+                </button>
+              </li>
+            </ul>
+            <button class="placement-button" type="button" data-move-drawer="right" aria-label="将执行台移到右侧检查器并记住此位置">
+              <svg class="icon" viewBox="0 0 20 20" aria-hidden="true"><path d="M15.5 3.5v13"/><path d="m7 6.5 3.5 3.5L7 13.5"/></svg>
+              <span>移到右侧</span>
+            </button>
+          </div>
+
+          <div class="execution-drawer-host execution-drawer-host-bottom" id="bottom-drawer-host"></div>
+        </section>
+
+        <aside class="inspector" aria-label="会话详情">
+          <div class="inspector-tabs" role="tablist" aria-label="会话详情">
+            <button type="button" role="tab" data-inspector-tab="execution" aria-selected="false" hidden>执行 <small>2</small></button>
+            <button type="button" role="tab" data-inspector-tab="tasks" aria-selected="true">任务 <small>2</small></button>
+            <button type="button" role="tab" data-inspector-tab="members" aria-selected="false">队员 <small>4</small></button>
+          </div>
+          <div class="inspector-content">
+            <section class="inspector-panel inspector-execution" data-inspector-panel="execution" hidden>
+              <div class="run-pulse run-pulse-inspector">
+                <div class="run-pulse-heading">
+                  <div class="run-pulse-title">
+                    <svg class="icon" viewBox="0 0 18 18" aria-hidden="true"><path d="M2 9h3l1.5-4 3 8 2.4-6 2 4 1.3-2H16"/></svg>
+                    <strong>执行台</strong>
+                  </div>
+                </div>
+                <button class="placement-button" type="button" data-move-drawer="bottom" aria-label="将执行台移回底部并记住此位置">
+                  <svg class="icon" viewBox="0 0 20 20" aria-hidden="true"><path d="M3.5 15.5h13"/><path d="m6.5 7 3.5 3.5L13.5 7"/></svg>
+                  <span>移回底部</span>
+                </button>
+                <ul class="run-pulse-list">
+                  <li>
+                    <button class="agent-chip is-selected" type="button" data-open-drawer>
+                      <span class="member-avatar" style="--member-color:var(--identity-2)" aria-hidden="true">奥</span>
+                      <strong>奥黛丽</strong>
+                      <span class="agent-chip-state is-running" role="img" aria-label="执行中" title="执行中"></span>
+                    </button>
+                  </li>
+                  <li>
+                    <button class="agent-chip" type="button">
+                      <span class="member-avatar" style="--member-color:var(--identity-3)" aria-hidden="true">雾</span>
+                      <strong>雾切响子</strong>
+                      <span class="agent-chip-state" role="img" aria-label="已完成" title="已完成"></span>
+                    </button>
+                  </li>
+                </ul>
+              </div>
+              <div class="execution-drawer-host execution-drawer-host-inspector" id="inspector-drawer-host"></div>
+            </section>
+
+            <section class="inspector-panel task-panel" data-inspector-panel="tasks">
+              <div class="panel-heading"><strong>当前任务</strong><span>2 项</span></div>
+              <div class="task-row">
+                <span class="task-state" aria-hidden="true"></span>
+                <span class="task-copy"><strong>连续 Tool 聚合交互稿</strong><span>奥黛丽 · 进行中</span></span>
+              </div>
+              <div class="task-row is-complete">
+                <span class="task-state" aria-hidden="true"></span>
+                <span class="task-copy"><strong>定位执行台换位卡顿</strong><span>爱丽丝 · 已完成</span></span>
+              </div>
+            </section>
+
+            <section class="inspector-panel member-panel" data-inspector-panel="members" hidden>
+              <div class="panel-heading"><strong>协作队员</strong><span>4 位在线</span></div>
+              <div class="member-row"><span class="member-avatar" style="--member-color:var(--identity-1)">爱</span><span class="member-copy"><strong>爱丽丝</strong><span>Default Lead · Codex CLI</span></span><span class="online-state">在线</span></div>
+              <div class="member-row"><span class="member-avatar" style="--member-color:var(--identity-2)">奥</span><span class="member-copy"><strong>奥黛丽</strong><span>Codex CLI · 执行中</span></span><span class="online-state">在线</span></div>
+              <div class="member-row"><span class="member-avatar" style="--member-color:var(--identity-3)">雾</span><span class="member-copy"><strong>雾切响子</strong><span>Codex CLI</span></span><span class="online-state">在线</span></div>
+              <div class="member-row"><span class="member-avatar" style="--member-color:var(--identity-4)">药</span><span class="member-copy"><strong>药师寺惠</strong><span>Codex CLI</span></span><span class="online-state">在线</span></div>
+            </section>
+          </div>
+          <div class="inspector-meta">run 9f7b2a…c41d · seq 6042</div>
+        </aside>
+
+        <div class="composer-controls">
+          <div class="composer-track">
+            <div class="composer-route">默认由 Lead · 爱丽丝接收</div>
+            <div class="composer-box">
+              <div class="composer-placeholder">和队伍继续前行：补充线索、调整方向或布置任务…</div>
+              <div class="composer-actions">
+                <svg class="icon" viewBox="0 0 18 18" aria-hidden="true"><path d="M6.3 9.9 11 5.2a2.5 2.5 0 0 1 3.5 3.5l-6.1 6.1a4 4 0 0 1-5.7-5.7l5.9-5.9"/></svg>
+                <button class="send-button" type="button" disabled>发送</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="execution-drawer" id="execution-drawer" data-placement="bottom" role="region" aria-labelledby="execution-drawer-title">
+        <div class="execution-resize-handle" aria-hidden="true"></div>
+        <header class="execution-drawer-header">
+          <div class="execution-drawer-agent">
+            <span class="member-avatar" style="--member-color:var(--identity-2)" aria-hidden="true">奥</span>
+            <div class="execution-drawer-agent-copy">
+              <div class="execution-title-line">
+                <h2 id="execution-drawer-title">奥黛丽 Codex CLI</h2>
+                <span class="execution-model">gpt-5.6-sol · 推理强度 高</span>
+              </div>
+              <p id="drawer-status-copy">共 1 次执行 · 当前正在执行</p>
+            </div>
+          </div>
+          <div class="execution-actions">
+            <button class="quiet-button danger" type="button">停止</button>
+            <button class="quiet-button" id="collapse-drawer" type="button" aria-label="收起执行详情">收起</button>
+          </div>
+        </header>
+        <div class="execution-drawer-body">
+          <ol class="execution-process-timeline">
+            <li class="execution-process-stage">
+              <span class="execution-process-node" aria-hidden="true"></span>
+              <article class="execution-process-card">
+                <header class="run-boundary">
+                  <div class="run-time-row">
+                    <time>20:05–现在</time>
+                    <span class="run-state" id="run-state-label">执行中</span>
+                    <span class="current-run-badge">当前执行</span>
+                  </div>
+                  <div class="run-meta">
+                    <span>执行 <code>9f7b2a…c41d</code></span>
+                    <span>直接执行</span>
+                    <span>本轮 <code>4bd78e…883a</code></span>
+                    <span>模型 <code>gpt-5.6-sol</code> · 默认</span>
+                  </div>
+                </header>
+                <div class="process-content">
+                  <p class="process-copy">我先核对现有执行台的布局、Tool 四轨与公开证据边界，再把连续 Tool 只在 Renderer 中派生为一组。</p>
+
+                  <details class="tool-group" id="previous-group">
+                    <summary id="previous-group-summary"></summary>
+                    <div class="tool-group-items" id="previous-tool-list"></div>
+                  </details>
+
+                  <p class="process-copy">分组不跨过这条叙述；新的连续 Tool 会形成下一组，顺序和单条 Tool 身份保持不变。</p>
+
+                  <details class="tool-group" id="current-group">
+                    <summary id="current-group-summary"></summary>
+                    <div class="tool-group-items" id="current-tool-list"></div>
+                  </details>
+
+                  <div class="processing-row" id="processing-row" role="status" hidden>
+                    <span class="processing-spinner" aria-hidden="true"></span>
+                    <span id="processing-copy">正在处理</span>
+                  </div>
+                </div>
+              </article>
+            </li>
+          </ol>
+        </div>
+      </section>
+    </section>
+  </main>
+
+  <div class="sr-only" id="live-region" aria-live="polite"></div>
+
+  <script>
+    var icons = {
+      group: '<path d="M3 4.25h10M3 8h10M3 11.75h10"/><circle cx="1.8" cy="4.25" r=".6"/><circle cx="1.8" cy="8" r=".6"/><circle cx="1.8" cy="11.75" r=".6"/>',
+      shell: '<rect x="1.75" y="2.25" width="12.5" height="11.5" rx="2"/><path d="M4.25 6 6.1 7.8 4.25 9.6M8 10h3.2"/>',
+      file: '<path d="M4 1.75h5.1L12.5 5v9.25H4z"/><path d="M9 1.9V5h3.2M6 8h4.4M6 10.5h3.3"/>',
+      git: '<circle cx="4" cy="3.25" r="1.35"/><circle cx="4" cy="12.75" r="1.35"/><circle cx="11.75" cy="7.2" r="1.35"/><path d="M4 4.6v6.8M4 6.1h2.2a3.2 3.2 0 0 1 3.2 3.2v.1M9.4 7.2h1"/>',
+      runtime: '<rect x="3.15" y="3.15" width="9.7" height="9.7" rx="1.45"/><rect x="5.5" y="5.5" width="5" height="5" rx=".75"/><path d="M5.25 1.5v1.65M8 1.5v1.65M10.75 1.5v1.65M5.25 12.85v1.65M8 12.85v1.65M10.75 12.85v1.65M1.5 5.25h1.65M1.5 8h1.65M1.5 10.75h1.65M12.85 5.25h1.65M12.85 8h1.65M12.85 10.75h1.65"/>'
+    };
+
+    var previousTools = [
+      { title: '读取 docs/README.md', short: '读取文档地图', domain: 'file', status: 'completed', result: '已定位 Renderer UI、Contract 与开发验收的权威入口。' },
+      { title: '读取 DESIGN.md 与会话工作区合同', short: '核对 UI 合同', domain: 'file', status: 'completed', result: '确认 Porcelain Day / Steel Night、开放阅读面、稳定四轨与 Inspector 结构。' },
+      { title: 'rg -n "ToolCallRow" CampWorkspace.tsx', short: '定位 Tool 行', domain: 'shell', status: 'completed', result: '找到 ToolCallRow、RunExecutionDisclosure 与稳定 Drawer host。' }
+    ];
+
+    var allTools = [
+      { title: '读取 Run Process Detail Surface v19', short: '读取 v19 合同', domain: 'file', result: '完整 chronology、公开命令、按需结果读取与焦点语义保持不变。' },
+      { title: '检查 ExecutionProgressItem 顺序', short: '检查顺序', domain: 'runtime', result: 'narration、plan、diagnostic 与 tool 的相对顺序可直接用于最大连续分组。' },
+      { title: 'rg -n "processItems.map" CampWorkspace.tsx', short: '搜索渲染点', domain: 'shell', result: '当前 Renderer 对 processItems 逐项渲染 ToolCallRow。' },
+      { title: '设计 ToolActivityGroup 派生投影', short: '设计派生组', domain: 'file', result: '分组仅存在于 Renderer，不创建 Core Process 或新的 Tool identity。' },
+      { title: 'pnpm test --filter desktop', short: '运行桌面测试', domain: 'shell', result: 'Renderer test suite\n✓ chronology preserved\n✓ nested Tool disclosure independent\n✓ state summary remains honest' },
+      { title: 'git diff --check', short: '检查差异', domain: 'git', result: '未发现空白错误。' },
+      { title: '检查 Day / Night 与 310px Inspector', short: '检查双主题', domain: 'file', result: 'Day / Night、底部 / Inspector 与键盘路径均完成检查。' }
+    ];
+
+    var stateLabels = {
+      running: '执行中',
+      completed: '全部成功',
+      failed: '存在失败',
+      waiting: '等待审批'
+    };
+    var toolStateLabels = {
+      running: '执行中',
+      completed: '成功',
+      failed: '失败',
+      waiting: '等待审批',
+      stopped: '已停止'
+    };
+    var variant = 'a';
+    var groupState = 'running';
+    var visibleCount = 5;
+    var placement = 'bottom';
+
+    var appShell = document.getElementById('app-shell');
+    var drawer = document.getElementById('execution-drawer');
+    var bottomHost = document.getElementById('bottom-drawer-host');
+    var inspectorHost = document.getElementById('inspector-drawer-host');
+    var currentSummary = document.getElementById('current-group-summary');
+    var previousSummary = document.getElementById('previous-group-summary');
+    var currentToolList = document.getElementById('current-tool-list');
+    var previousToolList = document.getElementById('previous-tool-list');
+    var liveRegion = document.getElementById('live-region');
+    var advanceButton = document.getElementById('advance-button');
+
+    function escapeMarkup(value) {
+      return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
+    function iconMarkup(name, className) {
+      return '<span class="' + className + '" aria-hidden="true"><svg class="icon" viewBox="0 0 16 16">' + (icons[name] || icons.runtime) + '</svg></span>';
+    }
+
+    function disclosureMarkup(className) {
+      return '<span class="' + className + '" aria-hidden="true"><svg class="icon" viewBox="0 0 16 16"><path d="m4 6 4 4 4-4"/></svg></span>';
+    }
+
+    function currentTools() {
+      var tools = allTools.slice(0, visibleCount).map(function (tool) {
+        return Object.assign({}, tool, { status: 'completed' });
+      });
+      if (groupState === 'running') tools[tools.length - 1].status = 'running';
+      if (groupState === 'failed') tools[tools.length - 1].status = 'failed';
+      if (groupState === 'waiting') tools[tools.length - 1].status = 'waiting';
+      return tools;
+    }
+
+    function factsFor(tools) {
+      var completed = tools.filter(function (tool) { return tool.status === 'completed'; }).length;
+      var failed = tools.filter(function (tool) { return tool.status === 'failed'; }).length;
+      var current = tools.slice().reverse().find(function (tool) {
+        return tool.status === 'running' || tool.status === 'waiting';
+      }) || tools[tools.length - 1];
+      return { total: tools.length, completed: completed, failed: failed, current: current };
+    }
+
+    function summaryText(tools, state, fixedLabel) {
+      var facts = factsFor(tools);
+      if (fixedLabel) return { primary: fixedLabel, command: '', count: '全部成功', state: 'completed' };
+      if (state === 'completed') return { primary: '已执行 ' + facts.total + ' 项操作', command: '', count: '全部成功', state: state };
+      if (state === 'failed') return { primary: '已执行 ' + facts.total + ' 项操作', command: '', count: facts.failed + ' 项失败', state: state };
+      if (state === 'waiting') return { primary: '等待审批', command: facts.current.title, count: facts.completed + ' 项已完成', state: state };
+      return { primary: '执行中', command: facts.current.title, count: facts.completed + ' 项已完成', state: state };
+    }
+
+    function traceMarkup(tools) {
+      return tools.slice(-3).map(function (tool, index, recent) {
+        var divider = index < recent.length - 1 ? '<span class="trace-divider" aria-hidden="true">—</span>' : '';
+        return '<span class="trace-step is-' + tool.status + '"><span class="trace-label">' + escapeMarkup(tool.short || tool.title) + '</span></span>' + divider;
+      }).join('');
+    }
+
+    function domainBreakdown(tools) {
+      var labels = { shell: 'Shell', file: 'File', git: 'Git', runtime: 'Runtime' };
+      var counts = tools.reduce(function (result, tool) {
+        result[tool.domain] = (result[tool.domain] || 0) + 1;
+        return result;
+      }, {});
+      return Object.keys(counts).map(function (domain) {
+        return (labels[domain] || 'Tool') + ' ' + counts[domain];
+      }).join(' · ');
+    }
+
+    function groupSummaryMarkup(tools, state, fixedLabel) {
+      var text = summaryText(tools, state, fixedLabel);
+      var countClass = text.state === 'failed' ? 'group-count is-danger' : 'group-count';
+      var mainLine = '<span class="group-line"><strong>' + escapeMarkup(text.primary) + '</strong>';
+      if (text.command) mainLine += '<span aria-hidden="true">·</span><code title="' + escapeMarkup(text.command) + '">' + escapeMarkup(text.command) + '</code>';
+      mainLine += '<span class="' + countClass + '">' + escapeMarkup(text.count) + '</span></span>';
+
+      var copy;
+      if (variant === 'b') {
+        var secondary = text.command
+          ? '<code title="' + escapeMarkup(text.command) + '">' + escapeMarkup(text.command) + '</code>'
+          : escapeMarkup(text.state === 'failed' ? text.count : domainBreakdown(tools));
+        copy = '<span class="group-copy">' +
+          '<span class="group-line"><strong>' + escapeMarkup(text.primary) + '</strong><span class="' + countClass + '">' + escapeMarkup(text.count) + '</span></span>' +
+          '<span class="group-secondary">' + secondary + '</span></span>';
+      } else if (variant === 'c') {
+        copy = '<span class="group-copy">' + mainLine +
+          '<span class="trace-row">' + traceMarkup(tools) + '</span></span>';
+      } else {
+        copy = '<span class="group-copy">' + mainLine + '</span>';
+      }
+
+      return '<span class="tool-group-summary variant-' + variant + '">' +
+        iconMarkup('group', 'group-icon') +
+        copy +
+        '<span class="group-state is-' + text.state + '" role="img" aria-label="' + stateLabels[text.state] + '" title="' + stateLabels[text.state] + '"></span>' +
+        disclosureMarkup('group-disclosure') +
+        '</span>';
+    }
+
+    function toolRowMarkup(tool, index, prefix) {
+      var label = toolStateLabels[tool.status] || tool.status;
+      return '<details class="tool-call" data-domain="' + tool.domain + '" data-result-key="' + prefix + '-' + index + '">' +
+        '<summary class="tool-call-summary">' +
+        iconMarkup(tool.domain, 'tool-icon') +
+        '<span class="tool-title" title="' + escapeMarkup(tool.title) + '">' + escapeMarkup(tool.title) + '</span>' +
+        '<span class="tool-state is-' + tool.status + '" role="img" aria-label="' + escapeMarkup(label) + '" title="' + escapeMarkup(label) + '"></span>' +
+        disclosureMarkup('tool-disclosure') +
+        '</summary>' +
+        '<div class="tool-detail"></div>' +
+        '</details>';
+    }
+
+    function bindLazyToolResults(host, tools) {
+      host.querySelectorAll('.tool-call').forEach(function (details, index) {
+        var summary = details.querySelector('summary');
+        details.addEventListener('toggle', function () {
+          if (!details.open || details.dataset.resultLoaded === 'true') return;
+          var tool = tools[index];
+          var result = document.createElement('pre');
+          result.className = 'tool-result';
+          result.tabIndex = 0;
+          result.setAttribute('role', 'region');
+          result.setAttribute('aria-label', tool.title + ' 的完整公开结果');
+          result.dataset.resultKey = details.dataset.resultKey;
+          result.textContent = tool.result;
+          result.addEventListener('keydown', function (event) {
+            if (event.key !== 'Escape') return;
+            event.preventDefault();
+            summary.focus({ preventScroll: true });
+          });
+          details.querySelector('.tool-detail').appendChild(result);
+          details.dataset.resultLoaded = 'true';
+        });
+      });
+    }
+
+    function renderSummaries() {
+      previousSummary.innerHTML = groupSummaryMarkup(previousTools, 'completed', '已执行 3 项操作');
+      currentSummary.innerHTML = groupSummaryMarkup(currentTools(), groupState);
+    }
+
+    function renderTools() {
+      previousToolList.innerHTML = previousTools.map(function (tool, index) {
+        return toolRowMarkup(tool, index, 'previous');
+      }).join('');
+      currentToolList.innerHTML = currentTools().map(function (tool, index) {
+        return toolRowMarkup(tool, index, 'current');
+      }).join('');
+      bindLazyToolResults(previousToolList, previousTools);
+      bindLazyToolResults(currentToolList, currentTools());
+    }
+
+    function renderState() {
+      renderSummaries();
+      renderTools();
+      var processingRow = document.getElementById('processing-row');
+      var processingCopy = document.getElementById('processing-copy');
+      var active = groupState === 'running' || groupState === 'waiting';
+      processingRow.hidden = active;
+      processingCopy.textContent = groupState === 'failed'
+        ? '一项操作失败，Agent 正在检查结果'
+        : groupState === 'completed'
+          ? '操作组已结束，Agent 正在继续处理'
+          : '正在处理';
+      document.getElementById('run-state-label').textContent = groupState === 'waiting' ? '等待审批' : '执行中';
+      document.getElementById('drawer-status-copy').textContent = groupState === 'waiting'
+        ? '共 1 次执行 · 当前等待用户操作'
+        : '共 1 次执行 · 当前正在执行';
+      document.getElementById('approval-summary').textContent = groupState === 'waiting'
+        ? '1 项待审批'
+        : '无待审批事项';
+      document.querySelectorAll('[data-open-drawer] .agent-chip-state').forEach(function (state) {
+        state.classList.toggle('is-running', groupState !== 'waiting');
+        state.classList.toggle('is-waiting', groupState === 'waiting');
+        state.setAttribute('aria-label', groupState === 'waiting' ? '等待审批' : '执行中');
+        state.setAttribute('title', groupState === 'waiting' ? '等待审批' : '执行中');
+      });
+      advanceButton.disabled = groupState !== 'running';
+    }
+
+    function followLatest() {
+      var body = drawer.querySelector('.execution-drawer-body');
+      body.scrollTop = body.scrollHeight;
+    }
+
+    function setVariant(next) {
+      variant = next;
+      document.querySelectorAll('[data-variant]').forEach(function (button) {
+        button.setAttribute('aria-pressed', String(button.dataset.variant === next));
+      });
+      renderSummaries();
+      liveRegion.textContent = '已切换到方案 ' + next.toUpperCase();
+    }
+
+    function selectInspectorTab(tab) {
+      document.querySelectorAll('[data-inspector-tab]').forEach(function (button) {
+        button.setAttribute('aria-selected', String(button.dataset.inspectorTab === tab));
+      });
+      document.querySelectorAll('[data-inspector-panel]').forEach(function (panel) {
+        panel.hidden = panel.dataset.inspectorPanel !== tab;
+      });
+    }
+
+    function setPlacement(next) {
+      placement = next;
+      appShell.dataset.placement = next;
+      drawer.dataset.placement = next === 'right' ? 'right' : 'bottom';
+      document.querySelectorAll('[data-placement]').forEach(function (button) {
+        button.setAttribute('aria-pressed', String(button.dataset.placement === next));
+      });
+      var executionTab = document.querySelector('[data-inspector-tab="execution"]');
+      if (next === 'right') {
+        executionTab.hidden = false;
+        inspectorHost.appendChild(drawer);
+        selectInspectorTab('execution');
+      } else {
+        bottomHost.appendChild(drawer);
+        executionTab.hidden = true;
+        selectInspectorTab('tasks');
+      }
+      liveRegion.textContent = '同一个执行详情已移到' + (next === 'bottom' ? '底部' : '右侧');
+    }
+
+    document.querySelectorAll('[data-variant]').forEach(function (button) {
+      button.addEventListener('click', function () { setVariant(button.dataset.variant); });
+    });
+    document.querySelectorAll('[data-placement]').forEach(function (button) {
+      button.addEventListener('click', function () { setPlacement(button.dataset.placement); });
+    });
+    document.querySelectorAll('[data-move-drawer]').forEach(function (button) {
+      button.addEventListener('click', function () { setPlacement(button.dataset.moveDrawer); });
+    });
+    document.querySelectorAll('[data-state]').forEach(function (button) {
+      button.addEventListener('click', function () {
+        groupState = button.dataset.state;
+        visibleCount = groupState === 'completed' ? allTools.length : groupState === 'failed' ? 6 : 5;
+        document.querySelectorAll('[data-state]').forEach(function (candidate) {
+          candidate.setAttribute('aria-pressed', String(candidate === button));
+        });
+        renderState();
+        window.requestAnimationFrame(followLatest);
+        liveRegion.textContent = '连续 Tool 组状态：' + stateLabels[groupState];
+      });
+    });
+    document.querySelectorAll('[data-theme]').forEach(function (button) {
+      button.addEventListener('click', function () {
+        document.documentElement.dataset.theme = button.dataset.theme;
+        document.querySelectorAll('[data-theme]').forEach(function (candidate) {
+          candidate.setAttribute('aria-pressed', String(candidate === button));
+        });
+        liveRegion.textContent = button.dataset.theme === 'day' ? '已切换 Porcelain Day' : '已切换 Steel Night';
+      });
+    });
+    document.querySelectorAll('[data-inspector-tab]').forEach(function (button) {
+      button.addEventListener('click', function () { selectInspectorTab(button.dataset.inspectorTab); });
+    });
+    document.querySelectorAll('[data-open-drawer]').forEach(function (button) {
+      button.addEventListener('click', function () {
+        drawer.classList.remove('is-collapsed');
+        liveRegion.textContent = '已展开奥黛丽的执行详情';
+      });
+    });
+    document.querySelectorAll('[data-conversation-view]').forEach(function (button) {
+      button.addEventListener('click', function () {
+        var view = button.dataset.conversationView;
+        document.querySelectorAll('[data-conversation-view]').forEach(function (candidate) {
+          candidate.setAttribute('aria-pressed', String(candidate === button));
+        });
+        document.getElementById('conversation-view').hidden = view !== 'conversation';
+        document.getElementById('world-view').hidden = view !== 'world';
+      });
+    });
+    document.getElementById('collapse-drawer').addEventListener('click', function () {
+      drawer.classList.add('is-collapsed');
+      liveRegion.textContent = '执行详情已收起，可从队员过程入口重新打开';
+    });
+    advanceButton.addEventListener('click', function () {
+      if (groupState !== 'running') return;
+      if (visibleCount < allTools.length) {
+        visibleCount += 1;
+        renderState();
+        window.requestAnimationFrame(followLatest);
+        liveRegion.textContent = '开始' + allTools[visibleCount - 1].title + '，此前 ' + (visibleCount - 1) + ' 项已完成';
+        return;
+      }
+      groupState = 'completed';
+      document.querySelectorAll('[data-state]').forEach(function (button) {
+        button.setAttribute('aria-pressed', String(button.dataset.state === 'completed'));
+      });
+      renderState();
+      window.requestAnimationFrame(followLatest);
+      liveRegion.textContent = '连续 Tool 组已完成，共 ' + allTools.length + ' 项操作';
+    });
+
+    document.getElementById('current-group').addEventListener('toggle', function (event) {
+      liveRegion.textContent = event.currentTarget.open ? '已展开这组的全部 Tool 行' : '已收起连续 Tool 组';
+    });
+
+    renderState();
+    setPlacement('bottom');
+    window.requestAnimationFrame(followLatest);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- add the Camp member management interaction prototype and design brief
- add the continuous Tool grouping interaction prototype and design brief
- retain the proactive app update prototype already present on main

## Validation

- inline JavaScript syntax checks for both new HTML prototypes
- pnpm docs:check
- git diff --check