### PR TITLE
fix(desktop): 修复执行浮层正文横向溢出

### DIFF
--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -2267,6 +2267,10 @@ html.file-preview-resizing .file-preview-pane { pointer-events: none; }
 .execution-drawer-inspector .execution-run-stop-state { max-width: 112px; min-height: 20px; overflow: hidden; padding: 0; font-size: 8.5px; text-overflow: ellipsis; }
 .execution-drawer-inspector .execution-drawer-body { padding: 10px 10px 17px; }
 .execution-drawer-inspector .execution-process-card { padding: 9px; }
+.execution-drawer-inspector .run-live,
+.execution-drawer-inspector .process-content { min-width: 0; grid-template-columns: minmax(0, 1fr); }
+.execution-drawer-inspector .process-copy pre { white-space: pre-wrap; }
+.execution-drawer-inspector .tool-call-title { display: block; line-height: 28px; }
 .execution-drawer-inspector .execution-run-model code { max-width: 18ch; }
 .execution-drawer-inspector .execution-run-recipients { display: grid; grid-template-columns: auto minmax(0, 1fr); }
 .execution-drawer-inspector .tool-group-items { margin-left: 0; padding-left: 0; }

--- a/scripts/fixtures/execution-avatar-rail/main.cjs
+++ b/scripts/fixtures/execution-avatar-rail/main.cjs
@@ -120,17 +120,62 @@ app.whenReady().then(async () => {
     assert.equal(value.inlineNames, false)
     assert.equal(value.stateIcons, true)
   }
+  const assertExecutionWidth = async () => {
+    const widths = await run(`(() => {
+      const body = document.querySelector('.execution-drawer-inspector .execution-drawer-body')
+      const bounds = body.getBoundingClientRect()
+      const boxes = [body, ...body.querySelectorAll('.execution-process-timeline, .execution-process-card, .execution-disclosure, .process-content, .process-copy, .tool-group-items')]
+        .filter(node => node.checkVisibility() && node.getBoundingClientRect().height > 0)
+        .map(node => ({ className: node.className, width: node.clientWidth, scrollWidth: node.scrollWidth }))
+      const prose = [...body.querySelectorAll('.process-copy p, .process-copy pre')].filter(node => node.checkVisibility() && node.getBoundingClientRect().height > 0)
+      const textRects = prose.flatMap(node => { const range = document.createRange(); range.selectNodeContents(node); return [...range.getClientRects()] })
+      return { boxes, textFits: textRects.every(rect => rect.left >= bounds.left && rect.right <= bounds.right),
+        completeProse: prose.some(node => node.textContent.endsWith('正文结束标记：完整可读。')) }
+    })()`)
+    assert.ok(widths.boxes.every(box => box.scrollWidth <= box.width + 1), `Execution content must fit the popover: ${JSON.stringify(widths)}`)
+    assert.ok(widths.textFits, 'Long prose wraps inside the popover instead of being clipped')
+    assert.ok(widths.completeProse, 'Wrapping preserves the full narration')
+  }
 
   try {
+    await focusWindow()
     await settle()
     let value = await state()
     if (value.panel.height === 0) value = await click('.camp-detail-entry[data-detail="execution"]')
+    value = await waitForState(value => value.panel.height > 0 && value.rail.height > 0, 'the initial execution popover')
     assert.equal(value.count, 12)
     assertLayout(value)
+    await assertExecutionWidth()
+    await run("document.querySelector('.tool-group-summary').scrollIntoView({block:'nearest',inline:'nearest',behavior:'instant'})")
+    await settle()
+    await click('.tool-group-summary')
+    await assertExecutionWidth()
+    await run("document.querySelector('.tool-call-summary').scrollIntoView({block:'center',inline:'nearest',behavior:'instant'})")
+    await settle()
+    const command = await run(`(() => {
+      const title = document.querySelector('.tool-call-title')
+      return { text: title.textContent, title: title.title, width: title.clientWidth, scrollWidth: title.scrollWidth, height: title.clientHeight }
+    })()`)
+    assert.ok(command.width > 0 && command.scrollWidth > command.width && command.height === 28, 'Long command occupies one constrained title row')
+    assert.equal(command.title, command.text, 'The full command remains available on hover and to assistive technology')
+    assert.ok(command.text.startsWith('git show HEAD -- /fixture/workspace/') && command.text.endsWith('report.md'))
+    await capture('execution-long-command')
+    await click('.tool-call-summary')
+    await assertExecutionWidth()
+    assert.equal(await run(`(() => {
+      const result = document.querySelector('.tool-call-result-scroll')
+      return result?.textContent.startsWith('$ ' + document.querySelector('.tool-call-title').textContent)
+        && result.textContent.endsWith('输出结束标记。') && result.scrollHeight > result.clientHeight
+        && result.scrollWidth <= result.clientWidth + 1
+    })()`), true, 'Expanded output preserves the full command and vertical scrolling without widening the popover')
+    await capture('execution-long-output')
+    await click('.tool-call-summary')
     assert.ok(value.rightEnabled && !value.leftEnabled)
+    await focusWindow()
+    value = await state()
     const hover = value.rects[0]
     window.webContents.sendInputEvent({ type: 'mouseMove', x: Math.round(hover.x + hover.width / 2), y: Math.round(hover.y + hover.height / 2) })
-    await settle()
+    await waitForState(value => value.tooltip?.startsWith('洛可 · '), 'the hovered member tooltip')
     assert.ok((await state()).tooltip?.startsWith('洛可 · '), 'Hover exposes the member name and status')
     window.webContents.sendInputEvent({ type: 'mouseMove', x: 800, y: 400 })
     await capture('avatar-rail-day-1440')
@@ -224,12 +269,16 @@ app.whenReady().then(async () => {
     await click('[data-count="12"]')
     await click('[data-theme-toggle]')
     await click('.camp-detail-entry[data-detail="execution"]')
+    await click('.run-pulse-avatar-rail [data-agent-id="agent-1"]')
+    await click('.execution-disclosure.worked > summary')
+    await assertExecutionWidth()
     await capture('avatar-rail-night-1440')
     window.webContents.debugger.attach('1.3')
     for (const [width, height] of [[1040, 700], [2560, 1440], [720, 460]]) {
       await window.webContents.debugger.sendCommand('Emulation.setDeviceMetricsOverride', { width, height, deviceScaleFactor: 1, mobile: false })
       await settle()
       assertLayout(await state())
+      await assertExecutionWidth()
       if (width === 1040) await capture('avatar-rail-night-1040')
     }
     await window.webContents.debugger.sendCommand('Emulation.setDeviceMetricsOverride', { width: 1440, height: 920, deviceScaleFactor: 1, mobile: false })
@@ -248,6 +297,7 @@ app.whenReady().then(async () => {
 
     console.log(JSON.stringify({ ok: true, cases: ['12/20-member overflow', '176px steps and overlap', 'mouse wheel/trackpad', 'keyboard and long-name tooltip',
       'selection and node retention', 'status refresh/reopen', 'Task navigation/repeated target', '8-member no overflow',
+      'long prose containment', 'single-line command and full expanded output',
       'Day/Night', '1040/1440/2560/200% layout', 'reduced motion', 'forced colors', 'bottom dock unchanged'] }))
     window.destroy()
     app.quit()

--- a/scripts/fixtures/execution-avatar-rail/renderer.tsx
+++ b/scripts/fixtures/execution-avatar-rail/renderer.tsx
@@ -9,6 +9,9 @@ import '../../../apps/desktop/src/renderer/src/styles.css'
 const now = '2026-08-31T04:00:00Z'
 const campId = 'rvcamp_01m0wzxbb8e1ht984tsbjmysfe'
 const fixtureMessage = '本页挂载真实的执行浮层、执行详情和三个生产入口。可检查头像横滑、键盘导航，并从任务的关联执行定位最后一位队员。'
+const longPath = `/fixture/workspace/${'execution_popover_width_regression_'.repeat(7)}report.md`
+const longCommand = `git show HEAD -- ${longPath}`
+const longNarration = `这是隔离验收数据。长正文、路径和行内代码应在浮层内完整换行，命令标题保持单行省略。\n\n检查文件：\`${longPath}\`。\n\n\`\`\`text\n${longPath}\n\`\`\`\n\n正文结束标记：完整可读。`
 const names = ['洛可', '沐瓦', '绵栀', '奇鹿', '言川', '予墨', '知夏', '负责跨项目执行审查与回归验收的长名称队员', '时屿', '星澜', '安禾', '云舒']
 const agents: AgentProfile[] = Array.from({ length: 20 }, (_, index) => ({
   agentId: `agent-${index + 1}`, displayName: names[index] ?? `队员 ${index + 1}`,
@@ -34,7 +37,7 @@ function snapshotFor(count: number, revision: number): CampSnapshot {
       cancelAcknowledgedAt: null, terminalResolutionSource: null, terminalReasonCode: null, failure: null,
       runtimeModel: { modelId: 'claude-opus-4-6' }, executionEpoch: 1, permissionSemantics: 'runtime_managed_v2',
       invocationKind: 'direct', triggerDeliveryGeneration: 0, a2aParentAgentRunId: null, a2aRootAgentRunId: null,
-      a2aDepth: 0, executionEvidenceCount: 1, hasUnsettledExternalEffects: false, workspace: { path: '/fixture/workspace' },
+      a2aDepth: 0, executionEvidenceCount: 2, hasUnsettledExternalEffects: false, workspace: { path: '/fixture/workspace' },
       startingGitObservation: null, endingGitObservation: null, version: revision + 1,
       createdAt: now, startedAt: now, endedAt: index < 3 ? null : now, updatedAt: now
     }
@@ -58,10 +61,21 @@ function snapshotFor(count: number, revision: number): CampSnapshot {
       content: [{ kind: 'text', text: fixtureMessage }], addressMode: 'default', attachments: [], addressedAgentIds: [], replyToCampMessageId: null,
       campTurnId: null, presentation: null, createdAt: now }],
     messageDeliveries: [], turns: [], agentRuns: runs,
-    executionEvidence: runs.map(run => ({ id: `evidence-${run.agentId}`, agentRunId: run.id, executionEpoch: 1,
+    executionEvidence: runs.flatMap<CampSnapshot['executionEvidence'][number]>(run => [{ id: `evidence-${run.agentId}`, agentRunId: run.id, executionEpoch: 1,
       sequence: 1, eventType: 'agent.text.delta', kind: 'narration', phase: 'updated',
-      payload: { itemId: `message-${run.agentId}`, delta: '这是隔离验收数据。队员身份、执行状态与模型仍在详情 Header 中展示；选择器只保留头像和状态符号。' },
-      contentBlobId: null, contentByteCount: 0, isTruncated: false, occurredAt: now })),
+      payload: { itemId: `message-${run.agentId}`, delta: longNarration },
+      contentBlobId: null, contentByteCount: 0, isTruncated: false, occurredAt: now }, {
+      id: `command-${run.agentId}`, agentRunId: run.id, executionEpoch: 1, sequence: 2,
+      eventType: 'activity.completed', kind: 'command', phase: 'completed',
+      payload: { item: { id: `shell-${run.agentId}`, type: 'commandExecution', command: longCommand,
+        status: 'completed', aggregatedOutput: `检查文件 ${longPath}\n${'完整输出仍可纵向滚动。\n'.repeat(24)}输出结束标记。` } },
+      canonical: { operationId: `shell-${run.agentId}`, classifierVersion: 'activity-v1',
+        activityDomain: 'shell', semanticKind: 'shell.execute', toolName: null, presentationHint: '执行 Shell 命令',
+        phase: 'terminal', outcome: 'succeeded', credibility: 'runtime_structured', coverageLevel: 'fine_grained',
+        sourceAuthority: 'runtime', sourceEvidenceIds: [`command-${run.agentId}`],
+        firstEvidenceSequence: 2, lastEvidenceSequence: 2, revision: 1 },
+      contentBlobId: null, contentByteCount: 0, isTruncated: false, occurredAt: now
+    }]),
     agentRunFileChanges: [], contextManifests: [], approvals: [], actions: [], timeline: []
   }
 }
@@ -74,6 +88,10 @@ Object.assign(window, { rovai: {
     if (method === 'skills.list' || method === 'skills.deliveryGroups.list') return []
     if (method === 'camp.composerDraft.get') return draft
     if (method === 'camp.composerDraft.save') { draft = { ...draft, ...params, revision: draft.revision + 1 }; return draft }
+    if (method === 'agentRunEvidence.getContent') {
+      const evidence = snapshotFor(20, 0).executionEvidence.find(item => item.id === params?.evidenceId)
+      if (evidence) return { payload: evidence.payload }
+    }
     throw new Error(`Unexpected fixture API: ${method}`)
   }
 } })


### PR DESCRIPTION
执行台作为浮层时，长 Markdown 代码块的内容宽度会撑开嵌套网格，导致整段正文出现横向滚动。命令标题原本使用 flex 布局，文字溢出时也没有正确显示省略号。

本次仅在执行浮层范围内补充 4 行样式：约束正文网格宽度，让代码块在框内换行，并让超长命令标题保持单行省略。完整命令仍保留在 title、可访问文本和展开后的结果中；头像轨道和底部执行台保持原样。

扩展现有真实组件原生验收，覆盖长正文、长路径、代码块、命令省略和完整输出；检查实际文本边界，防止用裁切掩盖溢出。保留头像轨道的鼠标、键盘和任务定位回归，并在操作前等待窗口焦点及浮层可见。

已同步最新 main（包含执行正文完整显示的修复）。验收通过：

- `pnpm typecheck`
- `pnpm test`：781 项 Vitest 测试通过，其余项目门禁通过
- `pnpm test:execution-avatar-rail`：日夜主题、1040/1440/2560/200% 布局、头像交互、长正文与命令回归通过
- `pnpm package:mac`
- `pnpm accept:runtime-activity-ui`：打包 App 使用隔离数据完成验收

设计静态检测未发现本次新增样式的问题；文件内既有告警不在此次修改范围。
