### PR TITLE
fix(desktop): render leading agent member mentions

### DIFF
--- a/apps/desktop/src/renderer/src/CampWorkspace.current-user-markdown.test.ts
+++ b/apps/desktop/src/renderer/src/CampWorkspace.current-user-markdown.test.ts
@@ -40,7 +40,8 @@ const members: CampSnapshot['members'] = [{
 function renderMessage(
   content: StructuredCampMessageContent,
   body = 'NON_AUTHORITATIVE_BODY_CACHE',
-  authorType: 'agent' | 'user' = 'agent'
+  authorType: 'agent' | 'user' = 'agent',
+  campMembers = members
 ): string {
   const message: CampMessageView = {
     id: 'message-current-user-markdown',
@@ -74,7 +75,7 @@ function renderMessage(
       createdAt: '2026-08-13T00:00:00Z',
       updatedAt: '2026-08-13T00:00:00Z'
     },
-    members,
+    members: campMembers,
     membershipReconciliations: [],
     tasks: [],
     messages: [message],
@@ -279,5 +280,118 @@ describe('Agent Current User Mention Markdown rendering', () => {
       expect(markup.replace(/<[^>]*>/gu, '')).not.toContain('docs/plan.md')
     }
     expect(currentUser).toContain('message-mention-token current-user')
+  })
+})
+
+describe('Agent leading Member Mention Markdown rendering', () => {
+  it('renders the structured recipient as an interactive prefix without losing GFM', () => {
+    const markup = renderMessage([
+      { kind: 'member_mention', agentId: 'agent_reviewer' },
+      { kind: 'text', text: [
+        ' review 结论：**通过**。',
+        '',
+        '## 事实复核',
+        '',
+        '- 保留列表和 `行内代码`',
+        '- [验收说明](docs/plan.md)',
+        '',
+        '```sh',
+        'pnpm test',
+        '```',
+        '',
+        '| 项目 | 结果 |',
+        '| --- | --- |',
+        '| Mention | PASS |',
+        '',
+        '<script>alert("unsafe")</script>'
+      ].join('\n') }
+    ])
+    const token = markup.match(/<span class="message-mention-token[^\"]*" data-agent-id="agent_reviewer"[^>]*>/)?.[0]
+    expect(token).toBeDefined()
+    expect(token).toContain('is-interactive')
+    expect(token).toContain('role="button"')
+    expect(token).toContain('tabindex="0"')
+    expect(token).toContain('aria-label="查看沐瓦的基础信息"')
+    expect(token).toContain('aria-haspopup="dialog"')
+    expect(markup).toContain('member-mention-markdown-body')
+    expect(markup).toContain('data-inline-body="true"')
+    expect(markup).toContain('<strong>通过</strong>')
+    expect(markup).toContain('<h3 data-markdown-heading="事实复核">事实复核</h3>')
+    expect(markup).toContain('<ul>')
+    expect(markup).toContain('<code>行内代码</code>')
+    expect(markup).toContain('title="docs/plan.md">验收说明</a>')
+    expect(markup).toContain('<pre><code class="language-sh">pnpm test')
+    expect(markup).toContain('<table>')
+    expect(markup).not.toContain('NON_AUTHORITATIVE_BODY_CACHE')
+    expect(markup).not.toContain('<script')
+    expect(markup).not.toContain('alert(&quot;unsafe&quot;)')
+  })
+
+  it('preserves multiple leading recipients and does not mutate authoritative content', () => {
+    const content: StructuredCampMessageContent = [
+      { kind: 'text', text: ' ' },
+      { kind: 'member_mention', agentId: 'agent_reviewer' },
+      { kind: 'text', text: ' ' },
+      { kind: 'member_mention', agentId: 'agent_author' },
+      { kind: 'text', text: ' 请一起 **复核**。' }
+    ]
+    const before = JSON.stringify(content)
+    const markup = renderMessage(content)
+    expect(markup).toContain('class="message-mention-token is-interactive" data-agent-id="agent_reviewer"')
+    expect(markup).toContain('class="message-mention-token is-interactive" data-agent-id="agent_author"')
+    expect(markup).toContain('<strong>复核</strong>')
+    expect(JSON.stringify(content)).toBe(before)
+  })
+
+  it('does not turn a literal at-name in an Agent body into an identity', () => {
+    const body = '@沐瓦 review 结论：**通过**。'
+    const markup = renderMessage([{ kind: 'text', text: body }], body)
+    expect(markup).toContain('@沐瓦 review 结论：<strong>通过</strong>。')
+    expect(markup).not.toContain('member-mention-markdown-body')
+    expect(markup).not.toContain('class="message-mention-token')
+  })
+
+  it.each(['left', 'removed', 'missing'] as const)('keeps an unavailable %s recipient static', (state) => {
+    const campMembers = state === 'missing' ? [members[0]] : [members[0], {
+      ...members[1],
+      ...(state === 'left' ? { membershipStatus: 'left' as const } : { profilePresence: 'removed' as const })
+    }]
+    const markup = renderMessage([
+      { kind: 'member_mention', agentId: 'agent_reviewer' },
+      { kind: 'text', text: ' **历史消息**' }
+    ], 'NON_AUTHORITATIVE_BODY_CACHE', 'agent', campMembers)
+    const token = markup.match(/<span class="message-mention-token[^\"]*" data-agent-id="agent_reviewer"[^>]*>/)?.[0]
+    expect(token).toBeDefined()
+    expect(token).toContain('is-unavailable')
+    expect(token).not.toContain('is-interactive')
+    expect(token).not.toContain('role=')
+    expect(token).not.toContain('tabindex=')
+    expect(markup).toContain(state === 'missing' ? '@不可用队员' : '@沐瓦')
+    expect(markup).toContain('<strong>历史消息</strong>')
+  })
+
+  it('does not interpret a recipient name as Markdown or HTML', () => {
+    const campMembers = [members[0], {
+      ...members[1],
+      displayName: '[评审](https://example.com/phish)<script>unsafe()</script>'
+    }]
+    const markup = renderMessage([
+      { kind: 'member_mention', agentId: 'agent_reviewer' },
+      { kind: 'text', text: ' **通过**' }
+    ], 'NON_AUTHORITATIVE_BODY_CACHE', 'agent', campMembers)
+    expect(markup).toContain('@[评审](https://example.com/phish)&lt;script&gt;unsafe()&lt;/script&gt;')
+    expect(markup).not.toContain('href="https://example.com/phish"')
+    expect(markup).not.toContain('<script>')
+    expect(markup).toContain('<strong>通过</strong>')
+  })
+
+  it('keeps a mention-only message visible and preserves the following paragraph boundary', () => {
+    const mention: StructuredCampMessageContent[number] = { kind: 'member_mention', agentId: 'agent_reviewer' }
+    const mentionOnly = renderMessage([mention])
+    expect(mentionOnly).toContain('@沐瓦</span>')
+    expect(mentionOnly).not.toContain('member-mention-markdown-content')
+    const separated = renderMessage([mention, { kind: 'text', text: '\n\n另一段 **正文**。' }])
+    expect(separated).toContain('data-inline-body="false"')
+    expect(separated).toContain('<p>另一段 <strong>正文</strong>。</p>')
   })
 })

--- a/apps/desktop/src/renderer/src/CampWorkspace.tsx
+++ b/apps/desktop/src/renderer/src/CampWorkspace.tsx
@@ -1053,8 +1053,15 @@ export function projectLeadingCurrentUserMentionMarkdownBody(
     || content.slice(1).some((segment) => segment.kind === 'current_user_mention')
   ) return null
 
+  return structuredCampContentMarkdownText(content.slice(1), members)
+}
+
+function structuredCampContentMarkdownText(
+  content: StructuredCampMessageContent,
+  members: ReadonlyArray<Pick<CampSnapshot['members'][number], 'agentId' | 'displayName'>>
+): string {
   const names = new Map(members.map((member) => [member.agentId, member.displayName]))
-  return content.slice(1).map((segment) => {
+  return content.map((segment) => {
     if (segment.kind === 'text') return segment.text
     if (segment.kind === 'all_members_mention') return escapeMarkdownLiteral('@所有队员')
     if (segment.kind === 'member_mention') {
@@ -3949,7 +3956,11 @@ export function CampWorkspace({
                                   )
                                     ? (
                                         <div className="final-copy">
-                                          <SafeMarkdown
+                                          <AgentMessageMarkdownBody
+                                            body={displayBody}
+                                            content={campMessage.content}
+                                            members={snapshot.members}
+                                            onActivateMemberMention={openMemberProfilePopover}
                                             onFileReference={(rawReference, source, target) => {
                                               if (!filePreview) return
                                               captureFilePreviewAnchor(source)
@@ -3962,9 +3973,7 @@ export function CampWorkspace({
                                                 if (outcome.kind === 'error') onNotify(outcome.error.message)
                                               })
                                             }}
-                                          >
-                                            {displayBody}
-                                          </SafeMarkdown>
+                                          />
                                         </div>
                                       )
                                     : (
@@ -6919,10 +6928,63 @@ function MessageSurface({
   )
 }
 
+function AgentMessageMarkdownBody({
+  body,
+  content,
+  members,
+  onActivateMemberMention,
+  onFileReference
+}: {
+  body: string
+  content: StructuredCampMessageContent | null
+  members: CampSnapshot['members']
+  onActivateMemberMention(agentId: string, trigger: HTMLElement, focusPanel: boolean): void
+  onFileReference?: FileReferenceActivation
+}): JSX.Element {
+  // Only authoritative leading tokens form a recipient prefix. Literal @names
+  // stay Markdown text; the Renderer never derives addressing from the body.
+  let prefixLength = 0
+  for (const [index, segment] of (content ?? []).entries()) {
+    if (segment.kind === 'member_mention') prefixLength = index + 1
+    else if (segment.kind !== 'text' || segment.text.trim().length > 0) break
+  }
+  if (!content || prefixLength === 0) {
+    return <SafeMarkdown onFileReference={onFileReference}>{body}</SafeMarkdown>
+  }
+
+  const markdownBody = structuredCampContentMarkdownText(content.slice(prefixLength), members)
+  const hasBody = markdownBody.trim().length > 0
+  const inlineBody = hasBody && !/^\s*[\r\n]/u.test(markdownBody)
+  const prefix = (
+    <StructuredMessageBody
+      inline={hasBody}
+      body=""
+      content={content.slice(0, prefixLength)}
+      members={members}
+      onActivateMemberMention={onActivateMemberMention}
+    />
+  )
+  return (
+    <div className="member-mention-markdown-body" data-inline-body={inlineBody}>
+      {hasBody ? (
+        <SafeMarkdown
+          className="member-mention-markdown-content"
+          leadingContent={prefix}
+          inlineLeadingContent={inlineBody}
+          onFileReference={onFileReference}
+        >
+          {markdownBody}
+        </SafeMarkdown>
+      ) : prefix}
+    </div>
+  )
+}
+
 function StructuredMessageBody({
   body,
   content,
   members,
+  inline = false,
   renderLeadingCurrentUserMarkdown = false,
   onActivateMemberMention,
   onActivateAllMembersMention,
@@ -6931,6 +6993,7 @@ function StructuredMessageBody({
   body: string
   content: StructuredCampMessageContent | null
   members: CampSnapshot['members']
+  inline?: boolean
   renderLeadingCurrentUserMarkdown?: boolean
   onActivateMemberMention?(
     agentId: string,
@@ -6958,8 +7021,9 @@ function StructuredMessageBody({
     )
   }
   const memberById = new Map(members.map((member) => [member.agentId, member]))
+  const Tag = inline ? 'span' : 'p'
   return (
-    <p className="structured-message-body">
+    <Tag className="structured-message-body">
       {content.map((segment, index) => {
         if (segment.kind === 'text') return (
           <span key={`text-${index}`}>
@@ -7050,7 +7114,7 @@ function StructuredMessageBody({
           </span>
         )
       })}
-    </p>
+    </Tag>
   )
 }
 

--- a/apps/desktop/src/renderer/src/SafeMarkdown.test.ts
+++ b/apps/desktop/src/renderer/src/SafeMarkdown.test.ts
@@ -62,3 +62,44 @@ describe('SafeMarkdown file preview references', () => {
     expect(markup).not.toContain('class="markdown-file-reference"')
   })
 })
+
+describe('SafeMarkdown trusted leading content', () => {
+  const prefix = createElement('span', { className: 'trusted-prefix' }, '@评审')
+
+  it('keeps the prefix inside the first native paragraph without flattening Markdown', () => {
+    const markup = renderToStaticMarkup(createElement(SafeMarkdown, {
+      leadingContent: prefix,
+      children: 'review **通过**。\n\n第二段。'
+    }))
+    expect(markup).toContain('<p><span class="trusted-prefix">@评审</span> review <strong>通过</strong>。</p>')
+    expect(markup).toContain('<p>第二段。</p>')
+    expect(markup.match(/trusted-prefix/g)).toHaveLength(1)
+    expect(markup).not.toContain('data-rovai-leading-content')
+  })
+
+  it('gives block content and explicitly separated prose their own paragraphs', () => {
+    for (const children of ['## 标题', '- 列表', '> 引用', '```sh\npnpm test\n```']) {
+      const markup = renderToStaticMarkup(createElement(SafeMarkdown, { leadingContent: prefix, children }))
+      expect(markup).toContain('<p><span class="trusted-prefix">@评审</span></p>')
+      expect(markup).not.toContain('<p><p>')
+      expect(markup.match(/trusted-prefix/g)).toHaveLength(1)
+    }
+    const separated = renderToStaticMarkup(createElement(SafeMarkdown, {
+      leadingContent: prefix,
+      inlineLeadingContent: false,
+      children: '\n\n单独一段。'
+    }))
+    expect(separated).toContain('<p><span class="trusted-prefix">@评审</span></p>\n<p>单独一段。</p>')
+  })
+
+  it('preserves reference definitions and does not accept a prefix marker from raw HTML', () => {
+    const markup = renderToStaticMarkup(createElement(SafeMarkdown, {
+      leadingContent: prefix,
+      children: '[doc]: https://example.com/review\n\n查看 [说明][doc]。\n\n<p data-rovai-leading-content="true">forged</p>'
+    }))
+    expect(markup).toContain('<p><span class="trusted-prefix">@评审</span> 查看 <a href="https://example.com/review"')
+    expect(markup.match(/trusted-prefix/g)).toHaveLength(1)
+    expect(markup).not.toContain('forged')
+    expect(markup).not.toContain('data-rovai-leading-content')
+  })
+})

--- a/apps/desktop/src/renderer/src/SafeMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/SafeMarkdown.tsx
@@ -1,4 +1,4 @@
-import { isValidElement, useEffect, useLayoutEffect, useMemo, useRef, type JSX, type ReactNode } from 'react'
+import { createContext, isValidElement, useContext, useEffect, useLayoutEffect, useMemo, useRef, type JSX, type ReactNode } from 'react'
 import Markdown, { defaultUrlTransform } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { FILE_REFERENCE_FRAGMENT, FileReferenceLink, type FileReferenceActivation } from './FileReferenceLink'
@@ -16,6 +16,28 @@ type MarkdownTreeNode = {
   children?: MarkdownTreeNode[]
   url?: string
   data?: { hProperties?: Record<string, string> }
+}
+
+const LeadingMarkdownContentContext = createContext<ReactNode>(null)
+
+function LeadingMarkdownContent(): JSX.Element {
+  return <>{useContext(LeadingMarkdownContentContext)}</>
+}
+
+function remarkLeadingContent({ enabled, inline }: { enabled: boolean; inline: boolean }): (tree: MarkdownTreeNode) => void {
+  return (tree) => {
+    if (!enabled) return
+    const children = tree.children ??= []
+    const firstBlock = children.find((node) => !['definition', 'footnoteDefinition'].includes(node.type ?? ''))
+    const paragraph = inline && firstBlock?.type === 'paragraph'
+      ? firstBlock
+      : { type: 'paragraph', children: [] }
+    if (paragraph !== firstBlock) children.unshift(paragraph)
+    paragraph.data = {
+      ...paragraph.data,
+      hProperties: { ...paragraph.data?.hProperties, 'data-rovai-leading-content': 'true' }
+    }
+  }
 }
 
 function markdownHeadingText(children: ReactNode): string {
@@ -120,7 +142,9 @@ export function SafeMarkdown({
   onFileReference,
   localImageUrl,
   headingTarget,
-  onHeadingTargetResult
+  onHeadingTargetResult,
+  leadingContent,
+  inlineLeadingContent = true
 }: {
   children: string
   className?: string
@@ -128,6 +152,9 @@ export function SafeMarkdown({
   localImageUrl?(rawReference: string): string | null
   headingTarget?: string
   onHeadingTargetResult?(found: boolean): void
+  /** Trusted inline UI, never parsed from the Markdown source. */
+  leadingContent?: ReactNode
+  inlineLeadingContent?: boolean
 }): JSX.Element {
   const rootRef = useRef<HTMLDivElement>(null)
   const callbacks = useRef({ onFileReference, onHeadingTargetResult })
@@ -135,6 +162,7 @@ export function SafeMarkdown({
     callbacks.current = { onFileReference, onHeadingTargetResult }
   }, [onFileReference, onHeadingTargetResult])
   const fileReferencesEnabled = Boolean(onFileReference)
+  const hasLeadingContent = leadingContent !== undefined && leadingContent !== null
 
   useEffect(() => {
     if (!headingTarget) return undefined
@@ -148,6 +176,7 @@ export function SafeMarkdown({
   // Parsing old messages must not be coupled to Composer keystrokes or Runtime
   // deltas. Keep event callbacks fresh without rebuilding the Markdown tree;
   // image projection changes still invalidate it because they change the output.
+  // Leading UI reads context so member/profile updates do not reparse Markdown.
   const markdown = useMemo(() => {
     const heading = (Tag: 'h3' | 'h4') => function MarkdownHeading({ children: headingChildren }: { children?: ReactNode }) {
       const text = markdownHeadingText(headingChildren)
@@ -159,7 +188,8 @@ export function SafeMarkdown({
         remarkPlugins={[
           [remarkGfm, { singleTilde: false }],
           remarkRepairCjkUrlTail,
-          ...(fileReferencesEnabled ? [remarkFileReferences] : [])
+          ...(fileReferencesEnabled ? [remarkFileReferences] : []),
+          [remarkLeadingContent, { enabled: hasLeadingContent, inline: inlineLeadingContent }]
         ]}
         skipHtml
         disallowedElements={[
@@ -168,6 +198,16 @@ export function SafeMarkdown({
         ]}
         unwrapDisallowed
         components={{
+          p({ node, children: paragraphChildren }) {
+            const leading = node?.properties['data-rovai-leading-content'] === 'true'
+            return (
+              <p>
+                {leading && <LeadingMarkdownContent />}
+                {leading && paragraphChildren ? ' ' : null}
+                {paragraphChildren}
+              </p>
+            )
+          },
           h1: heading('h3'),
           h2: heading('h3'),
           h3: heading('h4'),
@@ -240,11 +280,13 @@ export function SafeMarkdown({
         {children}
       </Markdown>
     )
-  }, [children, fileReferencesEnabled, localImageUrl])
+  }, [children, fileReferencesEnabled, localImageUrl, hasLeadingContent, inlineLeadingContent])
 
   return (
-    <div ref={rootRef} className={className ? `safe-markdown ${className}` : 'safe-markdown'}>
-      {markdown}
-    </div>
+    <LeadingMarkdownContentContext.Provider value={leadingContent}>
+      <div ref={rootRef} className={className ? `safe-markdown ${className}` : 'safe-markdown'}>
+        {markdown}
+      </div>
+    </LeadingMarkdownContentContext.Provider>
   )
 }

--- a/scripts/accept-structured-mentions-ui.mjs
+++ b/scripts/accept-structured-mentions-ui.mjs
@@ -70,6 +70,30 @@ const currentUserMentionContent = [
   { kind: 'current_user_mention', userId: 'local_user' },
   { kind: 'text', text: currentUserMentionText }
 ]
+const agentMemberMentionMessageId = 'message-agent-member-mention-accept'
+const agentLiteralMentionMessageId = 'message-agent-literal-mention-accept'
+const agentMemberMentionText = [
+  ' review 结论：**通过**。请检查开头的队员 Mention。',
+  '',
+  '## 事实复核',
+  '',
+  '- 保留列表与 `行内代码`',
+  '- 保留 [验收说明](docs/plan.md) 文件链接',
+  '',
+  '```sh',
+  'pnpm test',
+  '```',
+  '',
+  '| 检查项 | 结果 |',
+  '| --- | --- |',
+  '| Markdown | PASS |'
+].join('\n')
+const agentMemberMentionBody = `@叮叮${agentMemberMentionText}`
+const agentMemberMentionContent = [
+  { kind: 'member_mention', agentId: 'agent_1' },
+  { kind: 'text', text: agentMemberMentionText }
+]
+const agentLiteralMentionBody = '@叮叮 是普通文字，不应打开人物信息卡。'
 const nativeDomRegressionBody = '原生输入回归'
 const acceptanceModelCatalog = JSON.stringify([{
   id: 'gpt-structured-mentions-accept',
@@ -1405,10 +1429,12 @@ try {
   // App then exercises the real read model, copy bridge, and Composer paste.
   await closeApp(running)
   running = null
+  await insertAgentMemberMentionFixtures(databasePath, campId)
   await insertCurrentUserMentionFixture(databasePath, campId)
   running = await launchApp(dataDir, debugPort, 1440, 920)
   await setTheme(running.cdp, 'night')
   await openCamp(running.cdp, campId)
+  const agentMemberMentionInspection = await acceptAgentMemberMention(running.cdp)
   await waitForExpression(running.cdp, `(() => {
     const message = document.querySelector('[data-message-id=${JSON.stringify(currentUserMentionMessageId)}]')
     return message?.querySelector('.current-user-markdown-body, .structured-message-body')?.textContent
@@ -1907,6 +1933,7 @@ try {
     mentionSelectedText,
     selectedText,
     currentUserMentionInspection,
+    agentMemberMentionInspection,
     currentUserClipboardPayload,
     currentUserPasteDowngradedToText: true,
     availableReplyDraft,
@@ -2068,6 +2095,165 @@ async function insertCurrentUserMentionFixture(path, campId) {
     FROM camp WHERE id = ${sqlLiteral(campId)};
     COMMIT;
   `)
+}
+
+async function insertAgentMemberMentionFixtures(path, campId) {
+  // These are inert presentation fixtures: no Delivery, Run or model invocation.
+  for (const message of [
+    { id: agentMemberMentionMessageId, body: agentMemberMentionBody, content: agentMemberMentionContent, recipients: ['agent_1'] },
+    { id: agentLiteralMentionMessageId, body: agentLiteralMentionBody, content: [{ kind: 'text', text: agentLiteralMentionBody }], recipients: [] }
+  ]) {
+    await runSql(path, `
+      BEGIN IMMEDIATE;
+      UPDATE camp SET last_message_sequence = last_message_sequence + 1, version = version + 1
+      WHERE id = ${sqlLiteral(campId)};
+      INSERT INTO camp_message(
+        id, camp_id, sequence, author_type, author_id, body, structured_content_json,
+        content_digest, address_mode, addressed_agent_ids_json, effective_recipient_ids_json,
+        agent_addressing_mode, version, created_at, updated_at
+      ) SELECT
+        ${sqlLiteral(message.id)}, id, last_message_sequence, 'agent', 'agent_2',
+        ${sqlLiteral(message.body)}, ${sqlLiteral(JSON.stringify(message.content))},
+        ${sqlLiteral(`sha256:structured-mentions-accept:${message.id}`)},
+        ${sqlLiteral(message.recipients.length ? 'explicit' : 'default')},
+        ${sqlLiteral(JSON.stringify(message.recipients))}, ${sqlLiteral(JSON.stringify(message.recipients))},
+        'automatic', 1, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+      FROM camp WHERE id = ${sqlLiteral(campId)};
+      COMMIT;
+    `)
+  }
+}
+
+async function acceptAgentMemberMention(cdp) {
+  const messageSelector = `[data-message-id="${agentMemberMentionMessageId}"]`
+  const tokenSelector = `${messageSelector} .message-mention-token[data-agent-id="agent_1"]`
+  await waitForSelector(cdp, tokenSelector)
+  const cases = []
+  const screenshots = {}
+  for (const variant of [
+    { name: 'day', theme: 'day', width: 1440, height: 920 },
+    { name: 'night', theme: 'night', width: 1440, height: 920 },
+    { name: 'day-compact', theme: 'day', width: 1040, height: 700 },
+    { name: 'night-compact', theme: 'night', width: 1040, height: 700 },
+    { name: 'night-wide', theme: 'night', width: 2560, height: 1440 },
+    { name: 'night-zoom200', theme: 'night', width: 2560, height: 1440, zoom: 2 }
+  ]) {
+    await setTheme(cdp, variant.theme)
+    if (variant.zoom) await emulateDesktopZoom(cdp, variant.width, variant.height, variant.zoom)
+    else await setViewport(cdp, variant.width, variant.height)
+    await evaluate(cdp, `document.querySelector(${JSON.stringify(messageSelector)})?.scrollIntoView({ block: 'start' })`)
+    await cdp.send('Input.dispatchMouseEvent', { type: 'mouseMoved', x: 2, y: 2, button: 'none', buttons: 0 })
+    await wait(180)
+    const inspection = await evaluate(cdp, `(() => {
+      const message = document.querySelector(${JSON.stringify(messageSelector)})
+      const token = message?.querySelector('.message-mention-token')
+      const body = message?.querySelector('.member-mention-markdown-content')
+      const paragraph = body?.querySelector('p')
+      if (!token || !body || !paragraph) return null
+      const style = getComputedStyle(token)
+      const colorProbe = document.createElement('span')
+      colorProbe.style.color = 'var(--mention-ink)'
+      document.body.appendChild(colorProbe)
+      const expectedColor = getComputedStyle(colorProbe).color
+      colorProbe.remove()
+      const line = document.createRange()
+      const bodyText = [...paragraph.childNodes].find((node) => node.nodeType === Node.TEXT_NODE && node.textContent.trim())
+      line.setStart(bodyText, 0)
+      line.setEnd(bodyText, 1)
+      const paragraphStyle = getComputedStyle(paragraph)
+      const timeline = document.querySelector('.camp-timeline')
+      const literal = document.querySelector('[data-message-id="${agentLiteralMentionMessageId}"]')
+      return {
+        tokenText: token.textContent,
+        role: token.getAttribute('role'), tabIndex: token.getAttribute('tabindex'),
+        label: token.getAttribute('aria-label'), popup: token.getAttribute('aria-haspopup'),
+        color: style.color, expectedColor, background: style.backgroundColor,
+        display: style.display, cursor: style.cursor,
+        sameLine: Math.abs(token.getBoundingClientRect().top - line.getBoundingClientRect().top) < 3,
+        paragraphDisplay: paragraphStyle.display,
+        proseWidthPreserved: innerWidth < 1800 || (
+          paragraph.getBoundingClientRect().width <= parseFloat(paragraphStyle.maxWidth) + 1
+          && Number.isFinite(parseFloat(paragraphStyle.maxWidth))
+        ),
+        heading: body.querySelector('h3')?.textContent,
+        listCount: body.querySelectorAll('li').length,
+        strong: body.querySelector('strong')?.textContent,
+        code: body.querySelector('pre code')?.textContent?.trim(),
+        table: Boolean(body.querySelector('table')),
+        fileLink: Boolean(body.querySelector('a[title="docs/plan.md"]')),
+        literalText: literal?.querySelector('.safe-markdown')?.textContent,
+        literalHasToken: Boolean(literal?.querySelector('.message-mention-token')),
+        noOverflow: document.documentElement.scrollWidth <= innerWidth + 1
+          && timeline.scrollWidth <= timeline.clientWidth + 1
+      }
+    })()`)
+    assert(inspection && inspection.tokenText === '@叮叮'
+      && inspection.role === 'button' && inspection.tabIndex === '0'
+      && inspection.label === '查看叮叮的基础信息' && inspection.popup === 'dialog'
+      && inspection.color === inspection.expectedColor && inspection.background === 'rgba(0, 0, 0, 0)'
+      && inspection.display === 'inline' && inspection.cursor === 'pointer'
+      && inspection.sameLine && inspection.paragraphDisplay === 'block' && inspection.proseWidthPreserved
+      && inspection.heading === '事实复核' && inspection.listCount === 2
+      && inspection.strong === '通过' && inspection.code === 'pnpm test'
+      && inspection.table && inspection.fileLink && inspection.noOverflow
+      && inspection.literalText === agentLiteralMentionBody && !inspection.literalHasToken,
+    `Agent Member Mention regression (${variant.name}): ${JSON.stringify(inspection)}`)
+    cases.push({ variant: variant.name, ...inspection })
+    screenshots[variant.name] = join(outputDir, `agent-member-mention-${variant.name}.png`)
+    await capture(cdp, screenshots[variant.name])
+  }
+
+  await setViewport(cdp, 1440, 920)
+  await setTheme(cdp, 'night')
+  await evaluate(cdp, `window.getSelection()?.removeAllRanges()`)
+  await mouseClick(cdp, tokenSelector)
+  await waitForExpression(cdp, `document.querySelector('.mention-profile-popover')?.classList.contains('is-positioned')`)
+  await wait(180)
+  assertSelectedMemberPopover(await inspectMentionPopover(cdp), 'Agent leading Mention click')
+  screenshots.popover = join(outputDir, 'agent-member-mention-popover.png')
+  await capture(cdp, screenshots.popover)
+  await pressEscape(cdp)
+  await waitForExpression(cdp, `!document.querySelector('.mention-profile-popover')`)
+  for (const activation of [
+    { key: 'Enter', code: 'Enter', windowsVirtualKeyCode: 13, nativeVirtualKeyCode: 36 },
+    { key: ' ', code: 'Space', windowsVirtualKeyCode: 32, nativeVirtualKeyCode: 49 }
+  ]) {
+    await evaluate(cdp, `document.querySelector(${JSON.stringify(tokenSelector)})?.focus()`)
+    await pressKey(cdp, activation)
+    await waitForExpression(cdp, `document.querySelector('.mention-profile-popover')?.classList.contains('is-positioned')`)
+    await wait(180)
+    assertSelectedMemberPopover(await inspectMentionPopover(cdp), `Agent leading Mention ${activation.code}`)
+    await pressEscape(cdp)
+    await waitForExpression(cdp, `!document.querySelector('.mention-profile-popover')
+      && document.activeElement === document.querySelector(${JSON.stringify(tokenSelector)})`)
+  }
+
+  const drag = await evaluate(cdp, `(() => {
+    const token = document.querySelector(${JSON.stringify(tokenSelector)})
+    token.scrollIntoView({ block: 'center' })
+    const paragraph = document.querySelector(${JSON.stringify(messageSelector)} + ' .member-mention-markdown-content > p')
+    const text = [...paragraph.childNodes].find((node) => node.nodeType === Node.TEXT_NODE && node.textContent.trim())
+    const point = (node, offset, end) => {
+      const range = document.createRange()
+      range.setStart(node, offset); range.setEnd(node, offset + 1)
+      const rect = range.getBoundingClientRect()
+      return { x: end ? rect.right - 0.1 : rect.left + 0.1, y: rect.top + rect.height / 2 }
+    }
+    return { start: point(token.firstChild, 0, false), end: point(text, text.textContent.indexOf('review') + 5, true) }
+  })()`)
+  await dispatchMouseDrag(cdp, drag.start, drag.end)
+  const selectedText = await evaluate(cdp, `window.getSelection()?.toString() ?? ''`)
+  assert(selectedText.includes('@叮叮') && selectedText.includes('review')
+    && !(await evaluate(cdp, `Boolean(document.querySelector('.mention-profile-popover'))`)),
+  `Agent Mention drag selection failed: ${JSON.stringify(selectedText)}`)
+  await evaluate(cdp, `window.getSelection()?.removeAllRanges()`)
+  await moveMouseToElement(cdp, `${messageSelector} .message-surface`)
+  await mouseClick(cdp, `${messageSelector} .message-copy-button`)
+  await waitForExpression(cdp, `document.querySelector(${JSON.stringify(messageSelector)} + ' .copy-feedback')?.textContent === '已复制'`)
+  const copiedText = await runProcess('/usr/bin/pbpaste', [])
+  assert(copiedText === agentMemberMentionBody, `Agent Mention copy lost source content: ${JSON.stringify(copiedText)}`)
+  await evaluate(cdp, `document.querySelector('[data-message-id="${currentUserMentionMessageId}"]')?.scrollIntoView({ block: 'center' })`)
+  return { cases, screenshots, activations: ['click', 'Enter', 'Space'], selectedText, copyPreserved: true }
 }
 
 async function removeDirectoryWithRetry(path) {


### PR DESCRIPTION
## Summary

- 修复 Agent 公共消息开头的结构化 Member Mention 被普通 Markdown 正文扁平化的问题，复用已有蓝色 Mention 和人物信息卡交互。
- 将可信 Mention 前缀放入 Markdown 原生段落，保持宽屏正文行宽、GFM、文件链接及 Markdown 解析缓存；不从普通 `@名字` 文本推导身份。
- 保持当前用户 Mention、不可用队员、复制和收件人路由的既有语义，不修改 Core 消息或 Delivery 数据。
- 补充结构化前缀、恶意显示名、Markdown 分块和原始 HTML 安全回归，以及真实 App 的日夜主题、宽窄窗口、200% 缩放、点击/键盘/拖选/复制验收。

## Validation

本修复的隔离 macOS arm64 开发包已由用户验收通过。该包完成了：

- `pnpm package:mac` 及 App / Core / CLI 签名校验
- 完整结构化 Mention 成品验收
- Composer Skill Picker 专项成品验收
- Runtime activity / A2A footer 成品验收

分支基于 `253d53f6`（会话投影调整合入后）。推送前重新验证并全部通过：

- `pnpm typecheck`
- `pnpm test`：843 项 Vitest 测试；219 项 Node 测试，1 项 Windows 平台测试跳过
- `pnpm test:rust:staged`：无 Rust 改动，按规则跳过 staged Rust 检查
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `pnpm test:rust:pr`：418 项 fast、32 项 CLI、294 项 slow integration 测试

合并前继续等待 GitHub CI 验证与当前 `main` 的集成。

本 PR 仅包含修复与测试，不包含开发包、样例数据库、个人目录、截图或其他原型改动。
