### PR TITLE
fix(core): resume delivery pumps after cancellation

### DIFF
--- a/crates/rovai-core/src/agent_profile.rs
+++ b/crates/rovai-core/src/agent_profile.rs
@@ -2642,7 +2642,8 @@ impl AgentProfileService {
         database: &mut Database,
         envelope: &CommandEnvelope<RemoveMemberCommand>,
     ) -> Result<CommandExecution> {
-        self.gateway.execute(database, envelope, |transaction| {
+        let mut settled_run_ids = Vec::new();
+        let execution = self.gateway.execute(database, envelope, |transaction| {
             if !matches!(envelope.actor, crate::command::ActorRef::User { .. }) {
                 return Ok(CommandHandlerResult::rejected(
                     "agent_profile.remove_user_required",
@@ -2745,7 +2746,7 @@ impl AgentProfileService {
                     .collect::<rusqlite::Result<Vec<_>>>()?
             };
             for camp_id in current_camps {
-                end_camp_membership(
+                let outcome = end_camp_membership(
                     transaction,
                     &camp_id,
                     &envelope.payload.agent_id,
@@ -2756,6 +2757,7 @@ impl AgentProfileService {
                     envelope.execution_epoch,
                     &now,
                 )?;
+                settled_run_ids.extend(outcome.affected_run_ids);
             }
             transaction.execute(
                 r#"
@@ -2775,7 +2777,9 @@ impl AgentProfileService {
                 version + 1,
                 "agent_profile.removed",
             ))
-        })
+        })?;
+        crate::runtime::pump_targets_after_runs_terminal(database, &settled_run_ids)?;
+        Ok(execution)
     }
 
     pub fn create_installation(
@@ -4244,8 +4248,9 @@ fn runtime_blocker(code: &str, payload: Value) -> RuntimeConfigurationBlocker {
     }
 }
 
-#[cfg(test)]
-pub(crate) fn configure_test_runtime(database: &Database, agent_ids: &[&str]) {
+#[cfg(any(test, feature = "slow-tests"))]
+#[doc(hidden)]
+pub fn configure_test_runtime(database: &Database, agent_ids: &[&str]) {
     let now = chrono::Utc::now().to_rfc3339();
     let installation_id = "adapter-test-codex";
     let executable_path = std::env::current_exe()

--- a/crates/rovai-core/src/channel.rs
+++ b/crates/rovai-core/src/channel.rs
@@ -4264,7 +4264,8 @@ impl ChannelService {
             anyhow::bail!("managed Quick Chat path is unavailable");
         }
         let quick_chat_path = quick_chat_path.to_string_lossy().to_string();
-        self.gateway.execute(database, envelope, |transaction| {
+        let mut settled_run_ids = Vec::new();
+        let execution = self.gateway.execute(database, envelope, |transaction| {
             if !is_channel_host(&envelope.actor) {
                 return Ok(rejected(
                     "channel.host_required",
@@ -4552,7 +4553,13 @@ impl ChannelService {
             )?;
             mark_aggregate_finalized(transaction, &aggregate.id, &now_text)?;
             let admission = if queue_position == 1 {
-                try_admit_request(transaction, &request_id, &now_text, &envelope.command_id)?
+                try_admit_request(
+                    transaction,
+                    &request_id,
+                    &now_text,
+                    &envelope.command_id,
+                    &mut settled_run_ids,
+                )?
             } else {
                 AdmissionAttempt::Deferred
             };
@@ -4589,7 +4596,9 @@ impl ChannelService {
                     entity_id: request_id,
                 }),
             ))
-        })
+        })?;
+        crate::runtime::pump_targets_after_runs_terminal(database, &settled_run_ids)?;
+        Ok(execution)
     }
 
     pub fn resolve_pending_camp_binding(
@@ -4636,7 +4645,8 @@ impl ChannelService {
         if !quick_chat {
             refresh_project_catalog(database)?;
         }
-        self.gateway.execute(database, envelope, |transaction| {
+        let mut settled_run_ids = Vec::new();
+        let execution = self.gateway.execute(database, envelope, |transaction| {
             if !is_channel_host(&envelope.actor) {
                 return Ok(rejected(
                     "channel.host_required",
@@ -5007,7 +5017,13 @@ impl ChannelService {
             }
             for (index, (request_id, queue_position, ack_app_id)) in queued.iter().enumerate() {
                 let admission = if index == 0 {
-                    try_admit_request(transaction, request_id, &now_text, &envelope.command_id)?
+                    try_admit_request(
+                        transaction,
+                        request_id,
+                        &now_text,
+                        &envelope.command_id,
+                        &mut settled_run_ids,
+                    )?
                 } else {
                     AdmissionAttempt::Deferred
                 };
@@ -5067,7 +5083,9 @@ impl ChannelService {
                     entity_id: binding_id,
                 }),
             ))
-        })
+        })?;
+        crate::runtime::pump_targets_after_runs_terminal(database, &settled_run_ids)?;
+        Ok(execution)
     }
 
     pub fn authorize_execution_console_page(
@@ -5237,6 +5255,7 @@ impl ChannelService {
             .context("Channel Host actor does not identify a supported provider")?;
         // Even an empty response can expire, settle or admit work. Keep all
         // maintenance and delivery claims atomic, but never journal the poll.
+        let mut settled_run_ids = Vec::new();
         let transaction = database
             .connection_mut()
             .transaction_with_behavior(TransactionBehavior::Immediate)?;
@@ -5272,7 +5291,7 @@ impl ChannelService {
             decline_unattended_channel_retries(&transaction, actor, &now_text)?;
             project_active_request_deliveries(&transaction, &now_text)?;
             settle_terminal_requests(&transaction, &now_text)?;
-            promote_ready_requests(&transaction, &now_text)?;
+            promote_ready_requests(&transaction, &now_text, &mut settled_run_ids)?;
             let claims = claim_deliveries(
                 &transaction,
                 provider,
@@ -5309,6 +5328,7 @@ impl ChannelService {
             }
         };
         transaction.commit()?;
+        crate::runtime::pump_targets_after_runs_terminal(database, &settled_run_ids)?;
         Ok(result)
     }
 
@@ -7789,6 +7809,7 @@ fn try_admit_request(
     request_id: &str,
     now: &str,
     command_id: &str,
+    settled_run_ids: &mut Vec<String>,
 ) -> Result<AdmissionAttempt> {
     let camp_id: Option<String> = transaction
         .query_row(
@@ -7798,7 +7819,11 @@ fn try_admit_request(
         )
         .optional()?;
     if let Some(camp_id) = camp_id {
-        crate::runtime::settle_pending_camp_cancellations_in_tx(transaction, &camp_id, now)?;
+        settled_run_ids.extend(crate::runtime::settle_pending_camp_cancellations_in_tx(
+            transaction,
+            &camp_id,
+            now,
+        )?);
     }
     let request = transaction
         .query_row(
@@ -9170,7 +9195,11 @@ fn settle_terminal_requests_for_turn(
     Ok(())
 }
 
-fn promote_ready_requests(transaction: &Transaction<'_>, now: &str) -> Result<()> {
+fn promote_ready_requests(
+    transaction: &Transaction<'_>,
+    now: &str,
+    settled_run_ids: &mut Vec<String>,
+) -> Result<()> {
     let candidates = query_rows(
         transaction,
         r#"
@@ -9197,7 +9226,13 @@ fn promote_ready_requests(transaction: &Transaction<'_>, now: &str) -> Result<()
         // Audit causation belongs to the durable request, not a transient poll.
         // try_admit_request appends request_id and admission, while the queued
         // state and the same write transaction prevent a second admission.
-        try_admit_request(transaction, &request_id, now, "channel-host-maintenance")?;
+        try_admit_request(
+            transaction,
+            &request_id,
+            now,
+            "channel-host-maintenance",
+            settled_run_ids,
+        )?;
     }
     Ok(())
 }

--- a/crates/rovai-core/src/collaboration.rs
+++ b/crates/rovai-core/src/collaboration.rs
@@ -1790,7 +1790,8 @@ impl CollaborationService {
         {
             anyhow::bail!("membership removal reason must be 1-160 characters");
         }
-        self.gateway.execute(database, envelope, |transaction| {
+        let mut settled_run_ids = Vec::new();
+        let execution = self.gateway.execute(database, envelope, |transaction| {
             let camp = transaction
                 .query_row(
                     "SELECT membership_generation FROM camp WHERE id = ?1",
@@ -1942,6 +1943,7 @@ impl CollaborationService {
                 envelope.execution_epoch,
                 &now,
             )?;
+            settled_run_ids = outcome.affected_run_ids.clone();
             advance_membership_source_generation(
                 transaction,
                 &envelope.actor,
@@ -1973,7 +1975,9 @@ impl CollaborationService {
                     ),
                 }),
             ))
-        })
+        })?;
+        crate::runtime::pump_targets_after_runs_terminal(database, &settled_run_ids)?;
+        Ok(execution)
     }
 
     pub fn create_task(
@@ -5692,6 +5696,7 @@ pub(crate) struct CampMembershipEndOutcome {
     pub next_default_lead_agent_id: Option<String>,
     pub reconciliation_id: String,
     pub reconciliation_status: &'static str,
+    pub affected_run_ids: Vec<String>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -6122,6 +6127,7 @@ pub(crate) fn end_camp_membership(
         next_default_lead_agent_id,
         reconciliation_id,
         reconciliation_status,
+        affected_run_ids,
     })
 }
 

--- a/crates/rovai-core/src/main.rs
+++ b/crates/rovai-core/src/main.rs
@@ -1683,6 +1683,7 @@ struct Core {
     attachment_projection_requests: mpsc::UnboundedSender<String>,
     compaction_detector_policies: DesiredCompactionDetectorPolicies,
     agent_run_cancellation_notify: Notify,
+    agent_run_cleanup_inflight: Mutex<HashSet<ActiveExecutionKey>>,
     pending_execution_recovery: Mutex<()>,
     skill_library: SkillLibraryService,
     mcp_config: Result<McpConfigStore>,
@@ -8716,78 +8717,111 @@ impl Core {
                 }
             }
         };
-        let mut tasks = tokio::task::JoinSet::new();
         for candidate in candidates {
-            let core = self.clone();
-            tasks.spawn(async move {
-                let fence = core
-                    .cleanup_agent_run_runtime(
-                        &candidate.agent_run_id,
-                        candidate.execution_epoch,
-                        &candidate.adapter_kind,
-                    )
-                    .await;
-                (candidate, fence)
-            });
-        }
-        while let Some(result) = tasks.join_next().await {
-            let Ok((candidate, fence)) = result else {
-                continue;
-            };
-            if fence == RuntimeCancellationIngressFence::Unproven {
-                // Rotate retries without changing business state or its version.
-                let database = self.database.lock().await;
-                let _ = ExecutionRuntimeService::default().defer_runtime_cleanup(
-                    &database,
-                    &candidate.agent_run_id,
-                    candidate.execution_epoch,
-                );
+            let key = ActiveExecutionKey::new(&candidate.agent_run_id, candidate.execution_epoch);
+            if !self
+                .agent_run_cleanup_inflight
+                .lock()
+                .await
+                .insert(key.clone())
+            {
                 continue;
             }
-            let recorded = {
-                let database = self.database.lock().await;
-                ExecutionRuntimeService::default().record_runtime_cleanup_completed(
-                    &database,
+            let core = self.clone();
+            let output = output.clone();
+            tokio::spawn(async move {
+                // Keep the supervisor separate so a worker panic cannot permanently
+                // strand this process-local de-duplication key.
+                let cleanup_core = core.clone();
+                let cleanup = tokio::spawn(async move {
+                    cleanup_core
+                        .finish_agent_run_runtime_cleanup(&output, candidate)
+                        .await
+                });
+                let completed = match cleanup.await {
+                    Ok(completed) => completed,
+                    Err(error) => {
+                        eprintln!(
+                            "Runtime cleanup worker failed for {}/{}: {error}",
+                            key.agent_run_id, key.execution_epoch
+                        );
+                        false
+                    }
+                };
+                core.agent_run_cleanup_inflight.lock().await.remove(&key);
+                if completed {
+                    core.agent_run_cancellation_notify.notify_one();
+                }
+            });
+        }
+    }
+
+    async fn finish_agent_run_runtime_cleanup(
+        self: &Arc<Self>,
+        output: &mpsc::UnboundedSender<String>,
+        candidate: AgentRunCancellationCandidate,
+    ) -> bool {
+        let fence = self
+            .cleanup_agent_run_runtime(
+                &candidate.agent_run_id,
+                candidate.execution_epoch,
+                &candidate.adapter_kind,
+            )
+            .await;
+        if fence == RuntimeCancellationIngressFence::Unproven {
+            // Rotate retries without changing business state or its version.
+            let database = self.database.lock().await;
+            let _ = ExecutionRuntimeService::default().defer_runtime_cleanup(
+                &database,
+                &candidate.agent_run_id,
+                candidate.execution_epoch,
+            );
+            return false;
+        }
+        let recorded = {
+            let database = self.database.lock().await;
+            ExecutionRuntimeService::default().record_runtime_cleanup_completed(
+                &database,
+                &candidate.agent_run_id,
+                candidate.execution_epoch,
+            )
+        };
+        if let Err(error) = recorded {
+            eprintln!("failed to record Runtime cleanup: {error:#}");
+            return false;
+        }
+        self.planned_shutdown
+            .cleanup_completed(&ActiveExecutionKey::new(
+                &candidate.agent_run_id,
+                candidate.execution_epoch,
+            ))
+            .await;
+        emit(
+            output,
+            "agent_run.runtime_cleanup_completed",
+            json!({
+                "campId": candidate.camp_id, "agentRunId": candidate.agent_run_id,
+                "executionEpoch": candidate.execution_epoch,
+            }),
+        );
+        // Git and projection work do not extend the Runtime cleanup budget.
+        let core = self.clone();
+        tokio::spawn(async move {
+            core.reconcile_skill_projection_after_run_terminal(&candidate.execution_root)
+                .await;
+            if fence == RuntimeCancellationIngressFence::Flushed {
+                core.project_agent_run_file_changes_after_terminal(
                     &candidate.agent_run_id,
                     candidate.execution_epoch,
                 )
-            };
-            if let Err(error) = recorded {
-                eprintln!("failed to record Runtime cleanup: {error:#}");
-                continue;
-            }
-            self.planned_shutdown
-                .cleanup_completed(&ActiveExecutionKey::new(
-                    &candidate.agent_run_id,
-                    candidate.execution_epoch,
-                ))
                 .await;
-            emit(
-                output,
-                "agent_run.runtime_cleanup_completed",
-                json!({
-                    "campId": candidate.camp_id, "agentRunId": candidate.agent_run_id,
-                    "executionEpoch": candidate.execution_epoch,
-                }),
-            );
-            // Git and projection work do not extend the Runtime cleanup budget.
-            let core = self.clone();
-            tokio::spawn(async move {
-                core.reconcile_skill_projection_after_run_terminal(&candidate.execution_root)
+            }
+            if matches!(candidate.status.as_str(), "cancelled" | "failed") {
+                core.record_cancelled_run_ending_git_observation(&candidate)
                     .await;
-                if fence == RuntimeCancellationIngressFence::Flushed {
-                    core.project_agent_run_file_changes_after_terminal(
-                        &candidate.agent_run_id,
-                        candidate.execution_epoch,
-                    )
-                    .await;
-                }
-                if matches!(candidate.status.as_str(), "cancelled" | "failed") {
-                    core.record_cancelled_run_ending_git_observation(&candidate)
-                        .await;
-                }
-            });
-        }
+            }
+        });
+        true
     }
 
     async fn record_cancelled_run_ending_git_observation(
@@ -13041,6 +13075,7 @@ async fn run_core(
         attachment_projection_requests: attachment_projection_tx,
         compaction_detector_policies: compaction_detector_policies.clone(),
         agent_run_cancellation_notify: Notify::new(),
+        agent_run_cleanup_inflight: Mutex::new(HashSet::new()),
         pending_execution_recovery: Mutex::new(()),
         skill_library,
         mcp_config,
@@ -18873,6 +18908,7 @@ mod tests {
             attachment_projection_requests,
             compaction_detector_policies: compaction_detector_policies.clone(),
             agent_run_cancellation_notify: Notify::new(),
+            agent_run_cleanup_inflight: Mutex::new(HashSet::new()),
             pending_execution_recovery: Mutex::new(()),
             skill_library,
             mcp_config: Ok(mcp_config),
@@ -20813,6 +20849,225 @@ while IFS= read -r _ignored; do :; done
         assert_eq!(invalidation["method"], "navigation.invalidated");
         assert_eq!(invalidation["params"]["reason"], "agent_run.terminal");
         assert_eq!(invalidation["params"]["campId"], "rvcamp_test");
+    }
+
+    #[cfg(all(target_os = "macos", feature = "slow-tests"))]
+    #[tokio::test]
+    async fn runtime_cleanup_dispatch_is_non_blocking_and_deduplicated() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root =
+            std::env::temp_dir().join(format!("rovai-cleanup-dispatch-{}", uuid::Uuid::new_v4()));
+        let workspace = root.join("workspace");
+        fs::create_dir_all(&workspace).unwrap();
+        let core = Arc::new(runtime_resolution_test_core(&root).unwrap());
+        let (camp_id, draft_revision) = {
+            let mut database = core.database.lock().await;
+            let agent_id = AgentProfileService::default()
+                .list_profiles(&database)
+                .unwrap()
+                .into_iter()
+                .next()
+                .expect("the startup database should include a default member")
+                .agent_id;
+            rovai_core::agent_profile::configure_test_runtime(&database, &[agent_id.as_str()]);
+            let created = CollaborationService::default()
+                .create_camp(
+                    &mut database,
+                    &CommandEnvelope {
+                        command_id: uuid::Uuid::new_v4().to_string(),
+                        actor: ActorRef::User {
+                            user_id: "test-user".to_string(),
+                        },
+                        camp_id: None,
+                        expected_versions: Vec::new(),
+                        execution_epoch: None,
+                        payload: CreateCampCommand {
+                            name: Some("Runtime cleanup dispatch".to_string()),
+                            project_binding_kind: ProjectBindingKind::Directory,
+                            project_path: workspace.display().to_string(),
+                            member_agent_ids: vec![agent_id.clone()],
+                            default_lead_agent_id: agent_id,
+                            collaboration_mode: CampCollaborationMode::Peer,
+                            activation_state: CampActivationState::Active,
+                        },
+                    },
+                )
+                .unwrap();
+            let camp_id = created.result.payload["campId"]
+                .as_str()
+                .unwrap()
+                .to_string();
+            core.attachment_views
+                .ensure_empty_camp_ready(&mut database, &camp_id)
+                .unwrap();
+            let draft_revision = CampAttachmentStore::new(&core.data_dir)
+                .save_body(&mut database, &camp_id, "Keep cleanup busy")
+                .unwrap()
+                .revision;
+            (camp_id, draft_revision)
+        };
+        let sent = core
+            .send_test_camp_message_request(SendCampMessageParams {
+                command_id: uuid::Uuid::new_v4().to_string(),
+                camp_id: CampId::parse(&camp_id).unwrap(),
+                draft_revision,
+                execution: Some(ExecutionRequest {
+                    task_id: None,
+                    purpose: "Exercise Runtime cleanup".to_string(),
+                    completion_role: "required".to_string(),
+                    budget: None,
+                }),
+            })
+            .await
+            .unwrap();
+        let agent_run_id = sent["commandResult"]["payload"]["agentRunIds"][0]
+            .as_str()
+            .unwrap_or_else(|| panic!("message did not create an AgentRun: {sent:#}"))
+            .to_string();
+        let (version, execution_epoch) = {
+            let mut database = core.database.lock().await;
+            let candidate = ExecutionRuntimeService::default()
+                .list_dispatchable_agent_runs(&database, 10)
+                .unwrap()
+                .into_iter()
+                .find(|candidate| candidate.agent_run_id == agent_run_id)
+                .expect("the queued Run should be dispatchable before cancellation");
+            let claimed = ExecutionRuntimeService::default()
+                .claim_agent_run(
+                    &mut database,
+                    &CommandEnvelope {
+                        command_id: uuid::Uuid::new_v4().to_string(),
+                        actor: ActorRef::System {
+                            component_id: "agent-run-scheduler".to_string(),
+                        },
+                        camp_id: Some(camp_id.clone()),
+                        expected_versions: Vec::new(),
+                        execution_epoch: None,
+                        payload: ClaimAgentRunCommand {
+                            agent_run_id: agent_run_id.clone(),
+                            expected_version: candidate.version,
+                            lease_owner: "cleanup-dispatch-test".to_string(),
+                            lease_seconds: 60,
+                            workspace: Some(candidate.execution_workspace()),
+                            starting_git_observation: None,
+                        },
+                    },
+                )
+                .unwrap();
+            assert_eq!(claimed.result.code, "agent_run.claimed");
+            (
+                candidate.version + 1,
+                claimed.result.payload["executionEpoch"].as_i64().unwrap(),
+            )
+        };
+        let permit = core.planned_shutdown.enter_launch().await.unwrap();
+        let key = ActiveExecutionKey::new(&agent_run_id, execution_epoch);
+        assert!(
+            core.planned_shutdown
+                .register_active(&permit, key.clone(), AdapterKind::CodexCli)
+                .await
+        );
+        {
+            let mut database = core.database.lock().await;
+            let cancelled = ExecutionRuntimeService::default()
+                .request_agent_run_cancellation(
+                    &mut database,
+                    &CommandEnvelope {
+                        command_id: uuid::Uuid::new_v4().to_string(),
+                        actor: ActorRef::User {
+                            user_id: "test-user".to_string(),
+                        },
+                        camp_id: Some(camp_id.clone()),
+                        expected_versions: Vec::new(),
+                        execution_epoch: None,
+                        payload: CancelAgentRunCommand {
+                            camp_id: camp_id.clone(),
+                            agent_run_id: agent_run_id.clone(),
+                            expected_version: version,
+                        },
+                    },
+                )
+                .unwrap();
+            assert_eq!(cancelled.result.code, "agent_run.cancelled");
+        }
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            core.dispatch_agent_run_cancellations(&core.output),
+        )
+        .await
+        .expect("the scheduler-facing cleanup scan must not await Runtime cleanup");
+        assert_eq!(core.agent_run_cleanup_inflight.lock().await.len(), 1);
+        core.dispatch_agent_run_cancellations(&core.output).await;
+        assert_eq!(
+            core.agent_run_cleanup_inflight.lock().await.len(),
+            1,
+            "a second scan must not launch duplicate cleanup for the same execution"
+        );
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if core.agent_run_cleanup_inflight.lock().await.is_empty() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("an unproven cleanup must release its de-duplication key");
+        {
+            let database = core.database.lock().await;
+            assert!(
+                ExecutionRuntimeService::default()
+                    .list_cancellation_candidates(&database, 100)
+                    .unwrap()
+                    .into_iter()
+                    .any(|candidate| candidate.agent_run_id == agent_run_id),
+                "an unproven cleanup must remain eligible for a later scan"
+            );
+        }
+        core.dispatch_agent_run_cancellations(&core.output).await;
+        assert_eq!(core.agent_run_cleanup_inflight.lock().await.len(), 1);
+
+        drop(permit);
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let acknowledged = {
+                    let database = core.database.lock().await;
+                    ExecutionRuntimeService::default()
+                        .list_cancellation_candidates(&database, 100)
+                        .unwrap()
+                        .into_iter()
+                        .all(|candidate| candidate.agent_run_id != agent_run_id)
+                };
+                if acknowledged && core.agent_run_cleanup_inflight.lock().await.is_empty() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("background cleanup should acknowledge and release its de-duplication key");
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        CampAttachmentStore::new(&core.data_dir)
+            .remove_camp(&camp_id)
+            .unwrap();
+        let view_attachment_root = core.attachment_views.root().join("camps").join(&camp_id);
+        drop(core);
+        fs::set_permissions(&view_attachment_root, fs::Permissions::from_mode(0o700)).unwrap();
+        fs::set_permissions(
+            view_attachment_root.parent().unwrap(),
+            fs::Permissions::from_mode(0o700),
+        )
+        .unwrap();
+        fs::set_permissions(
+            view_attachment_root.parent().unwrap().parent().unwrap(),
+            fs::Permissions::from_mode(0o700),
+        )
+        .unwrap();
+        fs::remove_dir_all(root).unwrap();
     }
 
     #[cfg(all(target_os = "macos", feature = "slow-tests"))]

--- a/crates/rovai-core/src/runtime.rs
+++ b/crates/rovai-core/src/runtime.rs
@@ -2108,7 +2108,8 @@ impl ExecutionRuntimeService {
         database: &mut Database,
         envelope: &CommandEnvelope<CancelAgentRunCommand>,
     ) -> Result<CommandExecution> {
-        self.gateway.execute(database, envelope, |transaction| {
+        let mut settled_run_id = None;
+        let execution = self.gateway.execute(database, envelope, |transaction| {
             if !matches!(envelope.actor, ActorRef::User { .. }) {
                 return Ok(rejected(
                     "agent_run.cancel_user_required",
@@ -2200,6 +2201,7 @@ impl ExecutionRuntimeService {
                 &envelope.actor,
                 &now,
             )?;
+            settled_run_id = Some(settlement.agent_run_id.clone());
             let camp_turn_status = recompute_camp_turn(
                 transaction,
                 &camp_id,
@@ -2218,7 +2220,11 @@ impl ExecutionRuntimeService {
                 }),
                 Some(entity_ref("agent_run", &envelope.payload.agent_run_id)),
             ))
-        })
+        })?;
+        if let Some(agent_run_id) = settled_run_id {
+            pump_target_after_run_terminal(database, &agent_run_id)?;
+        }
+        Ok(execution)
     }
 
     pub fn runtime_cleanup_blocked_since(
@@ -4844,12 +4850,13 @@ pub(crate) fn settle_pending_camp_cancellations(
     )?;
     if pending {
         let transaction = database.connection_mut().transaction()?;
-        settle_pending_camp_cancellations_in_tx(
+        let settled_run_ids = settle_pending_camp_cancellations_in_tx(
             &transaction,
             camp_id,
             &chrono::Utc::now().to_rfc3339(),
         )?;
         transaction.commit()?;
+        pump_targets_after_runs_terminal(database, &settled_run_ids)?;
     }
     Ok(())
 }
@@ -4858,7 +4865,7 @@ pub(crate) fn settle_pending_camp_cancellations_in_tx(
     transaction: &Transaction<'_>,
     camp_id: &str,
     now: &str,
-) -> Result<()> {
+) -> Result<Vec<String>> {
     let targets = {
         let mut statement = transaction.prepare(
             "SELECT DISTINCT turn.id, turn.cancel_requested_at, turn.execution_budget_exhausted_at
@@ -4880,6 +4887,7 @@ pub(crate) fn settle_pending_camp_cancellations_in_tx(
     let actor = ActorRef::System {
         component_id: "camp-cancellation-recovery".into(),
     };
+    let mut settled_run_ids = Vec::new();
     for (turn_id, turn_cancelled, exhausted) in targets {
         if turn_cancelled.is_some() || exhausted.is_some() {
             settle_abortive_camp_turn_in_tx(
@@ -4908,11 +4916,14 @@ pub(crate) fn settle_pending_camp_cancellations_in_tx(
                     &actor,
                     now,
                 )?;
+                settled_run_ids.push(id);
             }
             recompute_camp_turn(transaction, camp_id, &turn_id, &actor, None, now)?;
         }
     }
-    Ok(())
+    settled_run_ids.sort();
+    settled_run_ids.dedup();
+    Ok(settled_run_ids)
 }
 
 pub(crate) fn recompute_camp_turn(
@@ -5053,6 +5064,17 @@ pub(crate) fn recompute_camp_turn(
         crate::channel::settle_terminal_request_for_turn_in_tx(transaction, camp_turn_id, now)?;
     }
     Ok(next_status.to_string())
+}
+
+pub(crate) fn pump_targets_after_runs_terminal(
+    database: &mut Database,
+    agent_run_ids: &[String],
+) -> Result<()> {
+    let unique_run_ids = agent_run_ids.iter().collect::<BTreeSet<_>>();
+    for agent_run_id in unique_run_ids {
+        pump_target_after_run_terminal(database, agent_run_id)?;
+    }
+    Ok(())
 }
 
 fn pump_target_after_run_terminal(database: &mut Database, agent_run_id: &str) -> Result<()> {

--- a/crates/rovai-core/src/team_tool.rs
+++ b/crates/rovai-core/src/team_tool.rs
@@ -2029,7 +2029,7 @@ mod tests {
         memory::{MEMORY_AGENT_MUTATIONS_PER_RUN, MemoryCreationOrigin, RetireMemoryCommand},
         memory_retrieval::{MemoryCacheState, MemoryReadInput, MemorySearchInput},
         message_delivery::{RetryMessageDeliveryCommand, dispatch_pending_for_recipient},
-        runtime::FailAgentRunCommand,
+        runtime::{CancelAgentRunCommand, FailAgentRunCommand},
     };
     use crate::{
         camp_attachment::CampAttachmentStore,
@@ -7526,6 +7526,73 @@ Use this exact public input @agent_2";
     }
 
     #[cfg(feature = "slow-tests")]
+    fn user_run_cancellation_releases_the_next_target_busy_delivery() {
+        let mut fixture = Fixture::new();
+        let busy_run_id = fixture.queue_direct_run("queue-run-cancel-recipient", "agent_2");
+        let invocation = fixture.public_send_invocation(
+            "run-cancel-waiting-delivery",
+            "Dispatch after the busy Run is cancelled",
+            &["agent_2"],
+        );
+        let sent = TeamToolService::default()
+            .send_public_message(&mut fixture.database, &invocation)
+            .unwrap();
+        let delivery_id = sent.result.payload["deliveryIds"][0]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(
+            fixture
+                .database
+                .connection()
+                .query_row(
+                    "SELECT status || ':' || wait_condition FROM message_delivery WHERE id = ?1",
+                    [&delivery_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "pending:target_busy"
+        );
+
+        let busy_run_version: i64 = fixture
+            .database
+            .connection()
+            .query_row(
+                "SELECT version FROM agent_run WHERE id = ?1",
+                [&busy_run_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let cancelled = ExecutionRuntimeService::default()
+            .request_agent_run_cancellation(
+                &mut fixture.database,
+                &user_envelope(
+                    "cancel-busy-recipient-run",
+                    Some(&fixture.camp_id),
+                    CancelAgentRunCommand {
+                        camp_id: fixture.camp_id.clone(),
+                        agent_run_id: busy_run_id,
+                        expected_version: busy_run_version,
+                    },
+                ),
+            )
+            .unwrap();
+        assert_eq!(cancelled.result.code, "agent_run.cancelled");
+        let delivery: (String, Option<String>, Option<String>) = fixture
+            .database
+            .connection()
+            .query_row(
+                "SELECT status, wait_condition, target_agent_run_id FROM message_delivery WHERE id = ?1",
+                [&delivery_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(delivery.0, "running");
+        assert!(delivery.1.is_none());
+        assert!(delivery.2.is_some());
+    }
+
+    #[cfg(feature = "slow-tests")]
     fn pending_outbound_delivery_is_cancelled_when_source_membership_ends() {
         let mut fixture = Fixture::new();
         let _busy_run_id = fixture.queue_direct_run("queue-pending-outbound-recipient", "agent_2");
@@ -7624,6 +7691,36 @@ Use this exact public input @agent_2";
             )
             .unwrap();
 
+        let unrelated_source_run_id =
+            fixture.queue_direct_run("queue-unrelated-source-before-member-leaves", "agent_3");
+        let (_unrelated_source_epoch, unrelated_source_credential) =
+            fixture.claim_bind_and_issue(&unrelated_source_run_id, "native-unrelated-source");
+        let unrelated_invocation = fixture.public_send_invocation_for(
+            &unrelated_source_credential,
+            "unrelated-delivery-behind-affected-target",
+            "This delivery must advance after the affected target stops",
+            &["agent_2"],
+        );
+        let unrelated = TeamToolService::default()
+            .send_public_message(&mut fixture.database, &unrelated_invocation)
+            .unwrap();
+        let unrelated_delivery_id = unrelated.result.payload["deliveryIds"][0]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(
+            fixture
+                .database
+                .connection()
+                .query_row(
+                    "SELECT status || ':' || wait_condition FROM message_delivery WHERE id = ?1",
+                    [&unrelated_delivery_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "pending:target_busy"
+        );
+
         let collaboration = CollaborationService::default();
         let preview = collaboration
             .camp_member_removal_preview(&fixture.database, &fixture.camp_id, "agent_1")
@@ -7670,6 +7767,18 @@ Use this exact public input @agent_2";
             .unwrap();
         assert!(target_state.0.is_some());
         assert_eq!(target_state.1, 1);
+        let unrelated_delivery: (String, Option<String>, Option<String>) = fixture
+            .database
+            .connection()
+            .query_row(
+                "SELECT status, wait_condition, target_agent_run_id FROM message_delivery WHERE id = ?1",
+                [&unrelated_delivery_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(unrelated_delivery.0, "running");
+        assert!(unrelated_delivery.1.is_none());
+        assert!(unrelated_delivery.2.is_some());
     }
 
     #[cfg(feature = "slow-tests")]
@@ -10139,6 +10248,10 @@ Use this exact public input @agent_2";
         #[test]
         fn an_existing_run_can_address_a_member_added_after_its_context_was_frozen() {
             super::an_existing_run_can_address_a_member_added_after_its_context_was_frozen();
+        }
+        #[test]
+        fn user_run_cancellation_releases_the_next_target_busy_delivery() {
+            super::user_run_cancellation_releases_the_next_target_busy_delivery();
         }
         #[test]
         fn pending_outbound_delivery_is_cancelled_when_source_membership_ends() {

--- a/docs/contracts/cancellation-settlement-v1.md
+++ b/docs/contracts/cancellation-settlement-v1.md
@@ -26,6 +26,9 @@ last_updated: 2026-09-01
   Turn payload 含 `campTurnId/campTurnStatus/runs`，每个 Run 带实际 `terminalStatus` 和清理目标。
 - 已终态重复取消为 Applied no-op，不改变终态或版本；同 command replay 仍返回原结果。活跃对象的版本冲突仍拒绝。
 - 只有整轮取消、预算终止、Camp 删除或应用退出能抑制整轮渠道投递。单 Run 取消和成员离队只走正常 Turn 聚合。
+- 只结算精确 Run 集合的事务提交后，必须对本次 Run ID 调用既有 terminal delivery pump，推进相同收件人的
+  `target_busy` Delivery 与刚满足条件的 Gather completion。整轮取消已先关闭该 Turn 的 pending Delivery，
+  不调用该 pump；不得在事务提交前派发。
 
 ## Runtime 清理
 
@@ -37,6 +40,8 @@ last_updated: 2026-09-01
 interrupt/flush 不能耗尽强制回收预算。进程回收未确认时保留原 lease/active 关联；后台可继续重试，业务终态不变。
 仅确认清理后按 Run ID + execution epoch 条件写 `cancel_acknowledged_at`，不推进 Run version、聚合 Turn 或创建
 `runtime-cancellation-ack` command receipt。普通 terminal/callback 不得删除仍需清理的 active 记录。
+Scheduler 扫描只按 `ActiveExecutionKey` 进程内去重并启动后台清理，不能等待本批任务完成；任务结束释放去重键，
+确认清理后唤醒 scheduler。`Unproven` 只旋转既有候选并留给后续扫描，不新增持久化清理状态或重试协议。
 
 同一 Conversation 的新 Run 在旧清理未确认时最多等待上述期限，随后终态
 `failed / runtime_cleanup_unconfirmed`，`manual_retry_allowed = true`。不无限 queued、不允许不明旧进程与新 Run

--- a/docs/versions/v1.37/implementation-plan.md
+++ b/docs/versions/v1.37/implementation-plan.md
@@ -151,6 +151,9 @@ Antigravity 原生生成、TRAE/Copilot 专用图片结果已接入，六种 Run
   随后创建进程却提前记为已清理。强制删除保留幂等回放和原 bypassedBlockers，退出 wire protocol 仍为 3。
 - 打开 Camp 或渠道准入只补偿该 Camp 的旧半取消对象。Renderer 停止状态只表示请求尚未返回，
   收到 Applied 即应用 Core 终态并刷新；不再等待 Runtime ACK。
+- 后续定向复核补正两个遗漏：Run-local、成员 cutover、成员全局移除与旧半取消修复都把精确 Run ID
+  带到事务提交后，再复用 terminal delivery pump；整轮取消仍不 pump。Runtime cleanup scanner 改为
+  `ActiveExecutionKey` 进程内去重后后台启动，主 scheduler 不等待三秒清理任务，原 Conversation fence 保留。
 
 取消回归 owner 与准入说明：
 
@@ -171,6 +174,16 @@ Antigravity 原生生成、TRAE/Copilot 专用图片结果已接入，六种 Run
   该检查必须经过真实 Core 清理入口、launch registry 与受管子进程，内存 timer 测试不能证明 reap。
   它不调用真实 Provider 或模型；超时允许 Unproven，但禁止进程仍在时宣称已清理。
   最小命令：`cargo test -p rovai-core --bin rovai-core --features slow-tests cancellation_covers_launch`。
+- `tests::runtime_cleanup_dispatch_is_non_blocking_and_deduplicated` 复用隔离 Core 与 launch registry，
+  持有未完成 launch 时验证 scheduler-facing scan 在一秒内返回、重复扫描只有一个 cleanup worker，
+  首次三秒清理为 `Unproven` 后释放去重键并保留候选供下轮扫描；release 后重试才写 cleanup ACK。
+  最小命令：
+  `cargo test -p rovai-core --bin rovai-core --features slow-tests runtime_cleanup_dispatch_is_non_blocking`。
+- `team_tool::tests::slow_tests::user_run_cancellation_releases_the_next_target_busy_delivery`
+  验证 Run cancel 提交后立即物化同收件人的下一条 A2A Delivery；既有
+  `running_outbound_delivery_target_is_reconciled_when_source_membership_ends` 扩展为验证成员 cutover
+  终止其派生目标 Run 后，无关来源的下一条 Delivery 继续运行。最小命令分别使用上述两个完整测试名执行
+  `cargo test -p rovai-core --lib --features slow-tests <test-name>`。
 - `channel::tests::cancellation_preserves_local_output_and_suppresses_only_aborted_turn_retries`
   复用既有渠道 fixture，分别验证单 Run 和整轮边界、pending/attempting/sent、迟到回执与下一请求 FIFO。
   旧发送重试测试没有取消业务事务，纯 outbox reducer 无法证明 Turn/request 的联动。
@@ -188,6 +201,9 @@ Antigravity 原生生成、TRAE/Copilot 专用图片结果已接入，六种 Run
 
 本轮隔离验证：
 
+- 后续 pump/scheduler 补正复跑：Library fast 472 项、slow 297 项、CLI 32 项通过；Core Main
+  194 项通过、4 项既有真实 Runtime 人工 smoke 忽略。Clippy、Rust fmt、文档三道门禁、TypeScript、
+  133 文件/1352 项 Vitest、220 项 Node 测试（1 项既有 Windows 原生跳过）和 Desktop build 通过。
 - Library 全量含 slow 768 项：767 项通过，既有 Runtime 版本探测在并发负载下出现一次超时；
   原条件单独复跑通过，没有放宽 deadline 或跳过该测试。退出/Git 观察/terminal provenance 的后续扩展通过。
 - Core Main 193 项和 CLI 32 项通过，4 项既有真实 Runtime 人工 smoke 仍按原规则忽略；


### PR DESCRIPTION
Direct terminal cancellation now commits the business state immediately, but two pieces of the retired ACK path were still coupled to that ACK: terminal delivery pumping and waiting for Runtime cleanup inside the scheduler. The first omission could leave `target_busy` A2A deliveries or Gather completion work stuck after a Run had already ended. The second could pause unrelated Camps for the full cleanup deadline.

This PR:

- carries the exact Run IDs settled by user cancellation, membership cutover, global member removal, and lazy cancellation repair past the transaction boundary, then invokes the existing terminal delivery pump;
- preserves full-turn cancellation behavior, where pending deliveries are already closed and no pump is needed;
- starts Runtime cleanup in detached tasks, with process-local `ActiveExecutionKey` de-duplication;
- releases the de-duplication key after confirmed cleanup, `Unproven`, or worker failure, and keeps existing candidates available for later scans;
- keeps the existing per-Conversation cleanup fence and persistent cleanup ACK semantics unchanged.

Validation:

- `cargo test -p rovai-core --lib --features slow-tests team_tool::tests::slow_tests::user_run_cancellation_releases_the_next_target_busy_delivery -- --exact`
- `cargo test -p rovai-core --lib --features slow-tests team_tool::tests::slow_tests::running_outbound_delivery_target_is_reconciled_when_source_membership_ends -- --exact`
- `cargo test -p rovai-core --bin rovai-core --features slow-tests tests::runtime_cleanup_dispatch_is_non_blocking_and_deduplicated -- --exact`
- Rust PR suites: 472 fast library, 297 slow library, and 32 CLI tests passed
- Core main suite: 194 passed, 4 existing manual Runtime smoke tests ignored
- Clippy, Rust fmt, documentation gates, typecheck, 1,352 Vitest tests, 220 Node tests (1 existing Windows-only skip), and desktop build passed
