### PR TITLE
fix(desktop): simplify runtime headings

### DIFF
--- a/apps/desktop/src/renderer/src/App.test.ts
+++ b/apps/desktop/src/renderer/src/App.test.ts
@@ -2822,15 +2822,15 @@ describe('task event projections', () => {
     expect(applicationGroup.indexOf('<strong>外观</strong>')).toBeLessThan(applicationGroup.indexOf('<strong>提醒</strong>'))
     expect(capabilitiesGroup).toContain('<strong>Skills</strong>')
     expect(capabilitiesGroup).toContain('<strong>MCP</strong>')
-    expect(capabilitiesGroup).toContain('<strong>Agent 运行时</strong>')
+    expect(capabilitiesGroup).toContain('<strong>运行时</strong>')
     expect(capabilitiesGroup).toContain('<strong>渠道</strong>')
     expect(capabilitiesGroup).toContain('data-navigation-icon="sparkles"')
     expect(capabilitiesGroup).toContain('data-navigation-icon="blocks"')
     expect(capabilitiesGroup).toContain('data-navigation-icon="cpu"')
     expect(capabilitiesGroup).toContain('data-navigation-icon="radio-tower"')
     expect(capabilitiesGroup.indexOf('<strong>Skills</strong>')).toBeLessThan(capabilitiesGroup.indexOf('<strong>MCP</strong>'))
-    expect(capabilitiesGroup.indexOf('<strong>MCP</strong>')).toBeLessThan(capabilitiesGroup.indexOf('<strong>Agent 运行时</strong>'))
-    expect(capabilitiesGroup.indexOf('<strong>Agent 运行时</strong>')).toBeLessThan(capabilitiesGroup.indexOf('<strong>渠道</strong>'))
+    expect(capabilitiesGroup.indexOf('<strong>MCP</strong>')).toBeLessThan(capabilitiesGroup.indexOf('<strong>运行时</strong>'))
+    expect(capabilitiesGroup.indexOf('<strong>运行时</strong>')).toBeLessThan(capabilitiesGroup.indexOf('<strong>渠道</strong>'))
     expect(supportGroup).toContain('<strong>诊断与修复</strong>')
     expect(supportGroup).toContain('<strong>运行监控</strong>')
     expect(supportGroup).toContain('<strong>关于与更新</strong>')
@@ -2862,7 +2862,7 @@ describe('task event projections', () => {
       general: '通用',
       skills: 'Skills',
       mcp: 'MCP',
-      runtime: 'Agent 运行时',
+      runtime: '运行时',
       channels: '渠道',
       appearance: '外观',
       notifications: '提醒',
@@ -2943,6 +2943,7 @@ describe('task event projections', () => {
     expect(rescan).toBeGreaterThan(0)
     expect(rescan).toBeLessThan(headerEnd)
     expect(headerEnd).toBeLessThan(directory)
+    expect(markup).toContain('<h1>运行时</h1>')
     expect(markup).toContain('管理本机 Agent 运行时及其可用状态。')
     expect(markup).not.toContain('Cursor Agent')
     expect(markup).not.toContain('高级诊断与自定义启动入口')
@@ -6274,12 +6275,12 @@ describe('task event projections', () => {
     expect(markup).not.toContain('Claude Code CLI')
     expect(markup).not.toContain('Antigravity App')
     expect(markup).not.toContain('/opt/homebrew/bin/codex')
-    expect(markup).toContain('<h3>运行时</h3>')
-    expect(markup).toContain('Agent 运行时')
+    expect(markup).toContain('<label class="field-label" for="member-runtime-select">运行时<select')
     expect(markup).toContain('保存运行配置')
     expect(markup).toContain('放弃更改')
     expect(markup).not.toContain('清除 Agent 运行时')
-    expect(markup).toContain('选择执行产品，并确认当前安装与可用状态')
+    expect(markup).not.toContain('<div class="member-section-heading">')
+    expect(markup).not.toContain('选择执行产品，并确认当前安装与可用状态')
   })
 
   it('keeps a missing Product Runtime as an unsaved draft and links to its checks', () => {

--- a/apps/desktop/src/renderer/src/CampNavigation.tsx
+++ b/apps/desktop/src/renderer/src/CampNavigation.tsx
@@ -855,7 +855,7 @@ const SETTINGS_SIDEBAR_GROUPS: SettingsSidebarGroup[] = [
     items: [
       { key: 'skills', icon: 'sparkles', label: 'Skills' },
       { key: 'mcp', icon: 'blocks', label: 'MCP' },
-      { key: 'runtime', icon: 'cpu', label: 'Agent 运行时' },
+      { key: 'runtime', icon: 'cpu', label: '运行时' },
       { key: 'channels', icon: 'radio-tower', label: '渠道' }
     ]
   },

--- a/apps/desktop/src/renderer/src/MemberManagement.tsx
+++ b/apps/desktop/src/renderer/src/MemberManagement.tsx
@@ -1099,16 +1099,9 @@ export const MemberRuntimeForm = forwardRef<MemberRuntimeFormHandle, {
 
   return (
     <section className="member-section member-runtime-section">
-      <div className="member-section-heading">
-        <div>
-          <h3>运行时</h3>
-          <p>选择执行产品，并确认当前安装与可用状态。</p>
-        </div>
-      </div>
-
       <form className="member-runtime-form" onSubmit={(event) => void submit(event)}>
         <div className="member-runtime-primary">
-          <label className="field-label" htmlFor="member-runtime-select">Agent 运行时
+          <label className="field-label" htmlFor="member-runtime-select">运行时
           <select
             id="member-runtime-select"
             value={selectedKind}
@@ -1582,7 +1575,7 @@ export function RuntimeInstallationsPanel({ health, onReload }: {
     <>
       <SettingsPageHeader
         eyebrow="Settings / Runtime"
-        title="Agent 运行时"
+        title="运行时"
         description="管理本机 Agent 运行时及其可用状态。"
         aside={(
           <button className="quiet-button" disabled={busy !== null || (health !== null && !hasQualifiedRuntime)} onClick={() => void rescan()}>


### PR DESCRIPTION
## Summary

- rename the Runtime item and page heading in Settings to `运行时`
- remove the redundant Runtime section heading and helper line from member configuration
- shorten the member Runtime field label to `运行时` while preserving all other Agent Runtime copy

## Validation

- `pnpm exec vitest run apps/desktop/src/renderer/src/App.test.ts` (149 tests)
- `pnpm typecheck`
- `pnpm build:desktop`
- `git diff --check`
- Impeccable detector on both changed UI targets (0 findings)