### PR TITLE
Release Rovai AI 0.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "rovai-core"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/rovai-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.3"
+version = "0.0.4"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rovai/desktop",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "license": "MIT",
   "type": "module"

--- a/apps/desktop/src/main/package-metadata.test.ts
+++ b/apps/desktop/src/main/package-metadata.test.ts
@@ -9,7 +9,7 @@ const packageMetadata = JSON.parse(readFileSync(
 describe('desktop package metadata', () => {
   it('keeps the visible brand separate from Electron helper bundle identity', () => {
     expect(packageMetadata.productName).toBe('Rovai AI')
-    expect(packageMetadata.version).toBe('0.0.3')
+    expect(packageMetadata.version).toBe('0.0.4')
     expect(packageMetadata.build.productName).toBe('Rovai AI')
     expect(packageMetadata.build.mac.executableName).toBeUndefined()
     expect(packageMetadata.build.win.executableName).toBe('Rovai-ai')

--- a/build/release-notes.md
+++ b/build/release-notes.md
@@ -1,17 +1,19 @@
-# Rovai AI v0.0.3
+# Rovai AI v0.0.4
 
-Rovai AI 0.0.3 is the first release that existing 0.0.2 installations can install through Settings → About & Updates.
+Rovai AI 0.0.4 makes updates proactive, expands Camp membership management, and improves long-running collaboration reliability.
 
-macOS arm64 and x64 builds use the same fixed Rovai Release Signing certificate. Windows x64 remains an unsigned Preview build and may show a SmartScreen warning.
+macOS arm64 and x64 builds use the same fixed Rovai Release Signing certificate as 0.0.3. Windows x64 remains an unsigned Preview build and may show a SmartScreen warning.
 
 ## What's Changed
 
-- Fix Renderer code blocks to use the Steel Mist visual treatment.
-- Stabilize signed macOS installs when projects are removed.
-- Truncate long Quick Chat titles.
-- Group consecutive tool activity in the execution surface.
-- Discover Windows Codex installations.
-- Make command output deltas transient.
-- Simplify grouped tool activity summaries.
+- Proactively check for new releases and surface update prompts while keeping download, installation, and restart under explicit user control.
+- Add and remove members from an existing Camp with lifecycle-safe handling for runs, deliveries, gathers, tasks, and lead replacement.
+- Ingest new managed attachments without waiting for active runs or the legacy publication gate.
+- Drop high-volume Codex command deltas before persistence to reduce event amplification and improve Camp recovery.
+- Show the latest command in live tool activity and keep completed, failed, and stopped summaries stable.
+- Preserve failed installer retries without redownloading, and keep the app usable when the native updater is unavailable.
+- Coordinate Windows upgrades with planned shutdown before the installer replaces running files.
+- Fix IME input after trailing newlines, make cut operations atomic, and simplify the new-conversation empty state.
+- Clarify Camp member invitation and multiline message guidance.
 
-**Full changelog:** https://github.com/murray17/rovai-ai/compare/v0.0.2...v0.0.3
+**Full changelog:** https://github.com/murray17/rovai-ai/compare/v0.0.3...v0.0.4

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rovai-ai",
   "productName": "Rovai AI",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "type": "module",
   "description": "A desktop workspace for long-lived agent teams, shared Camps, visible execution, and collaborative memory.",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rovai/contracts",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/scripts/accept-app-updates-ui.mjs
+++ b/scripts/accept-app-updates-ui.mjs
@@ -56,7 +56,7 @@ try {
     outputDir,
     verified: {
       isolatedPackagedApplication: true,
-      packagedVersion: '0.0.3',
+      packagedVersion: '0.0.4',
       typedIdleUpdaterSnapshot: true,
       productAndBundleName: 'Rovai AI',
       existingSettingsVisualWorld: true,
@@ -93,12 +93,12 @@ async function openAboutUpdates(cdp) {
   assert(selected, 'About & Updates Settings entry was unavailable')
   await waitForSelector(cdp, '.about-updates-settings')
   await waitForExpression(cdp,
-    `document.querySelector('.about-version-value code')?.textContent === 'v0.0.3'`)
+    `document.querySelector('.about-version-value code')?.textContent === 'v0.0.4'`)
 }
 
 async function assertAboutUpdates(cdp, context) {
   const updaterSnapshot = await evaluate(cdp, 'window.rovai.appUpdates.get()', true)
-  assert(updaterSnapshot?.currentVersion === '0.0.3'
+  assert(updaterSnapshot?.currentVersion === '0.0.4'
     && updaterSnapshot.status === 'idle'
     && updaterSnapshot.availableRelease === null
     && updaterSnapshot.lastCheckSource === null
@@ -136,7 +136,7 @@ async function assertAboutUpdates(cdp, context) {
   assert(state.heading === '关于与更新', `${context} omitted the page heading`)
   assert(state.description === 'Rovai AI 会在正式打包版本中主动检查更新；下载、安装和重启始终由你确认。',
     `${context} used the wrong description`)
-  assert(state.product === 'Rovai AI' && state.version === 'v0.0.3',
+  assert(state.product === 'Rovai AI' && state.version === 'v0.0.4',
     `${context} used the wrong product/version: ${JSON.stringify(state)}`)
   assert(state.action === '检查更新' && state.actionTag === 'BUTTON' && state.actionFocused,
     `${context} did not expose a keyboard-focusable check action`)


### PR DESCRIPTION
## Summary

- bump Desktop, contracts, and Core release version to 0.0.4
- update the shared updater release notes for v0.0.4
- keep the macOS Release workflow pinned to signing certificate SHA-256 875C6F486E223AB1889A2AD63860FBE48F7E8C0E4D94832656896BA5DA4EF82E
- keep Windows x64 labeled as unsigned Preview

## Validation

- pnpm typecheck
- pnpm test
- pnpm build:desktop
- pnpm test:rust:pr
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings

## Post-merge release gates

- run macOS signed build from main and require the combined arm64/x64 update manifest
- use the main Windows unsigned package artifact
- publish the complete updater asset set and SHA256SUMS.txt under tag v0.0.4
- verify the release manifests, asset digests, and macOS signing reports before making the release public