### PR TITLE
fix(desktop): refine sidebar scrollbar

### DIFF
--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -621,7 +621,44 @@ html[data-rovai-platform="win32"] .unified-sidebar-drag {
 .command-palette-item .truncate { flex: 1 1 auto; }
 .command-palette-item small { flex: 0 0 auto; margin-left: auto; color: var(--faint); font: 10px/1.3 ui-monospace, SFMono-Regular, Menlo, monospace; }
 .command-palette-empty { margin: 0; padding: 16px 14px; color: var(--faint); font-size: 12px; text-align: center; }
-.navigation-scroll { min-height: 0; flex: 1 1 auto; overflow-x: hidden; overflow-y: auto; padding: 0 0 12px; scrollbar-width: thin; }
+.navigation-scroll {
+  --navigation-scrollbar-thumb: var(--surface-selected);
+  min-height: 0;
+  flex: 1 1 auto;
+  overflow-x: hidden;
+  overflow-y: auto;
+  margin-right: -6px;
+  padding: 0 6px 12px 0;
+  scrollbar-color: var(--navigation-scrollbar-thumb) transparent;
+  scrollbar-width: auto;
+}
+/* Updating the scroller's color also repaints the native thumb on focus changes. */
+.navigation-scroll:focus-within {
+  --navigation-scrollbar-thumb: color-mix(in srgb, var(--surface-selected) 88%, var(--ink));
+}
+@supports selector(::-webkit-scrollbar) {
+  /* Non-auto standard colors override Chromium's custom scrollbar geometry. */
+  .navigation-scroll { scrollbar-color: auto; }
+}
+/* Preserve the existing thin scrollbar's 11px gutter and paint only 7px. */
+.navigation-scroll::-webkit-scrollbar { width: 11px; }
+.navigation-scroll::-webkit-scrollbar-track,
+.navigation-scroll::-webkit-scrollbar-corner { background: transparent; }
+.navigation-scroll::-webkit-scrollbar-button { display: none; width: 0; height: 0; }
+.navigation-scroll::-webkit-scrollbar-thumb {
+  min-height: 44px;
+  border-left: 4px solid transparent;
+  border-radius: 999px;
+  background: var(--navigation-scrollbar-thumb);
+  background-clip: padding-box;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ink) 6%, transparent);
+}
+.navigation-scroll::-webkit-scrollbar-thumb:hover {
+  background-color: color-mix(in srgb, var(--surface-selected) 88%, var(--ink));
+}
+.navigation-scroll::-webkit-scrollbar-thumb:active {
+  background-color: color-mix(in srgb, var(--surface-selected) 80%, var(--ink));
+}
 .navigation-projects { margin-top: 15px; }
 .navigation-projects > .camp-nav-group + .camp-nav-group { margin-top: 8px; }
 .navigation-section-title {


### PR DESCRIPTION
## 变更
- 仅优化左侧会话菜单的 `.navigation-scroll`，不修改全局滚动条或正文、预览、执行台。
- 轨道透明，无上下箭头；滑块可见宽 7px，距侧栏内边界约 4px，默认使用 `--surface-selected`。
- Hover、Focus 和拖动仅轻微增强对比度，保留圆角。
- 保留实测原生 thin 滚动条的 11px 占位，以 4px 透明左边得到 7px 可见滑块，避免建议的 9px 占位造成操作按钮偏移。
- 在支持 WebKit 滚动条的浏览器中重置标准 scrollbar-color，避免 Chromium 覆盖自定义几何；使用局部颜色变量保证焦点状态正确重绘。

## 验证
- [x] `git diff --check`
- [x] `pnpm typecheck`
- [x] theme-tokens、theme、CampNavigationPagination：3 个测试文件，36 项测试通过
- [x] `pnpm build:desktop`
- [x] 生产 CampNavigation 组件隔离验收：浅/深主题、7px 可见宽、4px 内边距、项目/会话/操作按钮位置保持不变，其他滚动区域无变化
- [x] macOS Electron 43.1.1 / Chromium 150 隔离验收：滚轮、滑块拖动、Hover/Focus/Active、双主题像素检查（使用临时 userData，不启动真实 Core/Runtime）
- [ ] Windows 原生 Electron 真机验收尚未执行

## 范围
仅包含 `apps/desktop/src/renderer/src/styles.css`；不包含工作区中无关的预览稿。