### PR TITLE
fix(desktop): make composer cut atomic

### DIFF
--- a/apps/desktop/src/renderer/src/StructuredMentionComposer.tsx
+++ b/apps/desktop/src/renderer/src/StructuredMentionComposer.tsx
@@ -27,6 +27,7 @@ import {
   normalizeStructuredMentionContent,
   pasteStructuredPlainText,
   replaceStructuredSelection,
+  selectedStructuredMentionContent,
   structuredMentionContentLength,
   type StructuredMentionContent,
   type StructuredMentionEditorState,
@@ -35,7 +36,10 @@ import {
 import { MemberAvatar } from './MemberAvatar'
 import { SkillIdentityMark } from './SkillIdentityMark'
 import type { ComposerSkillOption } from './composer-skill-picker'
-import { readStructuredMessageClipboardContent } from './structured-message-clipboard'
+import {
+  createStructuredMessageClipboardData,
+  readStructuredMessageClipboardContent
+} from './structured-message-clipboard'
 
 export interface StructuredMentionMember {
   agentId: string
@@ -659,6 +663,32 @@ export function StructuredMentionComposer({
       : pasteStructuredPlainText(editorState(), plainText))
   }
 
+  const handleCut = (event: ClipboardEvent<HTMLDivElement>): void => {
+    if (disabled || isComposingRef.current) {
+      event.preventDefault()
+      return
+    }
+    const selection = currentSelection()
+    if (selection.anchor === selection.focus) return
+    // Own Cut before Chromium mutates the contenteditable subtree. Waiting for
+    // deleteByCut leaves a native filler BR that can be mistaken for a newline.
+    event.preventDefault()
+    const state = editorState(selection)
+    const selectedContent = selectedStructuredMentionContent(state)
+    const structuredClipboard = createStructuredMessageClipboardData(selectedContent, members)
+    if (structuredClipboard) {
+      event.clipboardData.setData('text/plain', structuredClipboard.text)
+      event.clipboardData.setData('text/html', structuredClipboard.html)
+    } else {
+      event.clipboardData.setData(
+        'text/plain',
+        selectedContent.map((segment) => segment.kind === 'text' ? segment.text : '').join('')
+      )
+    }
+    setQuery(null)
+    emitState(replaceStructuredSelection(state, []))
+  }
+
   const handleCompositionStart = (_event: CompositionEvent<HTMLDivElement>): void => {
     isComposingRef.current = true
     compositionGenerationRef.current += 1
@@ -735,6 +765,7 @@ export function StructuredMentionComposer({
           }
         }}
         onPaste={handlePaste}
+        onCut={handleCut}
         onCompositionStart={handleCompositionStart}
         onCompositionEnd={handleCompositionEnd}
         onPointerDown={handlePointerDown}
@@ -1010,6 +1041,7 @@ function authorableStructuredContent(
 }
 
 function readStructuredContent(editor: HTMLDivElement): StructuredMentionContent {
+  if (isNativeEmptyEditorFiller(editor)) return []
   const content: StructuredMentionContent = []
   for (const node of editor.childNodes) {
     if (node.nodeType === Node.ELEMENT_NODE) {
@@ -1042,6 +1074,36 @@ function readStructuredContent(editor: HTMLDivElement): StructuredMentionContent
     if (text) content.push({ kind: 'text', text })
   }
   return normalizeStructuredMentionContent(content)
+}
+
+function isNativeEmptyEditorFiller(editor: HTMLDivElement): boolean {
+  // Chromium represents an emptied contenteditable with one untagged BR.
+  // Tagged line breaks remain semantic and must never be collapsed here.
+  let bareBreakCount = 0
+  let semanticContentFound = false
+  const visit = (node: Node): void => {
+    if (semanticContentFound) return
+    if (node.nodeType === Node.TEXT_NODE) {
+      if ((node.textContent ?? '').length > 0) {
+        semanticContentFound = true
+      }
+      return
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) return
+    const element = node as HTMLElement
+    if (element.dataset.tokenKind || element.dataset.editorLineBreak === 'true') {
+      semanticContentFound = true
+      return
+    }
+    if (isEditorCaretHost(element)) return
+    if (element.tagName === 'BR') {
+      if (!isEditorCaretBreak(element)) bareBreakCount += 1
+      return
+    }
+    for (const child of element.childNodes) visit(child)
+  }
+  for (const child of editor.childNodes) visit(child)
+  return !semanticContentFound && bareBreakCount <= 1
 }
 
 function renderEditorText(text: string): ReactNode[] {

--- a/apps/desktop/src/renderer/src/structured-mention-model.test.ts
+++ b/apps/desktop/src/renderer/src/structured-mention-model.test.ts
@@ -11,6 +11,7 @@ import {
   normalizeStructuredMentionContent,
   pasteStructuredPlainText,
   replaceStructuredSelection,
+  selectedStructuredMentionContent,
   structuredMentionContentLength,
   type StructuredMentionEditorState
 } from './structured-mention-model'
@@ -211,6 +212,26 @@ describe('structured mention editing model', () => {
       content: [{ kind: 'text', text: '前后' }],
       selection: { anchor: 1, focus: 1 }
     })
+  })
+
+  it('returns the visible structured selection without splitting atomic tokens', () => {
+    expect(selectedStructuredMentionContent({
+      content: [
+        { kind: 'text', text: '前文' },
+        member('agent-a'),
+        { kind: 'text', text: '中段' },
+        skill('skill-review', 'review-pr'),
+        allMembers(),
+        { kind: 'text', text: '后文' }
+      ],
+      selection: { anchor: 7, focus: 1 }
+    })).toEqual([
+      { kind: 'text', text: '文' },
+      member('agent-a'),
+      { kind: 'text', text: '中段' },
+      skill('skill-review', 'review-pr'),
+      allMembers()
+    ])
   })
 
   it('pastes @ and slash text without upgrading either to structured tokens', () => {

--- a/apps/desktop/src/renderer/src/structured-mention-model.ts
+++ b/apps/desktop/src/renderer/src/structured-mention-model.ts
@@ -68,6 +68,20 @@ export function structuredMentionContentLength(
   )
 }
 
+export function selectedStructuredMentionContent(
+  state: StructuredMentionEditorState
+): StructuredMentionContent {
+  const content = normalizeStructuredMentionContent(state.content)
+  const length = structuredMentionContentLength(content)
+  const anchor = clampOffset(state.selection.anchor, length)
+  const focus = clampOffset(state.selection.focus, length)
+  return sliceStructuredMentionContent(
+    content,
+    Math.min(anchor, focus),
+    Math.max(anchor, focus)
+  )
+}
+
 export function replaceStructuredSelection(
   state: StructuredMentionEditorState,
   replacement: readonly StructuredMentionSegment[]

--- a/scripts/accept-structured-mentions-ui.mjs
+++ b/scripts/accept-structured-mentions-ui.mjs
@@ -12,6 +12,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { spawn } from 'node:child_process'
 import { seedCompletedOnboardingForAcceptance } from './lib/dev-desktop.mjs'
+import { removeEphemeralRuntimeCampFilesRoot } from './lib/runtime-camp-files-root.mjs'
 
 const root = resolve(import.meta.dirname, '..')
 const cliArguments = process.argv.slice(2)
@@ -39,6 +40,7 @@ const debugPort = Number(process.env.ROVAI_STRUCTURED_MENTIONS_ACCEPT_DEBUG_PORT
 const skillPickerOnly = cliArguments.includes('--skill-picker-only')
 const skillContextSmoke = cliArguments.includes('--skill-context-smoke')
 const imeNewlineOnly = cliArguments.includes('--ime-newline-only')
+const cutOnly = cliArguments.includes('--cut-only')
 const continuationOnly = cliArguments.includes('--continuation-only')
 const replyBackspaceOnly = cliArguments.includes('--reply-backspace-only')
 const databasePath = join(dataDir, 'rovai.sqlite')
@@ -161,7 +163,7 @@ try {
   assert(
     targetMemberIds.every((id) => configuredAgents.some((agent) =>
       agent.agentId === id
-      && agent.runtimeReadiness.status === 'ready'
+      && ['ready', 'light_ready'].includes(agent.runtimeReadiness.status)
       && agent.runtimeConfiguration?.adapterKind === 'codex-cli')),
     `Acceptance Runtime is not ready for every target: ${JSON.stringify(configuredAgents)}`
   )
@@ -214,8 +216,8 @@ try {
     return button?.getAttribute('aria-pressed') === 'true' && !timeline?.hidden
   })()`)
   const initialSnapshot = await request(running.cdp, 'camps.snapshot', { campId })
-  assert(initialSnapshot.schemaVersion === 32,
-    `Camp snapshot schema is not v32: ${initialSnapshot.schemaVersion}`)
+  assert(initialSnapshot.schemaVersion === 33,
+    `Camp snapshot schema is not v33: ${initialSnapshot.schemaVersion}`)
   assert(
     deepEqual(initialSnapshot.members.map((member) => member.agentId), targetMemberIds),
     `Camp does not contain exactly the three target members: ${JSON.stringify(initialSnapshot.members)}`
@@ -224,6 +226,20 @@ try {
   await waitForSelector(running.cdp, '#camp-message.structured-mention-editor')
   await waitForExpression(running.cdp,
     `document.querySelector('#camp-message')?.getAttribute('contenteditable') === 'true'`)
+  if (cutOnly) {
+    clipboardTouched = true
+    const composerCutInspection = await acceptComposerCutRegression(running.cdp, campId)
+    result = {
+      acceptance: 'composer-cut-ui',
+      appPath,
+      campId,
+      ...composerCutInspection,
+      clipboardItemCountBeforeTest: clipboardArchive.length,
+      clipboardRestored: false,
+      isolatedUserDataRemoved: false
+    }
+    break acceptance
+  }
   if (imeNewlineOnly) {
     const imeNewlineInspection = await acceptImeNewlineRegression(running.cdp, campId)
     result = {
@@ -237,6 +253,8 @@ try {
     }
     break acceptance
   }
+  clipboardTouched = true
+  await acceptComposerCutRegression(running.cdp, campId)
   await focusEditorAtEnd(running.cdp)
   await running.cdp.send('Input.insertText', { text: '/' })
   await waitForExpression(running.cdp, `(() => {
@@ -1922,6 +1940,10 @@ if (testFailure || cleanupFailure) {
 }
 
 if (!suppliedFixtureRoot) {
+  await removeEphemeralRuntimeCampFilesRoot(dataDir, {
+    homeDirectory: acceptanceHome,
+    temporaryDirectory: tmpdir()
+  })
   await removeDirectoryWithRetry(fixtureRoot)
 }
 if (!suppliedRuntimeTempDir) {
@@ -2249,6 +2271,147 @@ async function acceptImeNewlineRegression(cdp, campId) {
     (value) => deepEqual(value.content, []), 10_000)
 
   return { trailingNewlineInspection, postNewlineInputInspection, draft }
+}
+
+async function acceptComposerCutRegression(cdp, campId) {
+  await selectWholeEditor(cdp)
+  await pressKey(cdp, {
+    key: 'Backspace', code: 'Backspace', windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 51
+  })
+  await waitForValue(async () => request(cdp, 'camp.composerDraft.get', { campId }),
+    (draft) => deepEqual(draft.content, []) && draft.body === '', 10_000)
+
+  await focusEditorAtEnd(cdp)
+  await cdp.send('Input.insertText', { text: '123' })
+  await waitForValue(async () => request(cdp, 'camp.composerDraft.get', { campId }),
+    (draft) => deepEqual(draft.content, [{ kind: 'text', text: '123' }])
+      && draft.body === '123', 10_000)
+  await evaluate(cdp, `(() => {
+    window.__composerCutEditor = document.querySelector('#camp-message')
+    window.__composerCutShell = document.querySelector('.app-shell')
+    window.__composerCutWorkspace = document.querySelector('.camp-workspace')
+    window.__composerCutErrors = []
+    window.addEventListener('error', (event) => {
+      window.__composerCutErrors.push({
+        message: event.message,
+        stack: event.error instanceof Error ? event.error.stack : null
+      })
+    })
+  })()`)
+
+  await selectWholeEditor(cdp)
+  await cutSelectionWithMetaX(cdp)
+  const clipboardText = await waitForValue(
+    () => runProcess('/usr/bin/pbpaste', []),
+    (text) => text === '123',
+    3_000
+  )
+  const emptyDraft = await waitForValue(
+    () => request(cdp, 'camp.composerDraft.get', { campId }),
+    (draft) => deepEqual(draft.content, []) && draft.body === '',
+    10_000
+  )
+  await evaluate(cdp,
+    `new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))`, true)
+  const afterCut = await evaluate(cdp, `(() => {
+    const editor = document.querySelector('#camp-message')
+    return {
+      appShellStayedMounted: document.querySelector('.app-shell') === window.__composerCutShell,
+      workspaceStayedMounted: document.querySelector('.camp-workspace') === window.__composerCutWorkspace,
+      editorStayedMounted: editor === window.__composerCutEditor,
+      editorFocused: document.activeElement === editor,
+      editorText: editor?.textContent ?? null,
+      editorHtml: editor?.innerHTML ?? null,
+      emptyBreakCount: editor?.querySelectorAll('[data-editor-empty-break="true"]').length ?? -1,
+      lineBreakCount: editor?.querySelectorAll('[data-editor-line-break="true"]').length ?? -1,
+      errors: window.__composerCutErrors ?? []
+    }
+  })()`)
+  assert(
+    afterCut.appShellStayedMounted
+      && afterCut.workspaceStayedMounted
+      && afterCut.editorStayedMounted
+      && afterCut.editorFocused
+      && afterCut.editorText === ''
+      && afterCut.emptyBreakCount === 1
+      && afterCut.lineBreakCount === 0
+      && afterCut.errors.length === 0,
+    `Command+X did not leave one stable empty Composer: ${JSON.stringify(afterCut)}`
+  )
+
+  await cdp.send('Input.insertText', { text: '7' })
+  const nextDraft = await waitForValue(
+    () => request(cdp, 'camp.composerDraft.get', { campId }),
+    (draft) => deepEqual(draft.content, [{ kind: 'text', text: '7' }]) && draft.body === '7',
+    10_000
+  )
+  await evaluate(cdp,
+    `new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))`, true)
+  const afterSingleInput = await evaluate(cdp, `(() => {
+    const editor = document.querySelector('#camp-message')
+    return {
+      appShellStayedMounted: document.querySelector('.app-shell') === window.__composerCutShell,
+      workspaceStayedMounted: document.querySelector('.camp-workspace') === window.__composerCutWorkspace,
+      editorStayedMounted: editor === window.__composerCutEditor,
+      editorFocused: document.activeElement === editor,
+      editorText: editor?.textContent ?? null,
+      errors: window.__composerCutErrors ?? []
+    }
+  })()`)
+  assert(
+    afterSingleInput.appShellStayedMounted
+      && afterSingleInput.workspaceStayedMounted
+      && afterSingleInput.editorStayedMounted
+      && afterSingleInput.editorFocused
+      && afterSingleInput.editorText === '7'
+      && afterSingleInput.errors.length === 0,
+    `One post-cut digit did not stay one digit: ${JSON.stringify(afterSingleInput)}`
+  )
+
+  await selectWholeEditor(cdp)
+  const nativeDeleteApplied = await evaluate(cdp, `document.execCommand('delete')`)
+  assert(nativeDeleteApplied, 'Chromium did not apply the native delete command')
+  const afterNativeEmptyDraft = await waitForValue(
+    () => request(cdp, 'camp.composerDraft.get', { campId }),
+    (draft) => deepEqual(draft.content, []) && draft.body === '',
+    10_000
+  )
+  await evaluate(cdp,
+    `new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))`, true)
+  const afterNativeEmpty = await evaluate(cdp, `(() => {
+    const editor = document.querySelector('#camp-message')
+    return {
+      appShellStayedMounted: document.querySelector('.app-shell') === window.__composerCutShell,
+      workspaceStayedMounted: document.querySelector('.camp-workspace') === window.__composerCutWorkspace,
+      editorFocused: document.activeElement === editor,
+      editorText: editor?.textContent ?? null,
+      editorHtml: editor?.innerHTML ?? null,
+      emptyBreakCount: editor?.querySelectorAll('[data-editor-empty-break="true"]').length ?? -1,
+      lineBreakCount: editor?.querySelectorAll('[data-editor-line-break="true"]').length ?? -1,
+      errors: window.__composerCutErrors ?? []
+    }
+  })()`)
+  assert(
+    afterNativeEmpty.appShellStayedMounted
+      && afterNativeEmpty.workspaceStayedMounted
+      && afterNativeEmpty.editorFocused
+      && afterNativeEmpty.editorText === ''
+      && afterNativeEmpty.emptyBreakCount === 1
+      && afterNativeEmpty.lineBreakCount === 0
+      && afterNativeEmpty.errors.length === 0,
+    `A native empty filler became semantic content: ${JSON.stringify(afterNativeEmpty)}`
+  )
+
+  return {
+    clipboardText,
+    emptyDraft,
+    afterCut,
+    nextDraft,
+    afterSingleInput,
+    nativeDeleteApplied,
+    afterNativeEmptyDraft,
+    afterNativeEmpty
+  }
 }
 
 async function focusEditorAtEnd(cdp) {
@@ -2677,6 +2840,26 @@ async function copySelectionWithMetaC(cdp) {
   await cdp.send('Input.dispatchKeyEvent', {
     type: 'keyUp', key: 'c', code: 'KeyC', modifiers: 4,
     windowsVirtualKeyCode: 67, nativeVirtualKeyCode: 8
+  })
+  await cdp.send('Input.dispatchKeyEvent', {
+    type: 'keyUp', key: 'Meta', code: 'MetaLeft', modifiers: 0,
+    windowsVirtualKeyCode: 91, nativeVirtualKeyCode: 55
+  })
+}
+
+async function cutSelectionWithMetaX(cdp) {
+  await cdp.send('Input.dispatchKeyEvent', {
+    type: 'rawKeyDown', key: 'Meta', code: 'MetaLeft', modifiers: 4,
+    windowsVirtualKeyCode: 91, nativeVirtualKeyCode: 55
+  })
+  await cdp.send('Input.dispatchKeyEvent', {
+    type: 'rawKeyDown', key: 'x', code: 'KeyX', modifiers: 4,
+    windowsVirtualKeyCode: 88, nativeVirtualKeyCode: 7,
+    commands: ['Cut']
+  })
+  await cdp.send('Input.dispatchKeyEvent', {
+    type: 'keyUp', key: 'x', code: 'KeyX', modifiers: 4,
+    windowsVirtualKeyCode: 88, nativeVirtualKeyCode: 7
   })
   await cdp.send('Input.dispatchKeyEvent', {
     type: 'keyUp', key: 'Meta', code: 'MetaLeft', modifiers: 0,


### PR DESCRIPTION
## Summary

- handle Composer Cut as one synchronous clipboard + model transaction before Chromium mutates the contenteditable DOM
- preserve structured Mention/Skill selection semantics and normalize a sole native filler BR as empty content
- add packaged-Electron regression coverage for Command+X, post-cut single-character input, native empty fillers, and acceptance fixture cleanup

## Validation

- `pnpm typecheck`
- `pnpm exec vitest run` (82 files, 585 tests)
- `pnpm package:mac`
- `pnpm accept:structured-mentions-ui --cut-only`
- `pnpm accept:structured-mentions-ui --ime-newline-only`
- `pnpm accept:structured-mentions-ui`
- Impeccable detector: no findings