### PR TITLE
fix(ui): use workspace Steel for Camp popover accent

### DIFF
--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1457,7 +1457,7 @@ html[data-rovai-platform="win32"] .bootstrap-shell-brand { padding-left: 20px; }
   flex-direction: column;
   overflow: hidden;
   border: 1px solid var(--line-strong);
-  border-top: 2px solid var(--brand);
+  border-top: 2px solid var(--workspace-steel);
   border-radius: 10px;
   outline: 0;
   color: var(--ink);


### PR DESCRIPTION
执行、任务、队员浮层的顶部强调线当前使用品牌色，与执行状态和选中状态产生视觉竞争。本次将共享 `.camp-detail-popover` 的 `border-top` 改为 `2px solid var(--workspace-steel)`，让浮层延续工作区工具面板的颜色语义。

日间使用已有 Token `#476B85`，夜间使用 `#8FADC0`。只修改这一条 CSS 声明，线宽、布局、背景、圆角、阴影及交互均不变；不修改主题 Token 本身。

验证已通过：

- `pnpm typecheck`
- Theme Token、主题与文件预览布局相关测试：3 个文件、37 项测试
- `pnpm build:desktop`
- `pnpm test:camp-fast-layout`：隔离 Electron 中的生产浮层、鼠标/键盘、滚动和多尺寸布局回归；已检查日间与夜间截图
- `pnpm test:rust:staged`：无 Rust 改动，按既有路由跳过
- `git diff --check`

基线：`origin/main` / `cda0585233b1a8957e5aada34335f879ecde7af8`。无需新增或修改治理文档。合入后清理本次独立 worktree；主工作区其他未提交内容保持不动。
