### PR TITLE
fix(desktop): keep member model picker open during refresh

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1068,6 +1068,7 @@ function AuthoritativeApp({
   const newConversationReturnFocus = useRef<HTMLElement | null>(null)
   const liveRuntimeEventSequence = useRef(0)
   const runtimeHealthRefreshTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const runtimeHealthRefreshIncludesMembers = useRef(false)
   const membersViewRef = useRef<MembersViewHandle>(null)
   const startupResolvedSessionId = useRef<string | null>(null)
   const pendingRestorableLocation = useRef<RestorableLocation | null>(null)
@@ -1353,13 +1354,14 @@ function AuthoritativeApp({
     return request
   }, [])
 
-  const loadMemberData = useCallback(async (): Promise<void> => {
-    const [, nextInstallations] = await Promise.all([
-      loadAgents(),
-      window.rovai.request<AdapterInstallation[]>('runtime.installations.list')
-    ])
+  const loadInstallations = useCallback(async (): Promise<void> => {
+    const nextInstallations = await window.rovai.request<AdapterInstallation[]>('runtime.installations.list')
     setInstallations(nextInstallations)
-  }, [loadAgents])
+  }, [])
+
+  const loadMemberData = useCallback(async (): Promise<void> => {
+    await Promise.all([loadAgents(), loadInstallations()])
+  }, [loadAgents, loadInstallations])
 
   const applyNavigationPreferences = useCallback((
     snapshot: NavigationPreferencesSnapshot
@@ -2126,10 +2128,16 @@ function AuthoritativeApp({
         || event.method === 'runtime.discovery.completed'
         || event.method === 'runtime.availability.updated'
       ) {
+        runtimeHealthRefreshIncludesMembers.current ||= event.method !== 'runtime.availability.updated'
         if (runtimeHealthRefreshTimer.current) clearTimeout(runtimeHealthRefreshTimer.current)
         runtimeHealthRefreshTimer.current = setTimeout(() => {
           runtimeHealthRefreshTimer.current = null
-          void Promise.all([loadHealth(), loadMemberData()]).catch(() => undefined)
+          const includeMembers = runtimeHealthRefreshIncludesMembers.current
+          runtimeHealthRefreshIncludesMembers.current = false
+          void Promise.all([
+            loadHealth(),
+            includeMembers ? loadMemberData() : loadInstallations()
+          ]).catch(() => undefined)
         }, 80)
       }
       if (shouldRefreshNavigationForCoreEvent(event, shuttingDownRef.current)) {
@@ -2151,6 +2159,7 @@ function AuthoritativeApp({
   }, [
     activeCampRefreshCoordinator,
     loadHealth,
+    loadInstallations,
     loadMemberData,
     loadOverview,
     navigationRefreshCoordinator

--- a/apps/desktop/src/renderer/src/MemberManagement.tsx
+++ b/apps/desktop/src/renderer/src/MemberManagement.tsx
@@ -1173,11 +1173,7 @@ export const MemberRuntimeForm = forwardRef<MemberRuntimeFormHandle, {
             installation={installation}
             draft={draft}
             disabled={busy !== null || !runtimeMutationAllowed}
-            onOpenModelCatalog={async () => {
-              const catalog = await openRuntimeModelCatalog(selectedKind)
-              await onReload()
-              return catalog
-            }}
+            onOpenModelCatalog={() => openRuntimeModelCatalog(selectedKind)}
             onChange={(nextDraft) => {
               setDraft(nextDraft)
               setSubmitError(null)

--- a/apps/desktop/src/renderer/src/MemberRuntimeParameters.test.ts
+++ b/apps/desktop/src/renderer/src/MemberRuntimeParameters.test.ts
@@ -5,18 +5,66 @@ import { describe, expect, it } from 'vitest'
 import type {
   AdapterInstallation,
   AdapterKind,
-  PermissionOptionDescriptor
+  PermissionOptionDescriptor,
+  RuntimeModelCatalogView
 } from '@contracts'
 import {
   MemberModelParameters,
   MemberRuntimeParameters,
   draftFromDefaults,
+  liveCatalogIsAtLeastAsRecent,
   modelCatalogStatusCopy,
   runtimeDraftForMember,
   runtimeEditorInstallation
 } from './MemberRuntimeParameters'
 
 const styles = readFileSync(new URL('./styles.css', import.meta.url), 'utf8')
+
+describe('runtime model catalog source', () => {
+  const installation = runtimeInstallation('copilot-cli')
+  const cached: RuntimeModelCatalogView = {
+    runtimeKind: 'copilot-cli',
+    cache: { ...installation.modelCatalog, status: 'stale' },
+    models: installation.snapshot!.models,
+    refreshStatus: 'scheduled',
+    diagnosticCode: null
+  }
+  const refreshed: RuntimeModelCatalogView = {
+    ...cached,
+    cache: { ...cached.cache, status: 'fresh', observedAt: '2026-07-31T00:02:00Z' },
+    refreshStatus: 'completed'
+  }
+
+  it('lets a background installation update replace the cached response', () => {
+    expect(liveCatalogIsAtLeastAsRecent(cached, cached.cache)).toBe(true)
+    expect(liveCatalogIsAtLeastAsRecent(cached, refreshed.cache)).toBe(false)
+  })
+
+  it('uses a newer response before the installation update arrives', () => {
+    expect(liveCatalogIsAtLeastAsRecent(refreshed, cached.cache)).toBe(true)
+  })
+
+  it('does not let a late older response replace an already refreshed installation', () => {
+    expect(liveCatalogIsAtLeastAsRecent(refreshed, refreshed.cache)).toBe(true)
+    expect(liveCatalogIsAtLeastAsRecent(cached, refreshed.cache)).toBe(false)
+  })
+
+  it.each(['scheduled', 'joined', 'deferred'] as const)(
+    'keeps the live %s status when observations are equal',
+    (refreshStatus) => {
+      expect(liveCatalogIsAtLeastAsRecent({ ...cached, refreshStatus }, cached.cache)).toBe(true)
+    }
+  )
+
+  it('uses the installation until a live response exists and handles missing observations', () => {
+    const unavailableCache = { ...cached.cache, status: 'unavailable' as const, observedAt: null }
+    const unavailable = { ...cached, cache: unavailableCache }
+    expect(liveCatalogIsAtLeastAsRecent(null, cached.cache)).toBe(false)
+    expect(liveCatalogIsAtLeastAsRecent(unavailable, cached.cache)).toBe(false)
+    expect(liveCatalogIsAtLeastAsRecent(refreshed, unavailableCache)).toBe(true)
+    expect(liveCatalogIsAtLeastAsRecent(unavailable, unavailableCache)).toBe(true)
+  })
+})
 
 describe('member runtime parameters', () => {
   it('presents a superseded refresh as a temporary Runtime update, not a failure', () => {

--- a/apps/desktop/src/renderer/src/MemberRuntimeParameters.tsx
+++ b/apps/desktop/src/renderer/src/MemberRuntimeParameters.tsx
@@ -476,9 +476,12 @@ function RuntimeModelPicker({
   const initialModels = modelCatalogIsServiceable(initialCache)
     ? selectableModels(installation.snapshot?.models ?? [])
     : []
-  const cache = liveCatalog?.cache ?? initialCache
-  const models = liveCatalog
-    ? (modelCatalogIsServiceable(liveCatalog.cache) ? selectableModels(liveCatalog.models) : [])
+  const activeLiveCatalog = liveCatalogIsAtLeastAsRecent(liveCatalog, initialCache)
+    ? liveCatalog
+    : null
+  const cache = activeLiveCatalog?.cache ?? initialCache
+  const models = activeLiveCatalog
+    ? (modelCatalogIsServiceable(activeLiveCatalog.cache) ? selectableModels(activeLiveCatalog.models) : [])
     : initialModels
   const explicit = draft.model.mode === 'explicit' ? draft.model : null
   const selectedModel = explicit
@@ -493,14 +496,7 @@ function RuntimeModelPicker({
     setLoading(false)
     setRefreshFailed(false)
     setLiveCatalog(null)
-  }, [
-    adapterKind,
-    installation.id,
-    installation.lastProbeAttempt?.attemptedAt,
-    installation.lastProbeAttempt?.status,
-    initialCache.observedAt,
-    initialCache.status
-  ])
+  }, [adapterKind, installation.id])
 
   const loadCatalog = (): void => {
     if (!onOpenModelCatalog) return
@@ -535,7 +531,7 @@ function RuntimeModelPicker({
     loading,
     refreshFailed: refreshFailed || persistedRefreshFailed,
     servingCachedModels: models.length > 0,
-    refreshStatus: liveCatalog?.refreshStatus ?? null
+    refreshStatus: activeLiveCatalog?.refreshStatus ?? null
   })
   const missingSelectionLabel = explicit && !selectedModel
     ? missingModelLabel(explicit.modelId, cache.status)
@@ -661,6 +657,19 @@ function selectableModels(models: ModelDescriptor[]): ModelDescriptor[] {
 
 function modelCatalogIsServiceable(cache: RuntimeModelCatalogCache): boolean {
   return cache.status === 'fresh' || cache.status === 'stale'
+}
+
+export function liveCatalogIsAtLeastAsRecent(
+  liveCatalog: RuntimeModelCatalogView | null,
+  initialCache: RuntimeModelCatalogCache
+): boolean {
+  if (!liveCatalog) return false
+  const liveObservedAt = liveCatalog.cache.observedAt
+  const initialObservedAt = initialCache.observedAt
+  if (liveObservedAt === initialObservedAt) return true
+  if (liveObservedAt === null) return false
+  if (initialObservedAt === null) return true
+  return Date.parse(liveObservedAt) >= Date.parse(initialObservedAt)
 }
 
 function latestCatalogRefreshFailed(installation: AdapterInstallation): boolean {

--- a/scripts/fixtures/desktop-startup-presentation/renderer.tsx
+++ b/scripts/fixtures/desktop-startup-presentation/renderer.tsx
@@ -1,4 +1,4 @@
-import type { DesktopStartupSnapshot, OnboardingSnapshot, RestorableLocation, RovaiApi, SupervisorSnapshot } from '@contracts'
+import type { CoreEvent, DesktopStartupSnapshot, HealthStatus, OnboardingSnapshot, RestorableLocation, RovaiApi, SupervisorSnapshot } from '@contracts'
 import { createRoot, type Root } from 'react-dom/client'
 import { flushSync } from 'react-dom'
 import { App } from '../../../apps/desktop/src/renderer/src/App'
@@ -10,6 +10,8 @@ window.addEventListener('error', event => errors.push(String(event.error?.stack 
 window.addEventListener('unhandledrejection', event => errors.push(String(event.reason)))
 const calls: string[] = []
 const listeners = new Set<(snapshot: SupervisorSnapshot) => void>()
+const coreListeners = new Set<(event: CoreEvent) => void>()
+const responses = new Map<string, unknown>()
 let now = 0
 let nextTimer = 0
 const timers = new Map<number, { at: number; callback: () => void }>()
@@ -49,7 +51,7 @@ function session(target: RestorableLocation): DesktopStartupSnapshot {
 }
 
 // Unknown query methods remain pending, never return fabricated business empties.
-// Subscriptions are inert; every authority read/mutation is recorded and checked.
+// Only Supervisor and Core event subscriptions are active; authority calls are recorded.
 function api(path = ''): unknown {
   return new Proxy(() => undefined, {
     get(_target, key) {
@@ -61,6 +63,10 @@ function api(path = ''): unknown {
         listeners.add(args[0])
         return () => listeners.delete(args[0])
       }
+      if (path === 'onEvent') {
+        coreListeners.add(args[0])
+        return () => coreListeners.delete(args[0])
+      }
       if (path.split('.').at(-1)?.startsWith('on')) return () => undefined
       if (path === 'supervisor.getSnapshot') return initialSupervisor.promise
       if (path === 'desktopSession.getStartupSnapshot') { calls.push(path); return localSession.promise }
@@ -70,6 +76,7 @@ function api(path = ''): unknown {
         newConversationDefaults: null, newConversationDefaultsRequireConfirmation: false,
         oneClickNewConversationEnabled: false, worldMapEnabled: true })
       calls.push(path === 'request' ? args[0] : path)
+      if (path === 'request' && responses.has(args[0])) return Promise.resolve(responses.get(args[0]))
       if (path === 'onboarding.get') return onboarding.promise
       return new Promise(() => undefined)
     }
@@ -99,6 +106,8 @@ async function reset(target: RestorableLocation | null = { kind: 'camp', campId 
   if (root) flushSync(() => root!.unmount())
   timers.clear()
   listeners.clear()
+  coreListeners.clear()
+  responses.clear()
   calls.length = 0
   errors.length = 0
   now = 0
@@ -231,6 +240,49 @@ Object.assign(window, { startupTest: {
       'Local session failure must be visible before 400ms')
     noAuthority()
     cases.push('local preference read errors stay local and do not wait 400ms')
+
+    await reset({ kind: 'members', agentId: null, tab: 'runtime' })
+    const health: HealthStatus = {
+      core: { ok: true, version: 'fixture', dataDir: '/isolated/fixture' },
+      database: { ok: true, path: '/isolated/fixture/rovai.sqlite' },
+      git: { installed: true, version: 'fixture' },
+      hostPlatform: 'macos-arm64', runtimeCatalog: [], runtimePlatformAdmission: [], runtimeAvailability: [],
+      searchEnvironment: { generation: 1, createdAt: '2026-08-31T00:00:00Z', pathEntryCount: 0,
+        shell: { status: 'unavailable', interactive: false, shellName: null, entryCount: 0, elapsedMillis: 0 } }
+    }
+    responses.set('health.check', health)
+    responses.set('members.list', [])
+    responses.set('runtime.installations.list', [])
+    onboarding.resolve({ schemaVersion: 2, status: 'completed', origin: 'existing_installation',
+      completedAt: '2026-08-31T00:00:00Z', selectedMemberRole: null, memberAgentId: null, quickChatCampId: null })
+    publish({ runtimeMode: 'full_core', fullCoreState: 'ready', startupPhase: null,
+      authorityState: { kind: 'current', origin: 'existing' },
+      capabilities: { ...supervisor.capabilities, authoritativeWorkspace: true, coreRequests: true } })
+    await flush()
+    await flush()
+    await advance(0)
+    check(coreListeners.size > 0, 'The production App must subscribe to Core events')
+    for (const [events, memberReads] of [
+      [['runtime.availability.updated'], 0],
+      [['runtime.discovery.updated'], 1],
+      [['runtime.discovery.completed'], 1],
+      [['runtime.discovery.updated', 'runtime.availability.updated'], 1],
+      [['runtime.availability.updated', 'runtime.discovery.completed'], 1],
+      [['runtime.availability.updated'], 0]
+    ] as const) {
+      calls.length = 0
+      for (const method of events) {
+        coreListeners.forEach(listener => listener({ method, params: { runtimeKind: 'copilot-cli' } }))
+      }
+      await advance(79)
+      check(!calls.includes('runtime.installations.list'), 'Runtime reads must wait for the shared debounce')
+      await advance(1)
+      check(calls.filter(call => call === 'health.check').length === 1, `${events}: refresh health once`)
+      check(calls.filter(call => call === 'runtime.installations.list').length === 1, `${events}: refresh installations once`)
+      check(calls.filter(call => call === 'members.list').length === memberReads, `${events}: incorrect member refresh scope`)
+    }
+    cases.push('Runtime availability refreshes health and installations without reloading members')
+    cases.push('Runtime discovery retains full refresh across mixed debounce events')
     return { ok: true, cases }
   },
   async capture(theme: string) {

--- a/scripts/lib/desktop-startup-presentation.test.mjs
+++ b/scripts/lib/desktop-startup-presentation.test.mjs
@@ -50,6 +50,8 @@ test('the production App preserves route-local cold startup feedback and Core ad
     const report = JSON.parse(stdout.split('\n').find(line => line.startsWith('{')))
     assert.equal(report.ok, true)
     assert.ok(report.cases.length >= 8)
+    assert.ok(report.cases.includes('Runtime availability refreshes health and installations without reloading members'))
+    assert.ok(report.cases.includes('Runtime discovery retains full refresh across mixed debounce events'))
   } finally {
     if (child && child.exitCode === null && child.signalCode === null) {
       child.kill('SIGKILL')


### PR DESCRIPTION
模型目录探测会刷新 installation，原先与缓存时间绑定的 reset 会关闭下拉框；移除 reset 后，旧 liveCatalog 又可能遮住后台更新。探测事件还会触发不必要的队员列表重载。

本 PR 仅修正这两处状态与刷新链路：

- Picker 只在 adapter 或 installation 身份变化时重置，按 observedAt 选择较新的目录；相同时间保留 live 响应的即时刷新状态，cache 与 models 使用同一来源。
- 删除打开模型目录后的额外 onReload；提取 loadInstallations，让 availability 事件只刷新 health 和 installations。discovery 仍执行完整刷新，80ms debounce 内完整刷新只能升级、不能降级。
- 保留已有缓存可用性、失败文案、旧请求代次保护和保存队员配置的刷新逻辑。

验证：

- pnpm test：文档与 Skill 门禁、全量 Vitest 和 Node 回归通过；Windows 专用用例按平台跳过。
- pnpm exec vitest run：99 个文件、725 个测试通过，包含新增的目录新旧来源和晚到旧请求回归。
- pnpm test:startup-presentation：复用隔离 Electron 夹具，真实 App 事件回调已验证局部刷新、discovery 完整刷新和混合事件不降级；修改前可复现 availability 错误重载 members。
- pnpm typecheck、pnpm build:desktop、git diff --check 通过。
- pnpm test:rust:staged：没有 Rust 改动，按现有路由跳过。

不修改 Core 协议，不新增依赖、缓存层、事件类型或协调器；首次点击首帧耗时不在本次优化承诺内。
