### PR TITLE
Clarify add-member dialog copy

### DIFF
--- a/apps/desktop/src/renderer/src/CampWorkspace.tsx
+++ b/apps/desktop/src/renderer/src/CampWorkspace.tsx
@@ -5946,7 +5946,7 @@ function CampMembersPanel({
           <AppDialogContent className="camp-member-dialog" width="wide" aria-describedby="camp-add-member-description">
             <AppDialogHeader
               title="添加队员"
-              description={`加入「${snapshot.camp.title}」；不会改变队员的长期配置。`}
+              description="选择要加入这次讨论的队员。"
               descriptionId="camp-add-member-description"
               icon="user"
               kicker="当前会话"


### PR DESCRIPTION
## Summary

- replace the abstract add-member dialog description with the confirmed plain-language copy
- preserve the existing dialog behavior and layout

## Validation

- pnpm typecheck
- pnpm exec vitest run apps/desktop/src/renderer/src/App.test.ts (128 passed)
- pnpm build:desktop
- Impeccable static UI detector