### PR TITLE
fix(composer): recover stale DOM before controlled edits

### DIFF
--- a/apps/desktop/src/renderer/src/StructuredMentionComposer.tsx
+++ b/apps/desktop/src/renderer/src/StructuredMentionComposer.tsx
@@ -401,10 +401,34 @@ export function StructuredMentionComposer({
     onChange(next.content)
   }
 
-  const editorState = (selection = currentSelection()): StructuredMentionEditorState => ({
-    content,
-    selection
-  })
+  const scheduleEditorDomReset = (
+    editor: HTMLDivElement,
+    selection: StructuredMentionSelection
+  ): void => {
+    const editorFocused = document.activeElement === editor
+    pendingSelectionRef.current = editorFocused ? selection : null
+    restoreFocusAfterDomResetRef.current = editorFocused
+    setEditorDomRevision((current) => current + 1)
+  }
+
+  const stateForControlledEdit = (selection = currentSelection()): StructuredMentionEditorState => {
+    const editor = editorRef.current
+    if (!editor || !editorDomRequiresOwnershipReset(
+      editor,
+      content,
+      editorDomProjectionRef.current?.tree
+    )) {
+      return { content, selection }
+    }
+
+    // A controlled edit can arrive before Chromium emits an input event for a
+    // native DOM replacement. Preserve that native state and remount the whole
+    // editor host before React commits the edit; diffing the stale descendants
+    // can otherwise throw removeChild and unmount the Renderer root.
+    const nativeContent = readStructuredContent(editor)
+    scheduleEditorDomReset(editor, selection)
+    return { content: nativeContent, selection }
+  }
 
   const closeQueryIfSelectionMoved = (): void => {
     if (!query || isComposingRef.current) return
@@ -430,14 +454,14 @@ export function StructuredMentionComposer({
   const syncNativeDom = (nativeEvent?: InputEvent): StructuredMentionEditorState | null => {
     const editor = editorRef.current
     if (!editor) return null
-    const editorFocused = document.activeElement === editor
     const nextContent = readStructuredContent(editor)
     const nextSelection = readDomSelection(editor)
-    const requiresOwnershipReset = !editorDomMatchesReactProjection(editor, content)
-      // The empty placeholder span is removed as a unit by React on first input.
-      // Its descendants may change without resetting the IME host, but the span
-      // itself must still be the node React owns.
-      || !editorDomMatchesSnapshot(editor, editorDomProjectionRef.current?.tree, content.length > 0)
+    const editorFocused = document.activeElement === editor
+    const requiresOwnershipReset = editorDomRequiresOwnershipReset(
+      editor,
+      content,
+      editorDomProjectionRef.current?.tree
+    )
     const contentChanged = !structuredContentEqual(content, nextContent)
     lastSelectionRef.current = nextSelection
     if (requiresOwnershipReset) {
@@ -447,9 +471,7 @@ export function StructuredMentionComposer({
       // removeChild. Remount the editor host instead, so React discards the
       // mutated subtree as one unit and establishes ownership again.
       // Identical markup can still contain split or replaced, unowned nodes.
-      pendingSelectionRef.current = editorFocused ? nextSelection : null
-      restoreFocusAfterDomResetRef.current = editorFocused
-      setEditorDomRevision((current) => current + 1)
+      scheduleEditorDomReset(editor, nextSelection)
     }
     if (contentChanged) {
       pendingSelectionRef.current = editorFocused ? nextSelection : null
@@ -511,7 +533,7 @@ export function StructuredMentionComposer({
 
   const deleteFromKeyboard = (
     direction: 'backward' | 'forward',
-    state = editorState()
+    state = stateForControlledEdit()
   ): void => {
     const selection = state.selection
     const next = direction === 'backward'
@@ -534,7 +556,7 @@ export function StructuredMentionComposer({
 
     if (nativeEvent.inputType === 'insertText' && nativeEvent.data !== null) {
       event.preventDefault()
-      const next = insertStructuredText(editorState(selection), nativeEvent.data)
+      const next = insertStructuredText(stateForControlledEdit(selection), nativeEvent.data)
       emitState(next)
       setQuery((current) => {
         const nextMentionQuery = mentionQueryAfterTypedText(
@@ -549,7 +571,7 @@ export function StructuredMentionComposer({
     if (nativeEvent.inputType === 'insertParagraph' || nativeEvent.inputType === 'insertLineBreak') {
       event.preventDefault()
       setQuery(null)
-      emitState(insertStructuredText(editorState(selection), '\n'))
+      emitState(insertStructuredText(stateForControlledEdit(selection), '\n'))
       return
     }
     if (nativeEvent.inputType === 'deleteContentBackward') {
@@ -564,7 +586,7 @@ export function StructuredMentionComposer({
     }
     if (nativeEvent.inputType === 'deleteByCut') {
       event.preventDefault()
-      const next = replaceStructuredSelection(editorState(selection), [])
+      const next = replaceStructuredSelection(stateForControlledEdit(selection), [])
       emitState(next)
       setQuery(composerQueryAfterEdit(next))
     }
@@ -618,18 +640,18 @@ export function StructuredMentionComposer({
     }
     if (event.key === 'Backspace') {
       event.preventDefault()
-      deleteFromKeyboard('backward', reconciledCompositionState ?? editorState())
+      deleteFromKeyboard('backward', reconciledCompositionState ?? stateForControlledEdit())
       return
     }
     if (event.key === 'Delete') {
       event.preventDefault()
-      deleteFromKeyboard('forward', reconciledCompositionState ?? editorState())
+      deleteFromKeyboard('forward', reconciledCompositionState ?? stateForControlledEdit())
       return
     }
     if (event.key === 'Enter' && event.shiftKey) {
       event.preventDefault()
       setQuery(null)
-      emitState(insertStructuredText(reconciledCompositionState ?? editorState(), '\n'))
+      emitState(insertStructuredText(reconciledCompositionState ?? stateForControlledEdit(), '\n'))
       return
     }
     if (shouldSubmitStructuredComposerOnEnter({
@@ -662,9 +684,10 @@ export function StructuredMentionComposer({
       plainText,
       members
     )
+    const baseState = stateForControlledEdit()
     const next = structuredContent
-      ? replaceStructuredSelection(editorState(), authorableStructuredContent(structuredContent))
-      : pasteStructuredPlainText(editorState(), plainText)
+      ? replaceStructuredSelection(baseState, authorableStructuredContent(structuredContent))
+      : pasteStructuredPlainText(baseState, plainText)
     emitState(next)
     setQuery(composerQueryAfterEdit(next))
   }
@@ -679,7 +702,7 @@ export function StructuredMentionComposer({
     // Own Cut before Chromium mutates the contenteditable subtree. Waiting for
     // deleteByCut leaves a native filler BR that can be mistaken for a newline.
     event.preventDefault()
-    const state = editorState(selection)
+    const state = stateForControlledEdit(selection)
     const selectedContent = selectedStructuredMentionContent(state)
     const structuredClipboard = createStructuredMessageClipboardData(selectedContent, members)
     if (structuredClipboard) {
@@ -1172,6 +1195,18 @@ function editorDomMatchesSnapshot(
     && children.every((child, index) => checkDescendants
       ? editorDomMatchesSnapshot(child, snapshot.children[index])
       : child === snapshot.children[index].node)
+}
+
+function editorDomRequiresOwnershipReset(
+  editor: HTMLDivElement,
+  content: StructuredMentionContent,
+  snapshot: EditorDomSnapshot | undefined
+): boolean {
+  return !editorDomMatchesReactProjection(editor, content)
+    // The empty placeholder span is removed as a unit by React on first input.
+    // Its descendants may change without resetting the IME host, but the span
+    // itself must still be the node React owns.
+    || !editorDomMatchesSnapshot(editor, snapshot, content.length > 0)
 }
 
 function editorDomMatchesReactProjection(

--- a/scripts/fixtures/structured-mention-composer/main.cjs
+++ b/scripts/fixtures/structured-mention-composer/main.cjs
@@ -79,6 +79,7 @@ app.whenReady().then(async () => {
       'The saved value must agree with visible text')
     assert.equal(state.focused, true, 'Editing must retain focus')
     if (options.sameEditor) assert.equal(state.sameEditor, true, 'Simple native text edits must not reset the host')
+    return state
   }
   async function expectSkills(expected) {
     const state = await evaluate('window.composerTest.state()')
@@ -251,6 +252,26 @@ app.whenReady().then(async () => {
       await expectText('请完成以下工作：\n/agent')
       await key('Escape', 27)
       await expectSkills(null)
+    })
+
+    await run('external URL paste recovers an unowned empty placeholder as plain text', async () => {
+      const url = 'https://docs.example.test/wiki/url-paste-regression'
+      await reset('')
+      await evaluate('window.composerTest.captureEditor()')
+      await evaluate(`(() => {
+        const editor = document.getElementById('composer')
+        const emptyPlaceholder = editor.firstChild
+        emptyPlaceholder.replaceWith(emptyPlaceholder.cloneNode(true))
+        window.composerTest.focusEnd()
+        window.composerTest.paste(
+          ${JSON.stringify('https://docs.example.test/wiki/url-paste-regression')},
+          ${JSON.stringify('<a href="https://docs.example.test/wiki/url-paste-regression">https://docs.example.test/wiki/url-paste-regression</a>')}
+        )
+      })()`)
+      await frames()
+      const state = await expectText(url)
+      assert.equal(state.sameEditor, false, 'Lost DOM ownership must remount the complete editor host')
+      assert.equal(state.linkCount, 0, 'External URL HTML must be pasted as ordinary text')
     })
 
     await run('native fallback recomputes after replacement, deletion, undo and redo without event data', async () => {

--- a/scripts/fixtures/structured-mention-composer/renderer.tsx
+++ b/scripts/fixtures/structured-mention-composer/renderer.tsx
@@ -79,9 +79,10 @@ function Harness() {
           focusEnd()
           editor().dispatchEvent(new InputEvent('input', { bubbles: true, inputType }))
         },
-        paste(text: string) {
+        paste(text: string, html = '') {
           const clipboardData = new DataTransfer()
           clipboardData.setData('text/plain', text)
+          if (html) clipboardData.setData('text/html', html)
           editor().dispatchEvent(new ClipboardEvent('paste', { bubbles: true, cancelable: true, clipboardData }))
         },
         selectText,
@@ -99,6 +100,7 @@ function Harness() {
             errors: [...errors],
             focused: document.activeElement === element,
             sameEditor: capturedEditor === element,
+            linkCount: element?.querySelectorAll('a').length ?? 0,
             menuKind: menu ? (menu.classList.contains('skill-picker-menu') ? 'skill' : 'mention') : null,
             skillOptions: [...(menu?.querySelectorAll<HTMLElement>('[role="option"]') ?? [])]
               .map(option => option.dataset.skillName),

--- a/scripts/lib/structured-mention-composer.test.mjs
+++ b/scripts/lib/structured-mention-composer.test.mjs
@@ -53,7 +53,7 @@ test('Composer edits preserve text, structured tokens and Skill query interactio
     assert.equal(code, 0, `Native Composer regression failed (${signal}):\n${stdout}\n${stderr}`)
     const report = JSON.parse(stdout.split('\n').find(line => line.startsWith('{')))
     assert.equal(report.ok, true)
-    assert.equal(report.cases.length, 17)
+    assert.equal(report.cases.length, 18)
   } finally {
     if (child && child.exitCode === null && child.signalCode === null) {
       child.kill('SIGKILL')


### PR DESCRIPTION
## Summary

- detect native `contenteditable` ownership loss before controlled Composer edits and remount the complete editor host
- preserve native text, selection, and focus across recovery so React never deletes detached descendants
- keep external URL clipboard HTML as ordinary text while preserving Rovai's private structured Mention clipboard
- add a real Electron Renderer regression that reproduces the original `removeChild` white-screen failure

## Root cause

Paste previously committed the controlled draft directly even when Chromium had replaced a React-owned empty placeholder. React then tried to remove the detached placeholder during its commit and threw `NotFoundError`, unmounting the Renderer root. Native input reconciliation already had a host-remount path, but controlled paste and keyboard edits bypassed it.

## Validation

- `pnpm test:composer-input` (RED before the fix; GREEN after the fix and after rebasing onto current `origin/main`)
- `pnpm typecheck`
- 71 targeted Composer/model/clipboard Vitest cases
- `pnpm test` (133 files / 1356 Vitest cases; 220 Node cases passed, 1 platform skip)
- `pnpm build:desktop`
- `pnpm package:mac`
- `pnpm accept:composer-skill-picker-ui`
- `pnpm accept:structured-mentions-ui`
- Impeccable detector: no findings
- `pnpm test:rust:staged` (no Rust changes; skipped as expected)
