### PR TITLE
Fix AgentRun disclosure chevron alignment

### DIFF
--- a/apps/desktop/src/renderer/src/App.test.ts
+++ b/apps/desktop/src/renderer/src/App.test.ts
@@ -4912,6 +4912,10 @@ describe('task event projections', () => {
       run, campId: 'camp-1'
     }))
     expect(markup).toContain('<details class="execution-disclosure worked is-terminal" open="">')
+    expect(markup).toContain('class="process-disclosure-label"')
+    expect(markup).toContain('class="process-disclosure-slot"')
+    expect(markup).toContain('<path d="m4.75 6.25 3.25 3.5 3.25-3.5"></path>')
+    expect(markup).not.toContain('⌄')
     expect(markup).toContain('Claude Code 返回错误')
     expect(markup).toContain('请求受到速率限制')
     expect(markup).toContain('请稍后重试。')

--- a/apps/desktop/src/renderer/src/CampWorkspace.tsx
+++ b/apps/desktop/src/renderer/src/CampWorkspace.tsx
@@ -8551,8 +8551,12 @@ export function RunExecutionDisclosure({
       }}
     >
       <summary>
-        <span>{runDurationLabel(run)}</span>
-        <span className="process-chevron" aria-hidden="true">⌄</span>
+        <span className="process-disclosure-label">{runDurationLabel(run)}</span>
+        <span className="process-disclosure-slot" aria-hidden="true">
+          <svg viewBox="0 0 16 16" focusable="false">
+            <path d="m4.75 6.25 3.25 3.5 3.25-3.5" />
+          </svg>
+        </span>
       </summary>
       {content}
     </details>

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -3374,11 +3374,13 @@ button.task-event-card:focus-visible .task-card-chevron { color: var(--brand-ink
 }
 .execution-disclosure.worked { margin: 1px 0 12px; }
 .execution-disclosure.worked > summary {
-  display: flex;
+  display: grid;
+  min-width: 0;
   min-height: 34px;
+  grid-template-columns: minmax(0, 1fr) 24px;
   align-items: center;
-  gap: 6px;
-  padding: 5px 0 7px;
+  column-gap: 8px;
+  padding: 5px 2px 7px 0;
   border-bottom: 1px solid var(--line);
   color: var(--muted);
   cursor: pointer;
@@ -3388,8 +3390,13 @@ button.task-event-card:focus-visible .task-card-chevron { color: var(--brand-ink
   font-weight: 500;
 }
 .execution-disclosure.worked > summary::-webkit-details-marker { display: none; }
-.process-chevron { display: inline-grid; width: 14px; height: 14px; place-items: center; color: var(--faint); font-size: 13px; transition: transform 150ms ease; }
-.execution-disclosure.worked:not([open]) .process-chevron { transform: rotate(-90deg); }
+.execution-disclosure.worked > summary::marker { display: none; content: ""; }
+.process-disclosure-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.process-disclosure-slot { display: grid; width: 24px; height: 24px; place-items: center; justify-self: end; border-radius: 5px; color: var(--faint); transition: color 120ms ease, background-color 120ms ease; }
+.process-disclosure-slot svg { display: block; width: 14px; height: 14px; fill: none; stroke: currentColor; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1.55; transition: transform 150ms ease; }
+.execution-disclosure.worked:not([open]) .process-disclosure-slot svg { transform: rotate(-90deg); }
+.execution-disclosure.worked > summary:hover .process-disclosure-slot,
+.execution-disclosure.worked > summary:focus-visible .process-disclosure-slot { color: var(--ink); background: var(--surface-hover); }
 .process-content { display: grid; gap: 14px; padding: 13px 0 6px; }
 .run-live > .process-content { padding: 0; }
 .process-copy { margin: 0; color: var(--ink); font-size: 12.5px; line-height: 1.68; }

--- a/apps/desktop/src/renderer/src/theme-tokens.test.ts
+++ b/apps/desktop/src/renderer/src/theme-tokens.test.ts
@@ -323,6 +323,13 @@ describe('Porcelain Day + Steel Night theme tokens', () => {
     )
   })
 
+  it('keeps AgentRun disclosure in a fixed trailing SVG track', () => {
+    expect(css).toMatch(/\.execution-disclosure\.worked > summary\s*\{[^}]*display:\s*grid[^}]*grid-template-columns:\s*minmax\(0, 1fr\) 24px/)
+    expect(css).toMatch(/\.process-disclosure-slot\s*\{[^}]*width:\s*24px[^}]*height:\s*24px/)
+    expect(css).toMatch(/\.process-disclosure-slot svg\s*\{[^}]*width:\s*14px[^}]*height:\s*14px[^}]*stroke-width:\s*1\.55/)
+    expect(css).toMatch(/\.execution-disclosure\.worked:not\(\[open\]\) \.process-disclosure-slot svg\s*\{[^}]*transform:\s*rotate\(-90deg\)/)
+  })
+
   it('keeps complete Tool results in the shared four-track, keyboard-scrollable surface', () => {
     expect(css).toMatch(/\.tool-call-summary\s*\{[^}]*display:\s*grid[^}]*grid-template-columns:\s*16px minmax\(0, 1fr\) 16px 20px/)
     expect(css).toMatch(/\.tool-call-icon svg\s*\{[^}]*width:\s*16px[^}]*height:\s*16px[^}]*fill:\s*none/)


### PR DESCRIPTION
## Summary

- replace the top-level AgentRun Unicode disclosure glyph with the prototype SVG chevron
- reserve a fixed 24px trailing track so the control stays aligned across labels and layouts
- keep command and completed-operation disclosures on their existing compact 20px tracks while sharing the same chevron geometry
- cover markup, sizing, and collapsed rotation with Renderer tests

## Validation

- pnpm vitest run apps/desktop/src/renderer/src/App.test.ts apps/desktop/src/renderer/src/theme-tokens.test.ts (173 passed)
- pnpm typecheck
- pnpm package:mac
- pnpm accept:runtime-activity-ui (13 runtimes; sidecar, bottom, compact, night, and 200% zoom visually inspected)