### PR TITLE
Unify renderer scrollbars

### DIFF
--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -128,6 +128,8 @@
   --conversation-artifact-width: 930px;
   --conversation-wide-width: 1040px;
   --conversation-composer-width: 1040px;
+  --scrollbar-gutter-size: 12px;
+  --scrollbar-thumb-inset: 2px;
 
 }
 
@@ -241,7 +243,39 @@
   --lightbox-shadow: 0 28px 80px rgb(0 0 0 / 52%);
 }
 
-* { box-sizing: border-box; }
+* {
+  box-sizing: border-box;
+  scrollbar-color: var(--surface-selected) transparent;
+  scrollbar-width: auto;
+}
+@supports selector(::-webkit-scrollbar) {
+  /* Standard colors override Chromium's custom scrollbar geometry. */
+  * { scrollbar-color: auto; }
+}
+*::-webkit-scrollbar {
+  width: var(--scrollbar-gutter-size);
+  height: var(--scrollbar-gutter-size);
+  background: transparent;
+}
+*::-webkit-scrollbar-track,
+*::-webkit-scrollbar-corner { background: transparent; }
+*::-webkit-scrollbar-button { display: none; width: 0; height: 0; }
+/* The 12px gutter and 2px inset on each edge leave an 8px visible thumb. */
+*::-webkit-scrollbar-thumb {
+  min-width: 44px;
+  min-height: 44px;
+  border: var(--scrollbar-thumb-inset) solid transparent;
+  border-radius: 999px;
+  background: var(--surface-selected);
+  background-clip: padding-box;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ink) 6%, transparent);
+}
+*::-webkit-scrollbar-thumb:hover {
+  background-color: color-mix(in srgb, var(--surface-selected) 88%, var(--ink));
+}
+*::-webkit-scrollbar-thumb:active {
+  background-color: color-mix(in srgb, var(--surface-selected) 80%, var(--ink));
+}
 html, body, #root { width: 100%; min-width: 0; height: 100%; margin: 0; }
 body { overflow: hidden; color: var(--ink); background: var(--canvas); }
 button, input, textarea, select { font: inherit; }
@@ -629,42 +663,12 @@ html[data-rovai-platform="win32"] .unified-sidebar-drag {
 .command-palette-item small { flex: 0 0 auto; margin-left: auto; color: var(--faint); font: 10px/1.3 ui-monospace, SFMono-Regular, Menlo, monospace; }
 .command-palette-empty { margin: 0; padding: 16px 14px; color: var(--faint); font-size: 12px; text-align: center; }
 .navigation-scroll {
-  --navigation-scrollbar-thumb: var(--surface-selected);
   min-height: 0;
   flex: 1 1 auto;
   overflow-x: hidden;
   overflow-y: auto;
   margin-right: -6px;
   padding: 0 6px 12px 0;
-  scrollbar-color: var(--navigation-scrollbar-thumb) transparent;
-  scrollbar-width: auto;
-}
-/* Updating the scroller's color also repaints the native thumb on focus changes. */
-.navigation-scroll:focus-within {
-  --navigation-scrollbar-thumb: color-mix(in srgb, var(--surface-selected) 88%, var(--ink));
-}
-@supports selector(::-webkit-scrollbar) {
-  /* Non-auto standard colors override Chromium's custom scrollbar geometry. */
-  .navigation-scroll { scrollbar-color: auto; }
-}
-/* Preserve the existing thin scrollbar's 11px gutter and paint only 7px. */
-.navigation-scroll::-webkit-scrollbar { width: 11px; }
-.navigation-scroll::-webkit-scrollbar-track,
-.navigation-scroll::-webkit-scrollbar-corner { background: transparent; }
-.navigation-scroll::-webkit-scrollbar-button { display: none; width: 0; height: 0; }
-.navigation-scroll::-webkit-scrollbar-thumb {
-  min-height: 44px;
-  border-left: 4px solid transparent;
-  border-radius: 999px;
-  background: var(--navigation-scrollbar-thumb);
-  background-clip: padding-box;
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ink) 6%, transparent);
-}
-.navigation-scroll::-webkit-scrollbar-thumb:hover {
-  background-color: color-mix(in srgb, var(--surface-selected) 88%, var(--ink));
-}
-.navigation-scroll::-webkit-scrollbar-thumb:active {
-  background-color: color-mix(in srgb, var(--surface-selected) 80%, var(--ink));
 }
 .navigation-projects { margin-top: 15px; }
 .navigation-projects > .camp-nav-group + .camp-nav-group { margin-top: 8px; }
@@ -1320,11 +1324,8 @@ html[data-rovai-platform="win32"] .bootstrap-shell-brand { padding-left: 20px; }
 .memory-search input { width: 100%; min-width: 0; min-height: 0; padding: 0; border: 0; border-radius: 0; outline: 0; color: var(--ink); background: transparent; box-shadow: none; font-size: 10px; }
 .memory-search input::placeholder { color: var(--workspace-faint); opacity: 1; }
 .memory-search input:focus-visible { border-color: transparent; outline: 0; box-shadow: none; }
-.memory-capacity-strip { display: flex; min-width: 0; flex: 0 0 auto; gap: 7px; margin: 0; padding: 0 0 5px; overflow-x: auto; overscroll-behavior-x: contain; list-style: none; scrollbar-color: var(--workspace-line) transparent; scrollbar-width: thin; }
+.memory-capacity-strip { display: flex; min-width: 0; flex: 0 0 auto; gap: 7px; margin: 0; padding: 0 0 5px; overflow-x: auto; overscroll-behavior-x: contain; list-style: none; }
 .memory-capacity-strip:focus-visible { border-radius: 8px; outline: 2px solid var(--focus); outline-offset: 2px; }
-.memory-capacity-strip::-webkit-scrollbar { height: 6px; }
-.memory-capacity-strip::-webkit-scrollbar-track { background: transparent; }
-.memory-capacity-strip::-webkit-scrollbar-thumb { border-radius: 999px; background: var(--workspace-line); }
 .memory-capacity-item { display: grid; min-width: 200px; flex: 0 0 200px; gap: 7px; padding: 9px 11px; border-radius: 9px; background: var(--workspace-surface-subtle); }
 .memory-capacity-name { overflow: hidden; color: var(--ink); font-size: 10px; font-weight: 650; text-overflow: ellipsis; white-space: nowrap; }
 .memory-capacity-metrics { display: flex; align-items: center; gap: 12px; color: var(--muted); }
@@ -2168,7 +2169,7 @@ html.file-preview-resizing .file-preview-pane { pointer-events: none; }
 .run-pulse-mark svg { width: 18px; height: 16px; fill: none; stroke: currentColor; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
 .run-pulse-heading strong { color: var(--brand-ink); font-size: 10px; letter-spacing: .08em; text-transform: uppercase; }
 .run-pulse-count { margin-left: 25px; color: var(--faint); font: 500 9.5px/1.3 ui-monospace, SFMono-Regular, Menlo, monospace; }
-.run-pulse-list { display: flex; min-width: 0; gap: 5px; margin: 0; overflow-x: auto; padding: 0; list-style: none; scrollbar-width: thin; }
+.run-pulse-list { display: flex; min-width: 0; gap: 5px; margin: 0; overflow-x: auto; padding: 0; list-style: none; }
 .run-pulse-list > li { min-width: 0; flex: 0 0 auto; }
 .run-pulse-chip { display: grid; width: 100%; min-width: 132px; max-width: 196px; grid-template-columns: 24px minmax(0, 1fr) auto; align-items: center; gap: 6px; padding: 5px 7px; border: 1px solid var(--line); border-radius: 7px; color: var(--ink); background: var(--conversation-surface); text-align: left; cursor: pointer; }
 .run-pulse-chip:hover { border-color: var(--control-line); }
@@ -3492,7 +3493,7 @@ button.task-event-card:focus-visible .task-card-chevron { color: var(--brand-ink
 .diff-deletion { color: var(--diff-remove); }
 .modified-file-row[open] .tool-call-disclosure-slot svg { transform: rotate(180deg); }
 .modified-file-summary:hover .tool-call-disclosure-slot { color: var(--ink); background: var(--surface-muted); }
-.modified-file-diff { max-height: min(220px, 30vh); min-width: 0; margin: 3px 0 8px; overflow: auto; overscroll-behavior: contain; border: 1px solid var(--evidence-line); border-radius: 6px; color: var(--evidence-ink); background: var(--evidence-surface); font: 10px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; scrollbar-color: var(--control-line) transparent; scrollbar-width: thin; }
+.modified-file-diff { max-height: min(220px, 30vh); min-width: 0; margin: 3px 0 8px; overflow: auto; overscroll-behavior: contain; border: 1px solid var(--evidence-line); border-radius: 6px; color: var(--evidence-ink); background: var(--evidence-surface); font: 10px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
 .modified-file-diff:focus-visible { border-color: var(--focus); outline: 2px solid var(--focus); outline-offset: 2px; }
 .modified-file-diff-line { display: grid; min-width: 520px; min-height: 20px; grid-template-columns: 20px 34px 34px minmax(0, 1fr); }
 .modified-file-diff-line > span { display: grid; place-items: center; color: var(--evidence-muted); user-select: none; }
@@ -3510,7 +3511,7 @@ button.task-event-card:focus-visible .task-card-chevron { color: var(--brand-ink
 .modified-file-diff.is-exact-mutation .modified-file-diff-line { min-width: 360px; grid-template-columns: 20px minmax(0, 1fr); }
 .modified-file-diff.is-exact-mutation .modified-file-diff-line code { border-left: 1px solid color-mix(in srgb, var(--evidence-line) 55%, transparent); }
 .tool-call-detail { position: relative; min-width: 0; margin: 5px 0 8px 24px; padding-right: 52px; }
-.tool-call-result-scroll { box-sizing: border-box; width: 100%; max-width: 100%; max-height: min(220px, 30vh); margin: 0; overflow: auto; overscroll-behavior: contain; scrollbar-gutter: stable; padding: 8px 9px; border: 1px solid var(--evidence-line); border-radius: 5px; color: var(--evidence-muted); background: var(--evidence-canvas); font: 10px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre-wrap; overflow-wrap: anywhere; scrollbar-color: var(--control-line) transparent; scrollbar-width: thin; }
+.tool-call-result-scroll { box-sizing: border-box; width: 100%; max-width: 100%; max-height: min(220px, 30vh); margin: 0; overflow: auto; overscroll-behavior: contain; scrollbar-gutter: stable; padding: 8px 9px; border: 1px solid var(--evidence-line); border-radius: 5px; color: var(--evidence-muted); background: var(--evidence-canvas); font: 10px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre-wrap; overflow-wrap: anywhere; }
 .tool-call-disclosure[data-activity-domain="shell"] .tool-call-detail { margin-left: 2px; }
 .tool-call-disclosure[data-activity-domain="shell"] .tool-call-result-scroll { background: var(--shell-result-canvas); }
 .tool-call-result-scroll:focus-visible { border-color: var(--focus); outline: 2px solid var(--focus); outline-offset: 2px; }
@@ -3819,7 +3820,7 @@ details summary { min-height: 28px; padding: 5px 0; color: var(--muted); font-si
 .composer-box:focus-within { border-color: var(--brand); box-shadow: 0 0 0 3px var(--focus-soft); }
 .pending-input-queue { --queue-surface: color-mix(in srgb, var(--surface-subtle) 44%, var(--conversation-surface)); --queue-surface-active: color-mix(in srgb, var(--brand-soft) 42%, var(--conversation-surface)); width: min(var(--conversation-composer-width), 100%); min-width: 0; margin: 0 auto 6px; color: var(--muted); }
 .pending-input-heading { display: flex; min-height: 26px; align-items: center; justify-content: space-between; gap: 8px; color: var(--muted); font-size: 11px; }
-.pending-input-list { display: grid; gap: 4px; max-height: min(176px, 23vh); margin: 0; padding: 0; overflow-y: auto; overscroll-behavior: contain; list-style: none; scrollbar-width: thin; }
+.pending-input-list { display: grid; gap: 4px; max-height: min(176px, 23vh); margin: 0; padding: 0; overflow-y: auto; overscroll-behavior: contain; list-style: none; }
 .pending-input-row { display: flex; min-width: 0; min-height: 32px; flex-wrap: wrap; align-items: center; gap: 4px; padding: 3px 4px 3px 9px; border: 1px solid color-mix(in srgb, var(--line) 82%, transparent); border-radius: 7px; background: var(--queue-surface); }
 .pending-input-row.is-editing { border-color: color-mix(in srgb, var(--brand) 42%, var(--line)); color: var(--ink); background: var(--queue-surface-active); }
 .pending-input-preview { display: flex; min-width: 0; flex: 1 1 160px; align-items: center; gap: 7px; min-height: 24px; padding: 2px 0; font-size: 10.5px; line-height: 1.35; }
@@ -3870,7 +3871,7 @@ details summary { min-height: 28px; padding: 5px 0; color: var(--muted); font-si
 .composer textarea:focus { border: 0; box-shadow: none; }
 .composer textarea:focus-visible { outline: 0; }
 .structured-mention-composer { width: 100%; min-height: 0; }
-.structured-mention-editor { display: block; width: 100%; min-height: 42px; max-height: min(180px, 26vh); overflow-x: hidden; overflow-y: auto; overscroll-behavior: contain; outline: 0; scrollbar-width: thin; }
+.structured-mention-editor { display: block; width: 100%; min-height: 42px; max-height: min(180px, 26vh); overflow-x: hidden; overflow-y: auto; overscroll-behavior: contain; outline: 0; }
 .structured-mention-editor:focus-visible { outline: 0; }
 .structured-mention-editor:not(:has(> [data-editor-empty="true"]:only-child > [data-editor-empty-break="true"]:only-child)) + .structured-mention-placeholder { visibility: hidden; }
 .composer-reply-region { display: grid; min-width: 0; gap: 4px; padding: 1px 0 2px; }
@@ -3944,7 +3945,7 @@ details summary { min-height: 28px; padding: 5px 0; color: var(--muted); font-si
 .composer-send { min-height: 28px; padding: 5px 12px; border-radius: 6px; font-size: 12px; font-weight: 650; }
 .composer-stop { min-height: 28px; padding: 5px 14px; border-color: var(--danger); border-radius: 6px; color: var(--danger-contrast); background: var(--danger); font-size: 12px; font-weight: 700; }
 .composer-stop:hover:not(:disabled) { border-color: color-mix(in srgb, var(--danger) 82%, black); background: color-mix(in srgb, var(--danger) 82%, black); }
-.composer-attachment-strip { display: flex; gap: 7px; min-width: 0; max-width: 100%; padding: 1px 0 4px; overflow-x: auto; overscroll-behavior-inline: contain; scrollbar-width: thin; }
+.composer-attachment-strip { display: flex; gap: 7px; min-width: 0; max-width: 100%; padding: 1px 0 4px; overflow-x: auto; overscroll-behavior-inline: contain; }
 .attachment-card { position: relative; display: flex; flex: 0 0 188px; min-width: 0; height: 52px; align-items: stretch; border: 1px solid var(--line); border-radius: 7px; background: var(--surface); overflow: hidden; }
 .attachment-open { display: flex; flex: 1 1 auto; min-width: 0; align-items: center; gap: 8px; padding: 5px 26px 5px 5px; border: 0; color: inherit; background: transparent; text-align: left; }
 button.attachment-open { cursor: pointer; }
@@ -4271,7 +4272,7 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
 .monitoring-section-heading { display: grid; gap: 4px; }
 .monitoring-section-heading h2 { margin: 0; color: var(--ink); font-size: 15px; font-weight: 650; letter-spacing: -0.01em; }
 .monitoring-section-heading p { max-width: 72ch; margin: 0; color: var(--muted); font-size: 10.5px; line-height: 1.55; }
-.monitoring-table-wrap { overflow-x: auto; border-radius: 11px; background: var(--workspace-surface-subtle); scrollbar-color: var(--faint) transparent; scrollbar-width: thin; }
+.monitoring-table-wrap { overflow-x: auto; border-radius: 11px; background: var(--workspace-surface-subtle); }
 .monitoring-table-wrap table { width: 100%; min-width: 590px; border-collapse: collapse; font-size: 10.5px; font-variant-numeric: tabular-nums; }
 .monitoring-table-wrap th,
 .monitoring-table-wrap td { height: 43px; padding: 8px 13px; border-bottom: 1px solid var(--line); text-align: right; }
@@ -4316,7 +4317,7 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
 .monitoring-keyline > div:nth-child(4n) { border-right: 0; }
 .monitoring-keyline > div:nth-last-child(-n + 4) { border-bottom: 0; }
 .monitoring-usage-trend { overflow: hidden; border-radius: 11px; background: var(--workspace-surface-subtle); }
-.monitoring-usage-bars { display: grid; height: 148px; grid-template-columns: repeat(auto-fit, minmax(10px, 1fr)); gap: 5px; align-items: end; overflow-x: auto; padding: 15px 14px 0; border-bottom: 1px solid var(--line); scrollbar-color: var(--faint) transparent; scrollbar-width: thin; }
+.monitoring-usage-bars { display: grid; height: 148px; grid-template-columns: repeat(auto-fit, minmax(10px, 1fr)); gap: 5px; align-items: end; overflow-x: auto; padding: 15px 14px 0; border-bottom: 1px solid var(--line); }
 .monitoring-usage-bucket { display: grid; min-width: 8px; height: 100%; grid-template-columns: repeat(4, minmax(1px, 1fr)); gap: 1px; align-items: end; }
 .monitoring-usage-bucket i { display: block; min-height: 2px; border-radius: 2px 2px 0 0; }
 .monitoring-usage-bucket .is-input,
@@ -4332,7 +4333,7 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
 .monitoring-usage-legend { display: flex; flex-wrap: wrap; justify-content: center; gap: 10px; }
 .monitoring-usage-legend span { display: inline-flex; align-items: center; gap: 5px; }
 .monitoring-usage-legend span::before { width: 6px; height: 6px; border-radius: 2px; content: ""; }
-.monitoring-trend-cost { display: flex; gap: 14px; overflow-x: auto; padding: 0 13px 9px; color: var(--muted); font-size: 9px; font-variant-numeric: tabular-nums; scrollbar-color: var(--faint) transparent; scrollbar-width: thin; }
+.monitoring-trend-cost { display: flex; gap: 14px; overflow-x: auto; padding: 0 13px 9px; color: var(--muted); font-size: 9px; font-variant-numeric: tabular-nums; }
 .monitoring-trend-cost > span { white-space: nowrap; }
 .monitoring-trend-cost > span:first-child { color: var(--faint); font-weight: 670; }
 .monitoring-table-wrap table { min-width: 890px; }
@@ -4833,7 +4834,7 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
 .onboarding-model-panel > header strong { font-size: 11px; }
 .onboarding-runtime-panel > header small,
 .onboarding-model-panel > header small { overflow: hidden; color: var(--faint); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
-.onboarding-runtime-list { max-height: 218px; overflow-y: auto; scrollbar-width: thin; }
+.onboarding-runtime-list { max-height: 218px; overflow-y: auto; }
 .onboarding-runtime-row {
   position: relative;
   display: grid;
@@ -4897,7 +4898,7 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
 .onboarding-scan-progress em.done { color: var(--success); }
 .onboarding-scan-progress em.active { color: var(--info); }
 .onboarding-scan-progress em i { width: 8px; height: 8px; border: 2px solid color-mix(in srgb, var(--info) 28%, transparent); border-top-color: var(--info); border-radius: 50%; animation: startup-route-spin 700ms linear infinite; }
-.onboarding-model-body { max-height: 154px; overflow: auto; padding: 0 13px 12px; scrollbar-width: thin; }
+.onboarding-model-body { max-height: 154px; overflow: auto; padding: 0 13px 12px; }
 .onboarding-model-parameter-form { grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0 10px; }
 .onboarding-model-parameter-form .field-label { gap: 5px; margin-top: 10px; font-size: 10px; }
 .onboarding-model-parameter-form .field-label select { min-height: 33px; padding: 6px 8px; font-size: 11px; }
@@ -5145,7 +5146,7 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
 .channel-section-heading h2 { margin: 0; color: var(--ink); font-size: 15px; font-weight: 620; line-height: 1.3; letter-spacing: -.01em; }
 .channel-section-heading p { max-width: 72ch; margin: 4px 0 0; color: var(--muted); font-size: 10.5px; line-height: 1.55; }
 .channel-section-heading > span { flex: 0 0 auto; color: var(--faint); font: 500 10px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; white-space: nowrap; }
-.channel-provider-strip { display: flex; min-width: 0; overflow-x: auto; padding: 7px 2px; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); scrollbar-width: thin; }
+.channel-provider-strip { display: flex; min-width: 0; overflow-x: auto; padding: 7px 2px; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
 .channel-provider-tab { display: grid; width: min(232px, 100%); min-height: 44px; grid-template-columns: 30px minmax(0, 1fr); gap: 9px; align-items: center; padding: 6px 9px; border: 0; border-radius: 7px; color: var(--muted); background: transparent; cursor: pointer; text-align: left; }
 .channel-provider-tab:hover { color: var(--ink); background: var(--workspace-surface-hover); }
 .channel-provider-tab.is-selected { color: var(--brand-ink); background: var(--brand-soft); }
@@ -6900,7 +6901,6 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
   gap: 7px;
   overflow-y: auto;
   padding-right: 3px;
-  scrollbar-width: thin;
 }
 .member-avatar-preset-list { grid-template-columns: 1fr 1fr; max-height: none; }
 .member-preset-card {
@@ -7162,7 +7162,6 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
   overflow-y: auto;
   padding: 6px 7px 16px;
   overscroll-behavior: contain;
-  scrollbar-width: thin;
 }
 .member-sidebar-group + .member-sidebar-group { margin-top: 8px; }
 .member-sidebar-group-heading {
@@ -7325,7 +7324,6 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
   overflow-y: auto;
   padding: 30px 26px 48px;
   overscroll-behavior: contain;
-  scrollbar-width: thin;
 }
 .member-detail-page { width: min(980px, 100%); margin: 0 auto; }
 .member-detail-header {

--- a/apps/desktop/src/renderer/src/theme-tokens.test.ts
+++ b/apps/desktop/src/renderer/src/theme-tokens.test.ts
@@ -232,6 +232,19 @@ describe('Porcelain Day + Steel Night theme tokens', () => {
     expect(css).toMatch(/\.project-heading-row\.current-project\s*\{[^}]*background: var\(--surface-selected\)/)
   })
 
+  it('uses one transparent-gutter 8px scrollbar thumb across visible scrollers', () => {
+    const gutterSize = Number.parseFloat(day['--scrollbar-gutter-size'])
+    const thumbInset = Number.parseFloat(day['--scrollbar-thumb-inset'])
+
+    expect(gutterSize - (thumbInset * 2)).toBe(8)
+    expect(css).toMatch(/\*::-webkit-scrollbar\s*\{[^}]*width: var\(--scrollbar-gutter-size\)[^}]*height: var\(--scrollbar-gutter-size\)[^}]*background: transparent/)
+    expect(css).toMatch(/\*::-webkit-scrollbar-track,\s*\*::-webkit-scrollbar-corner\s*\{[^}]*background: transparent/)
+    expect(css).toMatch(/\*::-webkit-scrollbar-thumb\s*\{[^}]*border: var\(--scrollbar-thumb-inset\) solid transparent[^}]*border-radius: 999px[^}]*background: var\(--surface-selected\)/)
+    expect(css).not.toContain('scrollbar-width: thin')
+    expect(css).toContain('.file-preview-tab-strip::-webkit-scrollbar { display: none; }')
+    expect(css).toContain('.run-pulse-inspector .run-pulse-list::-webkit-scrollbar { display: none; }')
+  })
+
   it('gives every page a controlled drag region and compacts only the Windows sidebar inset', () => {
     expect(css).toContain(`.content.compose-content,
 .content.settings-content,


### PR DESCRIPTION
## Summary

- unify every visible Renderer scrollbar around a 12px transparent gutter and an 8px capsule thumb
- reuse the existing sidecar surface-selected thumb color in both themes
- remove surface-specific thin/color overrides while preserving intentionally hidden tab-strip and inspector-avatar scrollbars
- add regression coverage for geometry, color token, transparent track/corner, and hidden exceptions

## Scope

Only scrollbar thumb and gutter styling changed. Typography, settings surfaces, gradients, layout, and component structure are unchanged.

## Validation

- pnpm typecheck
- pnpm exec vitest run apps/desktop/src/renderer/src/theme-tokens.test.ts apps/desktop/src/renderer/src/execution-console-layout.test.ts apps/desktop/src/renderer/src/file-preview-layout.test.ts (50 passed)
- pnpm test (133 files / 1363 Vitest passed; 220 Node tests passed, 1 platform skip)
- pnpm build:desktop
- pnpm package:mac
- codesign and arm64 checks for App, Core, and CLI
- isolated packaged manual preview accepted by the user