### PR TITLE
fix(desktop): remove Runtime discovery diagnostics

### DIFF
--- a/apps/desktop/.impeccable/surfaces/settings-workspace.md
+++ b/apps/desktop/.impeccable/surfaces/settings-workspace.md
@@ -122,7 +122,9 @@ installed, unsupported, unavailable and temporarily unknown. A successful bounde
 result reads “可用” and means the executable can be selected and tried; supporting copy says login, models and
 capabilities are confirmed by explicit check or first task. A path-only result remains temporarily unknown,
 never synthetic checking. Do not expose internal “found/not checked”, fingerprint or
-attempt stages. Executable path, fingerprint, backoff and audit remain inside advanced diagnostics.
+attempt stages. Do not show discovery summaries (source, entrypoint kind, candidate extension, native target
+resolution or version probe outcome) in Runtime rows on any platform. Executable path, fingerprint, backoff
+and audit remain inside advanced diagnostics.
 
 Before those machine states, every row consumes the Core-owned Runtime Platform Admission. On Windows,
 `not_qualified` renders “Windows 尚未验证” and `unsupported` renders “此平台不支持”; neither state has an

--- a/apps/desktop/src/renderer/src/App.test.ts
+++ b/apps/desktop/src/renderer/src/App.test.ts
@@ -6253,7 +6253,7 @@ describe('task event projections', () => {
     expect(markup).not.toContain('前往 Agent 运行时')
   })
 
-  it('keeps all product checks visible with redacted discovery diagnostics', () => {
+  it('keeps all product checks visible without discovery diagnostics', () => {
     const health: HealthStatus = {
       core: { ok: true, version: '0.0.1', dataDir: '/tmp/rovai' },
       database: { ok: true, path: '/tmp/rovai/rovai.db' },
@@ -6321,8 +6321,8 @@ describe('task event projections', () => {
     expect(markup.match(/检查可用性/g)).toHaveLength(12)
     expect(markup).not.toContain('重新扫描安装')
     expect(markup).toContain('codex-cli 1.0.0')
-    expect(markup).toContain('来源 inherited_path · 入口 native_executable · 后缀 native')
-    expect(markup).toContain('Native 目标 未解析 · Version Probe 成功')
+    expect(markup).not.toContain('来源 inherited_path')
+    expect(markup).not.toContain('Version Probe')
     expect(markup).not.toContain('九种已支持产品')
     expect(markup).not.toContain('自查命令')
     expect(markup).not.toContain('command -v')

--- a/apps/desktop/src/renderer/src/MemberManagement.tsx
+++ b/apps/desktop/src/renderer/src/MemberManagement.tsx
@@ -1632,9 +1632,6 @@ export function RuntimeInstallationsPanel({ health, onReload }: {
               item ?? null,
               health === null
             )
-            const discoveryDiagnostic = item
-              ? runtimeDiscoveryDiagnostic(item.discovery)
-              : null
             return (
               <article key={runtimeKind} className="runtime-product-row">
                 <span className="runtime-product-logo" aria-hidden="true">
@@ -1645,9 +1642,6 @@ export function RuntimeInstallationsPanel({ health, onReload }: {
                   <small>{admission?.status !== 'qualified'
                     ? presentation.detail
                     : item?.reportedVersion ?? adapterMaturityLabel(runtimeKind)}</small>
-                  {discoveryDiagnostic && (
-                    <small className="runtime-discovery-diagnostic">{discoveryDiagnostic}</small>
-                  )}
                 </div>
                 <span className={`runtime-snapshot-badge runtime-product-status status-${presentation.status}`}>
                   {presentation.label}
@@ -1666,21 +1660,6 @@ export function RuntimeInstallationsPanel({ health, onReload }: {
       </section>
     </>
   )
-}
-
-function runtimeDiscoveryDiagnostic(
-  discovery: ProductRuntimeAvailability['discovery']
-): string | null {
-  if (!discovery.entrypointKind || !discovery.candidateExtension) return null
-  const source = discovery.searchPathSource ?? discovery.source ?? 'unknown'
-  const target = discovery.resolvedNativeTarget ? '已解析' : '未解析'
-  const versionProbe = discovery.versionProbeSucceeded === true
-    ? '成功'
-    : discovery.versionProbeSucceeded === false ? '失败' : '未运行'
-  const extension = discovery.candidateExtension === 'native'
-    ? 'native'
-    : `.${discovery.candidateExtension}`
-  return `来源 ${source} · 入口 ${discovery.entrypointKind} · 后缀 ${extension} · Native 目标 ${target} · Version Probe ${versionProbe}`
 }
 
 function identityCommand(draft: IdentityDraft, agent: AgentProfile | null): CreateAgentProfileCommand | UpdateAgentProfileCommand {

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -7243,7 +7243,6 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
 .runtime-product-copy { display: grid; min-width: 0; gap: 3px; }
 .runtime-product-copy strong { overflow: hidden; color: var(--ink); font-size: 12.5px; font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
 .runtime-product-copy small { overflow: hidden; color: var(--workspace-faint); font-size: 10.5px; font-variant-numeric: tabular-nums; text-overflow: ellipsis; white-space: nowrap; }
-.runtime-product-copy .runtime-discovery-diagnostic { color: var(--muted); }
 .runtime-product-status { justify-self: end; white-space: nowrap; }
 .runtime-product-check { width: 110px; justify-content: center; white-space: nowrap; }
 .runtime-product-row > .runtime-failure-notice { grid-column: 2 / -1; }


### PR DESCRIPTION
Runtime 列表把可执行入口来源、类型、后缀、Native 目标解析和 Version Probe 结果直接展示给普通用户。这些诊断细节增加了页面噪声，而且 Windows 和 macOS 都会显示。

本次从共享 Renderer 组件移除整行诊断摘要，同时删除不再使用的拼接函数和专用样式。Runtime 名称、版本、可用状态、检查按钮和公开错误提示保持不变；Core 发现、探测及诊断数据不变。更新既有页面测试和设置页 brief，明确所有平台均不展示该摘要。

验证：

- `pnpm typecheck` 通过。
- `pnpm test` 通过：Vitest 102 个文件、762 项测试全部通过；后续 Node 测试 219 项通过，1 项 Windows 专用测试按平台跳过；文档与 Skill 门禁通过。
- `pnpm build:desktop` 通过。
- 使用生产组件及模拟的 macOS/Windows 状态完成日间、夜间主题预览，覆盖 1440×920 和 1040×700；诊断行消失，版本、状态和错误提示保留，无页面横向溢出。截图已本地留存；未声称完成 Windows 真机验收。
- `git diff --check` 通过。Impeccable 检查在改动区域无新增问题。
