### PR TITLE
fix(desktop): rename camp member action to invite

### DIFF
--- a/apps/desktop/src/renderer/src/CampWorkspace.tsx
+++ b/apps/desktop/src/renderer/src/CampWorkspace.tsx
@@ -5626,8 +5626,8 @@ function CampMembersPanel({
         setAddDialogOpen(false)
         setSelectedCandidateIds(new Set())
         onNotify(outcome.addedAgentIds.length === 1
-          ? '已添加 1 位队员；将在之后新建的执行中生效'
-          : `已添加 ${outcome.addedAgentIds.length} 位队员；将在之后新建的执行中生效`)
+          ? '1 位队员已加入；将在之后新建的执行中生效'
+          : `${outcome.addedAgentIds.length} 位队员已加入；将在之后新建的执行中生效`)
         return
       }
       setSelectedCandidateIds(new Set(outcome.failures.map((failure) => failure.agentId)))
@@ -5641,7 +5641,7 @@ function CampMembersPanel({
     } catch (error) {
       setAddResult({
         tone: 'danger',
-        message: error instanceof Error ? error.message : '添加队员失败，请重试。',
+        message: error instanceof Error ? error.message : '邀请队员失败，请重试。',
         failures: new Map()
       })
     } finally {
@@ -5751,7 +5751,7 @@ function CampMembersPanel({
               disabled={busy || !onAddMembers}
               onClick={openAddDialog}
             >
-              <span aria-hidden="true">＋</span> 添加
+              <span aria-hidden="true">＋</span> 邀请
             </button>
           </div>
         </div>
@@ -5945,7 +5945,7 @@ function CampMembersPanel({
           <Dialog.Overlay className="dialog-overlay app-dialog-overlay" />
           <AppDialogContent className="camp-member-dialog" width="wide" aria-describedby="camp-add-member-description">
             <AppDialogHeader
-              title="添加队员"
+              title="邀请队员"
               description="选择要加入这次讨论的队员。"
               descriptionId="camp-add-member-description"
               icon="user"
@@ -5968,10 +5968,10 @@ function CampMembersPanel({
                 />
               </label>
               <div className="camp-member-candidate-caption">
-                <strong>可添加队员</strong>
+                <strong>可邀请队员</strong>
                 <span>{filteredCandidates.length} 位</span>
               </div>
-              <div className="camp-member-candidate-list" role="group" aria-label="可添加队员">
+              <div className="camp-member-candidate-list" role="group" aria-label="可邀请队员">
                 {filteredCandidates.map((profile) => {
                   const failure = addResult?.failures.get(profile.agentId) ?? null
                   const checked = selectedCandidateIds.has(profile.agentId)
@@ -5999,7 +5999,7 @@ function CampMembersPanel({
                 })}
                 {filteredCandidates.length === 0 && (
                   <div className="camp-member-candidate-empty">
-                    <strong>{candidateProfiles.length === 0 ? '没有可添加的队员' : '没有匹配的队员'}</strong>
+                    <strong>{candidateProfiles.length === 0 ? '没有可邀请的队员' : '没有匹配的队员'}</strong>
                     <p>{candidateProfiles.length === 0
                       ? '所有当前在队的队员都已加入本会话。'
                       : '换一个姓名或角色关键词试试。'}</p>
@@ -6014,7 +6014,7 @@ function CampMembersPanel({
                 type="button"
                 disabled={selectedCandidateIds.size === 0 || addSubmitting}
                 onClick={() => void submitAddMembers()}
-              >{addSubmitting ? '正在添加…' : `添加队员${selectedCandidateIds.size > 0 ? ` · ${selectedCandidateIds.size}` : ''}`}</button>
+              >{addSubmitting ? '正在邀请…' : `邀请队员${selectedCandidateIds.size > 0 ? ` · ${selectedCandidateIds.size}` : ''}`}</button>
             </AppDialogFooter>
           </AppDialogContent>
         </Dialog.Portal>

--- a/docs/contracts/camp-membership-v1.md
+++ b/docs/contracts/camp-membership-v1.md
@@ -15,7 +15,7 @@ last_updated: 2026-08-26
 
 - `Camp.membershipGeneration >= 1`，每次真实成员集合变化恰好加一；幂等 no-op 不推进；
 - 每个 Agent 在一个 Camp 只有一行 `CampMember`。再次添加 left 行会把它变为 active、推进该行 `version`，
-  产品仍只称“添加队员”，不暴露 rejoined 状态；
+  产品界面仍只称“邀请队员”，不暴露 rejoined 状态；
 - Camp 始终至少一位 active member；Default Lead 若存在必须是 active member；
 - add 不创建 Conversation、CampTurn 或 AgentRun。只有以后新接受的执行按当时 active 名册冻结 Context。
 

--- a/docs/ui/components/conversation-workspace.md
+++ b/docs/ui/components/conversation-workspace.md
@@ -47,8 +47,9 @@ Camp 可以回到 Quick Chat。Notification navigation、恢复位置写入和�
 
 ## Camp 队员管理
 
-“当前会话”摘要行在标题右侧提供紧凑“添加”按钮。它打开可搜索的多选 Dialog，候选只包含当前
-`present` 且不在 active Camp members 中的 AgentProfile；曾离开的成员若再次出现，仍按普通候选与“添加队员”
+“当前会话”摘要行在标题右侧提供紧凑“邀请”按钮。它打开可搜索的多选 Dialog，说明固定为
+“选择要加入这次讨论的队员。”；候选只包含当前 `present` 且不在 active Camp members 中的 AgentProfile；
+曾离开的成员若再次出现，仍按普通候选与“邀请队员”
 文案处理，不显示“重新加入”或历史离队分组。提交按权威 membership generation 顺序执行；多选出现局部失败
 时保留失败项和明确原因，已成功项立即从候选移除，不伪装为整批回滚。
 

--- a/docs/versions/v1.29/README.md
+++ b/docs/versions/v1.29/README.md
@@ -33,8 +33,8 @@ reconciliation 完成已接受工作的正式结算。
   refs 与 durable ingest intent；新附件不再进入 legacy publication gate，不等待或 fence 活跃 AgentRun；
 - 新增 `camps.members.add`、`camps.members.removalPreview`、`camps.members.remove` Desktop API；增加使用
   exact membership generation/version 的添加、预览和移除命令；
-- 添加不创建 Conversation，也不修改已冻结 AgentRun 的 Collaboration State；曾离开的 Agent 再次添加仍是一次
-  普通“添加队员”，产品不暴露 rejoined 状态；对 active member（包括 away）的相同 overrides 为 no-op，不同
+- 添加不创建 Conversation，也不修改已冻结 AgentRun 的 Collaboration State；曾离开的 Agent 再次添加时，
+  产品界面仍按普通“邀请队员”处理，不暴露 rejoined 状态；对 active member（包括 away）的相同 overrides 为 no-op，不同
   overrides 返回 capability conflict，不由 add 静默修改能力或旋转 lifetime；受信 source 的 accepted no-op
   正常推进自身 reconciliation generation；
 - Camp 始终至少保留一位 active member。移除 Default Lead 时优先使用有效 successor；若剩余成员全部暂离，
@@ -51,7 +51,7 @@ reconciliation 完成已接受工作的正式结算。
   但不能在离队后发布内容；
 - 外部成员同步仅是提示：只有 System allowlist、已绑定的 source namespace/binding 和严格递增的 reconciliation
   generation 可以提交正式领域命令；
-- Camp 会话“当前会话”区域增加添加入口；成员行只保留一个 `•••` 菜单，收纳模型信息展开与移除。最后一位
+- Camp 会话“当前会话”区域增加“邀请”入口；成员行只保留一个 `•••` 菜单，收纳模型信息展开与移除。最后一位
   成员的移除操作可见但禁用，并解释“Camp 至少需要一位队员”；
 - 移除确认先读取权威影响预览，展示 Run、Task、Delivery、Gather 影响；冲突可刷新重试，正在 reconciliation
   的成员在会话区显示非阻塞状态。

--- a/docs/versions/v1.29/decisions.md
+++ b/docs/versions/v1.29/decisions.md
@@ -62,7 +62,7 @@ version。
 
 ### 后果
 
-- 再次添加在产品上仍是普通添加，但在授权上是新的 lifetime；
+- 再次添加在产品界面仍按普通“邀请队员”处理，但在授权上是新的 lifetime；
 - 所有 Agent 业务工具共用统一 exact-run fence，不依赖各 handler 自行记得补检查；
 - 已接受的普通 outbound A2A 不能在 source lifetime 结束后新建或重试下游 Run；
 - Missing-Send 和普通公开输出不会成为绕过离队 cutover 的旁路。

--- a/scripts/accept-member-lifecycle-ui.mjs
+++ b/scripts/accept-member-lifecycle-ui.mjs
@@ -694,24 +694,29 @@ try {
       && detail?.getAttribute('aria-label') === ${JSON.stringify(`${membershipLead.displayName}的当前模型配置`)}
   })()`)
 
-  await mouseClick(running.cdp, '.camp-add-member-button', '添加', true)
+  await mouseClick(running.cdp, '.camp-add-member-button', '邀请', true)
   await waitForSelector(running.cdp, '.camp-member-dialog')
   await waitForExpression(running.cdp,
     `document.activeElement === document.querySelector('.camp-member-search-field input')`)
   const addDialogState = await evaluate(running.cdp, `(() => ({
     title: document.querySelector('.camp-member-dialog h2')?.textContent?.trim(),
+    description: document.querySelector('.camp-member-dialog .app-dialog-description')?.textContent?.trim(),
+    candidateCaption: document.querySelector('.camp-member-candidate-caption strong')?.textContent?.trim(),
+    candidateListLabel: document.querySelector('.camp-member-candidate-list')?.getAttribute('aria-label'),
     candidateCount: document.querySelectorAll('.camp-member-candidate-row').length,
     hasRejoinCopy: /重新加入|已离开成员/.test(document.querySelector('.camp-member-dialog')?.textContent ?? '')
   }))()`)
   assert(
-    addDialogState.title === '添加队员'
+    addDialogState.title === '邀请队员'
+      && addDialogState.description === '选择要加入这次讨论的队员。'
+      && addDialogState.candidateCaption === '可邀请队员'
+      && addDialogState.candidateListLabel === '可邀请队员'
       && addDialogState.candidateCount === 3
       && !addDialogState.hasRejoinCopy,
     `Add-member dialog is unexpected: ${JSON.stringify(addDialogState)}`
   )
   await selectCampMemberCandidate(running.cdp, membershipCandidate.displayName)
-  await evaluate(running.cdp,
-    `document.querySelector('.camp-member-dialog .primary-button')?.click()`)
+  await mouseClick(running.cdp, '.camp-member-dialog .primary-button', '邀请队员', true)
   try {
     await waitForExpression(running.cdp,
       `document.querySelectorAll('.camp-inspector-member-row').length === 2
@@ -730,7 +735,7 @@ try {
       cause: error
     })
   }
-  await waitForText(running.cdp, '.app-toast', '已添加 1 位队员')
+  await waitForText(running.cdp, '.app-toast', '1 位队员已加入')
 
   await focusElement(
     running.cdp,
@@ -787,7 +792,7 @@ try {
       && !document.querySelector('.camp-member-removal-dialog')`, 30_000)
   await waitForText(running.cdp, '.app-toast', `已将${membershipCandidate.displayName}移出当前会话`)
 
-  await mouseClick(running.cdp, '.camp-add-member-button', '添加', true)
+  await mouseClick(running.cdp, '.camp-add-member-button', '邀请', true)
   await waitForSelector(running.cdp, '.camp-member-dialog')
   const ordinaryAddCopy = await evaluate(running.cdp,
     `document.querySelector('.camp-member-dialog')?.textContent ?? ''`)
@@ -797,11 +802,11 @@ try {
     `A previous membership was exposed as a product-level rejoin: ${ordinaryAddCopy}`
   )
   await selectCampMemberCandidate(running.cdp, membershipCandidate.displayName)
-  await mouseClick(running.cdp, '.camp-member-dialog .primary-button', '添加队员', true)
+  await mouseClick(running.cdp, '.camp-member-dialog .primary-button', '邀请队员', true)
   await waitForExpression(running.cdp,
     `document.querySelectorAll('.camp-inspector-member-row').length === 2
       && !document.querySelector('.camp-member-dialog')`, 30_000)
-  await waitForText(running.cdp, '.app-toast', '已添加 1 位队员')
+  await waitForText(running.cdp, '.app-toast', '1 位队员已加入')
   const membershipSnapshot = await request(running.cdp, 'camps.snapshot', {
     campId: membershipCampId
   })


### PR DESCRIPTION
## Summary

- rename the current-Camp member action and dialog copy from 添加 to 邀请
- keep the helper text fixed as 选择要加入这次讨论的队员。
- align loading, empty, success, accessibility, acceptance, and current documentation copy

## Validation

- pnpm typecheck
- pnpm test
- pnpm docs:test
- pnpm docs:check
- DOCS_BASE_REF=e8f67e8d78b8bd67fae42f02efa1f834271da77b pnpm docs:check:ci
- pnpm package:mac
- ROVAI_MEMBER_LIFECYCLE_ACCEPT_NO_SANDBOX=1 pnpm accept:member-lifecycle-ui
- Impeccable detector: no findings