### PR TITLE
fix(renderer): 修复共同记忆审核抽屉遮罩层级

### DIFF
--- a/apps/desktop/src/renderer/src/memory-review-drawer.test.ts
+++ b/apps/desktop/src/renderer/src/memory-review-drawer.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const css = readFileSync(new URL('./styles.css', import.meta.url), 'utf8')
+
+interface CssRule {
+  selectors: string[]
+  body: string
+  order: number
+}
+
+function cssRules(): CssRule[] {
+  return [...css.matchAll(/([^{}]+)\{([^{}]*)\}/g)]
+    .map((match, order) => ({
+      selectors: match[1]
+        .split(',')
+        .map((selector) => selector.trim())
+        .filter(Boolean),
+      body: match[2],
+      order
+    }))
+}
+
+function specificity(selector: string): number {
+  const ids = selector.match(/#[\w-]+/g)?.length ?? 0
+  const classes = selector.match(/\.[\w-]+/g)?.length ?? 0
+  return ids * 100 + classes * 10
+}
+
+function selectorMatchesClasses(selector: string, classNames: string[]): boolean {
+  const requiredClasses = selector.match(/\.[\w-]+/g)?.map((name) => name.slice(1)) ?? []
+  return requiredClasses.length > 0
+    && requiredClasses.every((className) => classNames.includes(className))
+}
+
+function computedZIndex(classNames: string[]): number | null {
+  let winner: { value: number, specificity: number, order: number } | null = null
+  for (const rule of cssRules()) {
+    for (const selector of rule.selectors) {
+      if (!selectorMatchesClasses(selector, classNames)) continue
+      const zIndex = rule.body.match(/(?:^|;)\s*z-index:\s*(-?\d+)/)?.[1]
+      if (!zIndex) continue
+      const next = {
+        value: Number.parseInt(zIndex, 10),
+        specificity: specificity(selector),
+        order: rule.order
+      }
+      if (
+        !winner
+        || next.specificity > winner.specificity
+        || (next.specificity === winner.specificity && next.order > winner.order)
+      ) {
+        winner = next
+      }
+    }
+  }
+  return winner?.value ?? null
+}
+
+describe('memory review drawer layering', () => {
+  it('keeps the modal overlay below the interactive review drawer', () => {
+    const overlayZIndex = computedZIndex(['dialog-overlay', 'memory-drawer-overlay'])
+    const drawerZIndex = computedZIndex(['memory-review-drawer'])
+
+    expect(overlayZIndex).not.toBeNull()
+    expect(drawerZIndex).not.toBeNull()
+    expect(overlayZIndex).toBeLessThan(drawerZIndex as number)
+  })
+})

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1131,7 +1131,7 @@ html[data-rovai-platform="win32"] .unified-sidebar-drag {
 .memory-review-drawer > header { display: flex; flex: 0 0 auto; align-items: flex-start; justify-content: space-between; gap: 16px; padding: 22px 22px 16px; border-bottom: 1px solid var(--line); }
 .memory-review-drawer h2 { margin: 0; font: 680 18px/1.3 -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif; }
 .memory-review-drawer [data-radix-dialog-description] { margin: 5px 0 0; color: var(--muted); font-size: 10.5px; line-height: 1.5; }
-.memory-drawer-overlay { z-index: 65; }
+.dialog-overlay.memory-drawer-overlay { z-index: 65; }
 .memory-review-drawer-list { min-height: 0; flex: 1 1 auto; overflow-y: auto; }
 .memory-review-section { display: grid; }
 .memory-review-section + .memory-review-section { border-top: 2px solid var(--line-strong); }


### PR DESCRIPTION
## Summary
- fix the memory review drawer overlay cascade so the drawer stays interactive
- add a CSS layering regression test for the review drawer overlay and content

Fixes #93

## Root Cause
The drawer overlay had both `.dialog-overlay` and `.memory-drawer-overlay`. The later global `.dialog-overlay` rule won the cascade and raised the overlay to `z-index: 100`, above the drawer content at `z-index: 70`.

## Verification
- `pnpm typecheck`
- `pnpm exec vitest run apps/desktop/src/renderer/src/memory-review-drawer.test.ts apps/desktop/src/renderer/src/memory-review-schedule.test.ts apps/desktop/src/renderer/src/theme-tokens.test.ts`