### PR TITLE
fix(desktop): retain safe-exit overlay during shutdown

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -617,11 +617,17 @@ export function ControlledShutdownOverlay({
 }
 
 export function App(): React.JSX.Element {
-  const [supervisor, setSupervisor] = useState<SupervisorSnapshot | null>(null)
+  const [supervisorState, setSupervisorState] = useState<{
+    latest: SupervisorSnapshot | null
+    lastNonShutdown: SupervisorSnapshot | null
+  }>({ latest: null, lastNonShutdown: null })
+  const supervisor = supervisorState.latest
   const [startupSnapshot, setStartupSnapshot] = useState<DesktopStartupSnapshot | null>(null)
   const [startupError, setStartupError] = useState<string | null>(null)
   const [startupReadAttempt, setStartupReadAttempt] = useState(0)
   const [startupFeedbackDelayElapsed, setStartupFeedbackDelayElapsed] = useState(false)
+  const [runtimeShuttingDown, setRuntimeShuttingDown] = useState(false)
+  const [shutdownFeedbackVisible, setShutdownFeedbackVisible] = useState(false)
   const startupStartedAt = useRef(performance.now())
 
   useEffect(() => {
@@ -667,9 +673,15 @@ export function App(): React.JSX.Element {
     let disposed = false
     const apply = (snapshot: SupervisorSnapshot): void => {
       if (disposed || snapshot.schemaVersion !== 1) return
-      setSupervisor((current) => (
-        current === null || snapshot.revision > current.revision ? snapshot : current
-      ))
+      setSupervisorState((current) => {
+        if (current.latest !== null && snapshot.revision <= current.latest.revision) return current
+        return {
+          latest: snapshot,
+          lastNonShutdown: snapshot.fullCoreState === 'shutting_down'
+            ? current.lastNonShutdown
+            : snapshot
+        }
+      })
     }
     const unsubscribe = window.rovai.supervisor.onChanged(apply)
     void window.rovai.supervisor.getSnapshot().then(apply).catch(() => undefined)
@@ -679,26 +691,59 @@ export function App(): React.JSX.Element {
     }
   }, [])
 
-  if (supervisor?.fullCoreState === 'blocked' || supervisor?.fullCoreState === 'crashed') {
-    return <BootstrapShell snapshot={supervisor} />
-  }
-  if (!authoritativeWorkspaceIsAvailable(supervisor) || !startupSnapshot) {
-    return <StartupWorkspace
+  useEffect(() => window.rovai.onEvent((event: CoreEvent) => {
+    if (event.method !== 'runtime.state') return
+    if (stringField(asRecord(event.params), 'status') === 'shutting_down') {
+      setRuntimeShuttingDown(true)
+    }
+  }), [])
+
+  const shuttingDown = runtimeShuttingDown || supervisor?.fullCoreState === 'shutting_down'
+  const presentationSupervisor = shuttingDown ? supervisorState.lastNonShutdown : supervisor
+
+  useEffect(() => {
+    if (!shuttingDown) {
+      setShutdownFeedbackVisible(false)
+      return undefined
+    }
+    const timer = window.setTimeout(
+      () => setShutdownFeedbackVisible(true),
+      SHUTDOWN_FEEDBACK_DELAY_MS
+    )
+    return () => window.clearTimeout(timer)
+  }, [shuttingDown])
+
+  let workspace: React.JSX.Element
+  if (
+    presentationSupervisor?.fullCoreState === 'blocked'
+    || presentationSupervisor?.fullCoreState === 'crashed'
+  ) {
+    workspace = <BootstrapShell snapshot={presentationSupervisor} />
+  } else if (!authoritativeWorkspaceIsAvailable(presentationSupervisor) || !startupSnapshot) {
+    workspace = <StartupWorkspace
       snapshot={startupSnapshot}
-      feedbackVisible={startupFeedbackDelayElapsed}
-      error={startupError}
+      feedbackVisible={!shuttingDown && startupFeedbackDelayElapsed}
+      error={shuttingDown ? null : startupError}
       onRetry={() => setStartupReadAttempt((attempt) => attempt + 1)}
     />
+  } else {
+    workspace = (
+      <div className="authoritative-workspace">
+        <AuthoritativeApp
+          initialStartupSnapshot={startupSnapshot}
+          startupStartedAtMs={startupStartedAt.current}
+          startupFeedbackDelayElapsed={startupFeedbackDelayElapsed}
+        />
+        <CoreSubsystemNotice subsystems={presentationSupervisor?.coreSubsystems ?? []} />
+      </div>
+    )
   }
+
   return (
-    <div className="authoritative-workspace">
-      <AuthoritativeApp
-        initialStartupSnapshot={startupSnapshot}
-        startupStartedAtMs={startupStartedAt.current}
-        startupFeedbackDelayElapsed={startupFeedbackDelayElapsed}
-      />
-      <CoreSubsystemNotice subsystems={supervisor?.coreSubsystems ?? []} />
-    </div>
+    <>
+      {workspace}
+      {shuttingDown && <ControlledShutdownOverlay visible={shutdownFeedbackVisible} />}
+    </>
   )
 }
 
@@ -975,7 +1020,6 @@ function AuthoritativeApp({
   const [state, setState] = useState<LoadState>('loading')
   const [shuttingDown, setShuttingDown] = useState(false)
   const shuttingDownRef = useRef(false)
-  const [shutdownFeedbackVisible, setShutdownFeedbackVisible] = useState(false)
   const [notificationHeadsUpVisible, setNotificationHeadsUpVisible] = useState(false)
   const [startupSnapshot, setStartupSnapshot] = useState<DesktopStartupSnapshot | null>(
     initialStartupSnapshot
@@ -1652,18 +1696,6 @@ function AuthoritativeApp({
   useEffect(() => {
     void loadStartupSnapshot()
   }, [loadStartupSnapshot])
-
-  useEffect(() => {
-    if (!shuttingDown) {
-      setShutdownFeedbackVisible(false)
-      return undefined
-    }
-    const timer = window.setTimeout(
-      () => setShutdownFeedbackVisible(true),
-      SHUTDOWN_FEEDBACK_DELAY_MS
-    )
-    return () => window.clearTimeout(timer)
-  }, [shuttingDown])
 
   useEffect(() => {
     void loadOnboarding()
@@ -3438,7 +3470,6 @@ function AuthoritativeApp({
           error={onboardingError || startupError}
           onRetry={retryStartup}
         />
-        {shuttingDown && <ControlledShutdownOverlay visible={shutdownFeedbackVisible} />}
       </>
     )
   }
@@ -3489,7 +3520,6 @@ function AuthoritativeApp({
           )}
           onComplete={() => void completeOnboarding()}
         />
-        {shuttingDown && <ControlledShutdownOverlay visible={shutdownFeedbackVisible} />}
       </div>
     )
   }
@@ -3784,7 +3814,6 @@ function AuthoritativeApp({
         onOpenDetails={openUpdateSettings}
         onDownload={appUpdates.download}
       />
-      {shuttingDown && <ControlledShutdownOverlay visible={shutdownFeedbackVisible} />}
     </div>
     </FilePreviewProvider>
   )

--- a/scripts/fixtures/desktop-startup-presentation/renderer.tsx
+++ b/scripts/fixtures/desktop-startup-presentation/renderer.tsx
@@ -162,6 +162,30 @@ Object.assign(window, { startupTest: {
     }
 
     await reset()
+    const startupFrameBeforeShutdown = document.querySelector('[data-startup-frame="camp"]')
+    check(coreListeners.size > 0, 'The root App must subscribe to shutdown before Core is ready')
+    coreListeners.forEach(listener => listener({ method: 'runtime.state', params: { status: 'shutting_down' } }))
+    publish({ runtimeMode: 'bootstrap_only', fullCoreState: 'shutting_down', startupPhase: null,
+      capabilities: { ...supervisor.capabilities, authoritativeWorkspace: false, coreRequests: false } })
+    await flush()
+    check(startupFrameBeforeShutdown === document.querySelector('[data-startup-frame="camp"]'),
+      'Shutdown before authority ready must preserve the existing startup frame')
+    check(document.querySelector('.shutdown-scrim.is-pending'),
+      'Shutdown must block interaction during the anti-flash window')
+    await advance(399)
+    check(!document.querySelector('.shutdown-scrim.is-visible, .startup-route-loading'),
+      'Shutdown must not expose opening feedback during the anti-flash window')
+    await advance(1)
+    check(document.querySelector('.shutdown-scrim.is-visible'),
+      'Shutdown before authority ready must show safe-exit feedback after 400ms')
+    check(document.body.textContent?.includes('正在安全退出'),
+      'Shutdown before authority ready must use the safe-exit copy')
+    check(!document.querySelector('.startup-route-loading'),
+      'Shutdown feedback must replace route-opening feedback rather than compete with it')
+    noAuthority()
+    cases.push('pre-ready shutdown preserves its frame and shows only safe-exit feedback')
+
+    await reset()
     publish({ startupPhase: 'migrating_authority' })
     await advance(399)
     pageFrame('camp', false)
@@ -290,6 +314,32 @@ Object.assign(window, { startupTest: {
     }
     cases.push('Runtime availability refreshes health and installations without reloading members')
     cases.push('Runtime discovery retains full refresh across mixed debounce events')
+
+    const authoritativeWorkspaceBeforeShutdown = document.querySelector('.authoritative-workspace')
+    const appShellBeforeShutdown = document.querySelector('.app-shell')
+    check(authoritativeWorkspaceBeforeShutdown && appShellBeforeShutdown,
+      'The ready authority surface must be mounted before the shutdown transition')
+    coreListeners.forEach(listener => listener({ method: 'runtime.state', params: { status: 'shutting_down' } }))
+    publish({ runtimeMode: 'bootstrap_only', fullCoreState: 'shutting_down', startupPhase: null,
+      capabilities: { ...supervisor.capabilities, authoritativeWorkspace: false, coreRequests: false } })
+    await flush()
+    check(authoritativeWorkspaceBeforeShutdown.isConnected
+      && authoritativeWorkspaceBeforeShutdown === document.querySelector('.authoritative-workspace')
+      && appShellBeforeShutdown === document.querySelector('.app-shell'),
+      'Planned shutdown must retain the mounted authoritative workspace')
+    check(document.querySelector('.shutdown-scrim.is-pending'),
+      'The retained authority surface must be guarded during the anti-flash window')
+    check(!document.querySelector('.startup-route-loading'),
+      'Planned shutdown must not remount the route-opening surface')
+    await advance(399)
+    check(!document.querySelector('.shutdown-scrim.is-visible'),
+      'Safe-exit feedback must remain hidden before 400ms')
+    await advance(1)
+    check(document.querySelector('.shutdown-scrim.is-visible'),
+      'The retained authority surface must show safe-exit feedback after 400ms')
+    check(document.body.textContent?.includes('正在安全退出'),
+      'The retained authority surface must use the safe-exit copy')
+    cases.push('planned shutdown retains the authoritative surface and safe-exit modal')
     return { ok: true, cases }
   },
   async capture(theme: string, state = 'loading') {


### PR DESCRIPTION
## Summary

- retain the last non-shutdown Supervisor presentation while Full Core enters shutting_down
- own the controlled shutdown overlay at the App root so both startup and authoritative surfaces show the safe-exit state
- cover pre-ready and ready shutdown transitions in the production Electron presentation fixture

## Verification

- pnpm typecheck
- pnpm exec vitest run apps/desktop/src/renderer/src/App.test.ts
- pnpm test:startup-presentation
- pnpm test
- pnpm build:desktop
- Impeccable detector: 0 findings
