### PR TITLE
fix(desktop): simplify new conversation empty state

### DIFF
--- a/apps/desktop/src/renderer/src/App.test.ts
+++ b/apps/desktop/src/renderer/src/App.test.ts
@@ -2507,7 +2507,7 @@ describe('task event projections', () => {
       contextManifests: [], executionEvidence: [],
       approvals: [], actions: [], timeline: []
     }
-    const markup = renderToStaticMarkup(createElement(CampWorkspace, {
+    const workspaceProps: Parameters<typeof CampWorkspace>[0] = {
       snapshot,
       projectName: null,
       agents: [unreadyProfile],
@@ -2528,6 +2528,14 @@ describe('task event projections', () => {
       },
       onConfigureRuntime: () => undefined,
       onDismissRuntimeRecovery: () => undefined
+    }
+    const markup = renderToStaticMarkup(createElement(CampWorkspace, workspaceProps))
+    const pendingMarkup = renderToStaticMarkup(createElement(CampWorkspace, {
+      ...workspaceProps,
+      snapshot: {
+        ...snapshot,
+        camp: { ...snapshot.camp, activationState: 'pending' }
+      }
     }))
 
     expect(markup).toContain('给 洛可 发消息')
@@ -2535,6 +2543,15 @@ describe('task event projections', () => {
     expect(markup).not.toContain('和队伍继续前行：补充线索、调整方向或布置新任务…')
     expect(markup).not.toContain('默认由 Lead · 洛可接收')
     expect(markup).toContain('开始这段协作')
+    expect(markup).toContain('class="empty-camp-mark" data-brand-mark="horizon" data-brand-layout="separated"')
+    expect(markup).not.toContain('data-brand-point="rendezvous"')
+    expect(markup).not.toContain('linearGradient')
+    expect(markup).not.toContain('empty-camp-eyebrow')
+    expect(markup).not.toContain('empty-camp-description')
+    expect(markup).not.toContain('这里已经保留当前工作区、队员和默认负责人。')
+    expect(pendingMarkup).toContain('开始一段新对话')
+    expect(pendingMarkup).not.toContain('新对话草稿')
+    expect(pendingMarkup).not.toContain('当前只是一份草稿。')
     expect(markup).toContain('快速对话')
     expect(markup).toContain('负责人 · 洛可')
     expect(markup).toContain('1 位队员已在队')

--- a/apps/desktop/src/renderer/src/CampWorkspace.tsx
+++ b/apps/desktop/src/renderer/src/CampWorkspace.tsx
@@ -6309,26 +6309,17 @@ function EmptyCampWelcome({
 
   return (
     <section className="empty-camp-welcome" aria-labelledby="empty-camp-title">
-      <svg className="empty-camp-mark" viewBox="0 0 88 66" aria-hidden="true">
-        <defs>
-          <linearGradient id="empty-camp-horizon" x1="0" y1="0" x2="1" y2="0">
-            <stop offset="0" stopColor="var(--aurora)" />
-            <stop offset=".52" stopColor="var(--brand)" />
-            <stop offset="1" stopColor="var(--violet)" />
-          </linearGradient>
-        </defs>
-        <path d="M44 5l2.1 9.4 9.4 2.1-9.4 2.1L44 28l-2.1-9.4-9.4-2.1 9.4-2.1L44 5z" fill="var(--brand)" />
-        <path d="M10 48c9-11 19-16 30-15 9 .8 14 7 22 7 6 0 11-2 16-6" fill="none" stroke="url(#empty-camp-horizon)" strokeLinecap="round" strokeWidth="3" />
-        <path d="M14 54h60" fill="none" stroke="var(--line-strong)" strokeLinecap="round" />
-        <circle cx="69" cy="25" r="3" fill="var(--ember)" />
+      <svg
+        className="empty-camp-mark"
+        data-brand-mark="horizon"
+        data-brand-layout="separated"
+        viewBox="0 0 72 56"
+        aria-hidden="true"
+      >
+        <path d="M36 4 L39.6 16.7 L53.9 20.4 L39.6 24.1 L36 36.8 L32.4 24.1 L18.1 20.4 L32.4 16.7 Z" fill="currentColor" />
+        <path d="M8 49.5 Q36 37.5 64 49.5" stroke="currentColor" strokeWidth="5" fill="none" strokeLinecap="round" />
       </svg>
-      <p className="empty-camp-eyebrow">{snapshot.camp.activationState === 'pending' ? '新对话草稿' : '新对话'}</p>
       <h2 id="empty-camp-title">{snapshot.camp.activationState === 'pending' ? '开始一段新对话' : '开始这段协作'}</h2>
-      <p className="empty-camp-description">
-        {snapshot.camp.activationState === 'pending'
-          ? '当前只是一份草稿。输入内容后会自动保留；发送第一条消息时才会正式创建对话。'
-          : '这里已经保留当前工作区、队员和默认负责人。发送第一条消息后，公共讨论、执行过程和最终结论会依次展开。'}
-      </p>
 
       <div className="empty-camp-context" aria-label="当前协作配置">
         <span><i aria-hidden="true">⌂</i><strong>{projectLabel}</strong></span>

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1477,20 +1477,12 @@ button.camp-world-map-live-caption { cursor: pointer; font: inherit; }
   padding: 36px 0 56px;
   text-align: center;
 }
-.empty-camp-mark { width: 88px; height: 66px; margin-bottom: 16px; }
-.empty-camp-eyebrow {
-  margin: 0;
-  color: var(--faint);
-  font: 700 9.5px/1.3 ui-monospace, SFMono-Regular, Menlo, monospace;
-  letter-spacing: .08em;
-  text-transform: uppercase;
-}
+.empty-camp-mark { width: 96px; height: 66px; margin-bottom: 14px; color: var(--rail-logo); }
 .empty-camp-welcome h2 {
-  margin: 8px 0 7px;
+  margin: 0;
   font: 700 clamp(23px, 2.4vw, 30px)/1.2 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif;
   letter-spacing: -.035em;
 }
-.empty-camp-description { max-width: 560px; margin: 0; color: var(--muted); font-size: 12.5px; line-height: 1.65; }
 .empty-camp-context {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary

- align the new-conversation empty-state mark with the application icon, without the yellow rendezvous point
- remove the redundant draft eyebrow and explanatory paragraphs
- keep the existing workspace context, starter prompts, and composer behavior

## Validation

- `pnpm typecheck`
- `pnpm exec vitest run apps/desktop/src/renderer/src/App.test.ts` (128 passed)
- `pnpm exec vitest run apps/desktop/src/renderer/src/theme-tokens.test.ts` (23 passed)
- `pnpm test` (82 Vitest files / 585 tests; 219 Node tests passed, 1 platform skip)
- `pnpm package:mac`
- isolated packaged-App visual acceptance in Day and Night themes at 1440×920 and 1040×700
- icon DOM check: 2 paths, 0 circles, 0 rendezvous points, no gradient