### PR TITLE
创建新对话下拉框采用 C 瓷白钢边配色

### DIFF
--- a/apps/desktop/.impeccable/surfaces/new-conversation-dialog.md
+++ b/apps/desktop/.impeccable/surfaces/new-conversation-dialog.md
@@ -62,6 +62,16 @@ state returns focus to the exact opener.
 Do not restore “协作方式 / 并肩协作 / 领队统筹 / 暂未开放”; the request continues to submit the existing
 `peer` semantics. This is a Renderer simplification, not a Core union or SQLite migration.
 
+## Active color review
+
+The [non-authoritative HTML color study](../../../../docs/prototypes/new-conversation-dialog-colors/index.html)
+keeps the current Dialog, Header, Footer and brand treatment while comparing the current picker colors with
+three cooler treatments for the workspace, member and Lead dropdowns. C “瓷白钢边” was selected on
+2026-09-01 and is implemented through the paired `--new-camp-picker-*` Day/Night semantic tokens. The
+optional-configuration accordion intentionally keeps the standard Dialog surface tokens because it is a
+secondary disclosure, not a picker. The study remains non-authoritative context; production tokens and this
+brief define the accepted component treatment.
+
 ## Inheritance and hard boundaries
 
 Inherit root [`DESIGN.md`](../../../../DESIGN.md), both theme contracts and

--- a/apps/desktop/src/renderer/src/new-conversation-dialog-structure.test.ts
+++ b/apps/desktop/src/renderer/src/new-conversation-dialog-structure.test.ts
@@ -35,4 +35,13 @@ describe('New Conversation dialog presentation contract', () => {
     expect(component).toContain('disabled={projectActionsDisabled}')
     expect(component).toContain(': closeButtonRef.current')
   })
+
+  it('scopes the selected porcelain picker colors to dropdown controls', () => {
+    expect(styles).toMatch(/\.new-camp-picker-trigger\s*\{[^}]*border:\s*1px solid var\(--new-camp-picker-line-strong\)[^}]*background:\s*var\(--new-camp-picker-surface\)/s)
+    expect(styles).toMatch(/\.new-camp-picker-menu\s*\{[^}]*border:\s*1px solid var\(--new-camp-picker-line-strong\)[^}]*background:\s*var\(--new-camp-picker-surface\)/s)
+    expect(styles).toMatch(/\.new-camp-lead-trigger\s*\{[^}]*border:\s*1px solid var\(--new-camp-picker-line-strong\)[^}]*background:\s*var\(--new-camp-picker-surface\)/s)
+    expect(styles).toMatch(/\.new-camp-lead-menu\s*\{[^}]*border:\s*1px solid var\(--new-camp-picker-line-strong\)[^}]*background:\s*var\(--new-camp-picker-surface\)/s)
+    expect(styles).toMatch(/\.new-camp-optional-shell\s*\{[^}]*background:\s*var\(--surface\)/s)
+    expect(styles).toMatch(/\.new-camp-optional-icon\s*\{[^}]*background:\s*var\(--surface-muted\)/s)
+  })
 })

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -44,6 +44,10 @@
   --line: #dfe4e8;
   --line-strong: #c7cfd6;
   --control-line: #8b9389;
+  --new-camp-picker-surface: #ffffff;
+  --new-camp-picker-soft: #e9eef3;
+  --new-camp-picker-hover: #edf2f5;
+  --new-camp-picker-line-strong: #8296a4;
   --brand: #526f88;
   --brand-hover: #3d5874;
   --brand-contrast: #ffffff;
@@ -170,6 +174,10 @@
   --line: #333e46;
   --line-strong: #53616b;
   --control-line: #687b88;
+  --new-camp-picker-surface: #1b2227;
+  --new-camp-picker-soft: #22303a;
+  --new-camp-picker-hover: #24323b;
+  --new-camp-picker-line-strong: #6a8190;
   --brand: #7897ae;
   --brand-hover: #b1c8d8;
   --brand-contrast: #091116;
@@ -6205,14 +6213,14 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
   align-items: center;
   gap: 11px;
   padding: 8px 11px;
-  border: 1px solid var(--line-strong);
+  border: 1px solid var(--new-camp-picker-line-strong);
   border-radius: 7px;
   color: var(--ink);
-  background: var(--surface);
+  background: var(--new-camp-picker-surface);
   text-align: left;
   cursor: pointer;
 }
-.new-camp-picker-trigger:hover:not(:disabled) { border-color: color-mix(in srgb, var(--line-strong) 55%, var(--brand) 45%); }
+.new-camp-picker-trigger:hover:not(:disabled) { border-color: color-mix(in srgb, var(--new-camp-picker-line-strong) 55%, var(--brand) 45%); background: var(--new-camp-picker-hover); }
 .new-camp-picker-trigger[aria-expanded="true"] { border-color: var(--focus); box-shadow: 0 0 0 2px var(--focus-soft); }
 .new-camp-picker-trigger > span:nth-child(2) { display: grid; min-width: 0; flex: 1; gap: 2px; }
 .new-camp-picker-trigger strong,
@@ -6227,7 +6235,7 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
   place-items: center;
   border-radius: 7px;
   color: var(--muted);
-  background: var(--surface-muted);
+  background: var(--new-camp-picker-soft);
 }
 .new-camp-project-folder-icon {
   width: 17px;
@@ -6295,9 +6303,9 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
   max-height: 280px;
   overflow-y: auto;
   padding: 6px;
-  border: 1px solid var(--line-strong);
+  border: 1px solid var(--new-camp-picker-line-strong);
   border-radius: 9px;
-  background: var(--surface-raised);
+  background: var(--new-camp-picker-surface);
   box-shadow: 0 18px 46px color-mix(in srgb, var(--overlay) 42%, transparent);
 }
 .new-camp-project-option {
@@ -6315,16 +6323,16 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
   text-align: left;
   cursor: pointer;
 }
-.new-camp-project-option:hover { background: var(--surface-muted); }
+.new-camp-project-option:hover { background: var(--new-camp-picker-hover); }
 .new-camp-project-option.selected { color: var(--brand-ink); background: var(--brand-soft); }
-.new-camp-project-option-icon { display: grid; width: 28px; height: 28px; place-items: center; border-radius: 6px; color: var(--muted); background: var(--surface-muted); }
+.new-camp-project-option-icon { display: grid; width: 28px; height: 28px; place-items: center; border-radius: 6px; color: var(--muted); background: var(--new-camp-picker-soft); }
 .new-camp-project-option > span:nth-child(2) { display: grid; min-width: 0; gap: 2px; }
 .new-camp-project-option b { opacity: 0; color: var(--brand); }
 .new-camp-project-option.selected b { opacity: 1; }
 .new-camp-project-option.choose-local { border-top: 1px solid var(--line); border-radius: 0 0 6px 6px; }
 .new-camp-picker-trigger.member-trigger { min-height: 52px; }
 .new-camp-member-stack { display: flex; min-width: 68px; align-items: center; padding-left: 2px; }
-.new-camp-member-stack .member-avatar { margin-left: -8px; box-shadow: 0 0 0 2px var(--surface); }
+.new-camp-member-stack .member-avatar { margin-left: -8px; box-shadow: 0 0 0 2px var(--new-camp-picker-surface); }
 .new-camp-member-stack .member-avatar:first-child { margin-left: 0; }
 .new-camp-picker-menu.member-menu { max-height: 310px; padding: 0 5px 5px; }
 .new-camp-member-toolbar {
@@ -6338,7 +6346,7 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
   padding: 6px 5px;
   border-bottom: 1px solid var(--line);
   color: var(--muted);
-  background: var(--surface-raised);
+  background: var(--new-camp-picker-surface);
   font-size: 11px;
 }
 .new-camp-member-toolbar button { border: 0; color: var(--brand-ink); background: transparent; font-size: 11px; cursor: pointer; }
@@ -6353,7 +6361,7 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
   border-radius: 6px;
   cursor: pointer;
 }
-.new-camp-member-option:hover { background: var(--surface-muted); }
+.new-camp-member-option:hover { background: var(--new-camp-picker-hover); }
 .new-camp-member-option.unselected .new-camp-member-copy { opacity: .58; }
 .new-camp-member-option input { width: 16px; height: 16px; margin: 0; accent-color: var(--brand); }
 .new-camp-member-copy { display: grid; min-width: 0; gap: 3px; }
@@ -6373,14 +6381,14 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
   align-items: center;
   gap: 10px;
   padding: 7px 10px;
-  border: 1px solid var(--line-strong);
+  border: 1px solid var(--new-camp-picker-line-strong);
   border-radius: 7px;
   color: var(--ink);
-  background: var(--surface);
+  background: var(--new-camp-picker-surface);
   text-align: left;
   cursor: pointer;
 }
-.new-camp-lead-trigger:hover:not(:disabled) { border-color: color-mix(in srgb, var(--line-strong) 55%, var(--brand) 45%); }
+.new-camp-lead-trigger:hover:not(:disabled) { border-color: color-mix(in srgb, var(--new-camp-picker-line-strong) 55%, var(--brand) 45%); background: var(--new-camp-picker-hover); }
 .new-camp-lead-trigger[data-state="open"] { border-color: var(--focus); box-shadow: 0 0 0 2px var(--focus-soft); }
 .new-camp-lead-trigger[data-state="open"] .new-camp-chevron { transform: rotate(180deg); }
 .new-camp-lead-copy { display: grid; min-width: 0; gap: 2px; }
@@ -6394,10 +6402,10 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
   max-height: min(260px, var(--radix-dropdown-menu-content-available-height));
   overflow-y: auto;
   padding: 5px;
-  border: 1px solid var(--line-strong);
+  border: 1px solid var(--new-camp-picker-line-strong);
   border-radius: 9px;
   color: var(--ink);
-  background: var(--surface-raised);
+  background: var(--new-camp-picker-surface);
   box-shadow: var(--shadow-menu);
 }
 .new-camp-lead-menu-label { padding: 5px 7px 7px; border-bottom: 1px solid var(--line); color: var(--faint); font-size: 10px; font-weight: 650; }
@@ -6412,7 +6420,7 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
   outline: 0;
   cursor: pointer;
 }
-.new-camp-lead-option[data-highlighted] { outline: 2px solid var(--focus); outline-offset: -2px; background: var(--surface-muted); }
+.new-camp-lead-option[data-highlighted] { outline: 2px solid var(--focus); outline-offset: -2px; background: var(--new-camp-picker-hover); }
 .new-camp-lead-option[data-state="checked"] { background: var(--brand-soft); }
 .new-camp-lead-option[data-state="checked"] .new-camp-lead-copy strong { color: var(--brand-ink); }
 .new-camp-lead-option[data-disabled] { opacity: .52; cursor: not-allowed; }

--- a/apps/desktop/src/renderer/src/theme-tokens.test.ts
+++ b/apps/desktop/src/renderer/src/theme-tokens.test.ts
@@ -30,6 +30,10 @@ const requiredTokens = [
   '--line',
   '--line-strong',
   '--control-line',
+  '--new-camp-picker-surface',
+  '--new-camp-picker-soft',
+  '--new-camp-picker-hover',
+  '--new-camp-picker-line-strong',
   '--brand',
   '--brand-hover',
   '--brand-contrast',
@@ -97,6 +101,9 @@ function expectTextContrast(tokens: Record<string, string>): void {
     ['--ink', '--surface'],
     ['--muted', '--surface'],
     ['--faint', '--surface'],
+    ['--ink', '--new-camp-picker-surface'],
+    ['--faint', '--new-camp-picker-surface'],
+    ['--muted', '--new-camp-picker-soft'],
     ['--ink', '--execution-running-surface'],
     ['--muted', '--execution-running-surface'],
     ['--info', '--execution-running-surface'],
@@ -171,6 +178,10 @@ describe('Porcelain Day + Steel Night theme tokens', () => {
     expect(day['--workspace-line']).toBe('#d5dadd')
     expect(day['--workspace-steel']).toBe('#476b85')
     expect(day['--line']).toBe('#dfe4e8')
+    expect(day['--new-camp-picker-surface']).toBe('#ffffff')
+    expect(day['--new-camp-picker-soft']).toBe('#e9eef3')
+    expect(day['--new-camp-picker-hover']).toBe('#edf2f5')
+    expect(day['--new-camp-picker-line-strong']).toBe('#8296a4')
     expect(day['--brand']).toBe('#526f88')
     expect(day['--brand-soft']).toBe('#e9eef3')
     expect(day['--brand-ink']).toBe('#405f7e')
@@ -205,6 +216,10 @@ describe('Porcelain Day + Steel Night theme tokens', () => {
     expect(night['--workspace-surface-selected']).toBe('#22303a')
     expect(night['--workspace-line']).toBe('#2b353b')
     expect(night['--workspace-steel']).toBe('#8fadc0')
+    expect(night['--new-camp-picker-surface']).toBe('#1b2227')
+    expect(night['--new-camp-picker-soft']).toBe('#22303a')
+    expect(night['--new-camp-picker-hover']).toBe('#24323b')
+    expect(night['--new-camp-picker-line-strong']).toBe('#6a8190')
     expect(night['--brand']).toBe('#7897ae')
     expect(night['--brand-soft']).toBe('#22303a')
     expect(night['--mention-ink']).toBe('#9cc7e2')
@@ -218,6 +233,15 @@ describe('Porcelain Day + Steel Night theme tokens', () => {
     expect(night['--danger']).not.toBe(night['--brand'])
     expect(night['--info']).not.toBe(night['--brand'])
     expect(contrast(night['--mention-ink'], night['--surface'])).toBeGreaterThanOrEqual(4.5)
+  })
+
+  it('keeps the selected New Conversation picker boundaries and text accessible', () => {
+    for (const tokens of [day, night]) {
+      expect(contrast(tokens['--ink'], tokens['--new-camp-picker-surface'])).toBeGreaterThanOrEqual(4.5)
+      expect(contrast(tokens['--faint'], tokens['--new-camp-picker-surface'])).toBeGreaterThanOrEqual(4.5)
+      expect(contrast(tokens['--muted'], tokens['--new-camp-picker-soft'])).toBeGreaterThanOrEqual(4.5)
+      expect(contrast(tokens['--new-camp-picker-line-strong'], tokens['--new-camp-picker-surface'])).toBeGreaterThanOrEqual(3)
+    }
   })
 
   it('preserves stable identity colors for Skill, MCP, and member marks in both themes', () => {

--- a/docs/prototypes/new-conversation-dialog-colors/README.md
+++ b/docs/prototypes/new-conversation-dialog-colors/README.md
@@ -1,0 +1,80 @@
+---
+document_type: ui-prototype-readme
+status: selected
+last_updated: 2026-09-01
+---
+
+# 创建新对话 Dialog 下拉框配色候选
+
+这是“创建新对话”生产 Dialog 的局部配色评审稿。C“瓷白钢边”已于 2026-09-01 选定并进入生产实现。
+Dialog 主承载面、Header、Footer、Ember 标记、Steel 品牌色和可选配置全部保持当前生产样式，只调整
+工作目录、队员与负责人三个下拉控件及其菜单的颜色。
+
+## 查看
+
+[打开 HTML 设计稿](index.html)。设计稿是自包含 HTML，不依赖服务器、外部字体、图片或第三方脚本，
+不会连接 App、Core 或 Runtime。
+
+- 当前对照 · 米白：复现生产下拉框的 `surface / muted / line-strong` 组合。
+- A · 淡钢蓝：下拉框使用很浅的 Steel 洗色，与当前主按钮自然呼应。
+- B · 冷雾灰：去掉米白暖感但不引入明显蓝色，更中性、克制。
+- C · 瓷白钢边（已选）：控件保持纯白，通过满足 3:1 非文字对比度的 Steel 灰边界建立层次。
+
+同一个文件支持候选切换、日间／夜间、完整场景／并排比较，以及工作目录、队员、负责人和可选配置
+的本地展开交互。无查询参数时默认显示已选 C；URL 查询参数会保存 `palette`、`theme` 和 `view`，
+只接受稿内已知值。
+
+## 不变的边界
+
+- Dialog 主承载面、Header、Footer、Ember 标记、可选配置、按钮与整体结构固定为当前生产样式。
+- 候选 token 只供工作目录、队员、负责人三个 trigger 及相应 popup menu 使用。
+- Steel 继续负责品牌、焦点和主要动作；成功、注意、危险、身份和证据颜色不改职责。
+- 三套候选都保留日夜成对设计，不创建第三套生产主题，也不引入字体、图标或 UI 框架。
+- HTML 中的目录、队员和提交交互只用于展示状态，不写入偏好或创建 Camp。
+- 这是保留候选上下文的视觉评审稿，不是领域合同或验收证据；已选 C 通过生产语义主题 token 落地。
+
+## UI-UX-PRO-MAX 应用
+
+本次只做定向查询，没有重建产品设计系统：
+
+1. `desktop dropdown cool neutral --domain color`：命中知识库／文档工具的冷中性背景、白色卡面和
+   灰蓝边界方向；只吸收到下拉控件，拒绝把整块 Dialog 改色，也拒绝紫色 AI 模板与高饱和青色。
+2. `keyboard focus modal --domain ux`：保留每个交互控件的 2px 可见焦点、合理 Tab 顺序和不被固定
+   footer 遮挡的焦点状态。
+3. `dialogs --stack react`：保留生产 Radix Dialog 的焦点陷阱、关闭后焦点返回和 Esc 语义；HTML
+   只模拟外观，不替代这些生产能力。
+
+具体候选色值依据现有 Porcelain Day / Steel Night token 手工推导，不冒充资料库成品色板。
+
+## 项目依据
+
+- [全局设计系统](../../../DESIGN.md)
+- [创建新对话 surface brief](../../../apps/desktop/.impeccable/surfaces/new-conversation-dialog.md)
+- [Porcelain Day](../../ui/themes/porcelain-day.md) / [Steel Night](../../ui/themes/steel-night.md)
+- [生产组件](../../../apps/desktop/src/renderer/src/NewConversationDialog.tsx)
+- [生产样式](../../../apps/desktop/src/renderer/src/styles.css)
+
+### 已发现的文档—实现漂移
+
+Surface brief 当前写的是 Dialog 距 viewport 四边 72px、最大高度 `min(790px, viewport - 72px)`；
+生产 CSS 实际使用宽度 `viewport - 48px`、最大高度 `viewport - 32px`。为了还原“现在的 UI”，本稿按
+生产 CSS 呈现，没有在本次配色实现中顺带改变几何或宣称任一侧已修复。后续需要单独确认由 brief
+还是现有 CSS 收敛这处差异。
+
+## 验证记录
+
+2026-09-01 完成以下静态验证：
+
+- 内联 JavaScript 语法通过；32 个 DOM ID 无重复，29 个脚本／ARIA／label 引用均有目标；无远程资源。
+- 静态断言确认 A / B / C 不覆盖 Dialog 主面、Header、Footer、结构线或 Ember token，只覆盖 picker token。
+- 日间四套下拉 surface / menu / hover 上的最小文字对比度为主文字 14.32:1、次要文字 4.56:1、
+  faint 文字 4.97:1，图标与 soft fill 为 4.51:1；夜间分别为 10.51:1、6.00:1、5.37:1、6.18:1。
+  已选 C 的控件边界对 surface 为日间 3.07:1、夜间 3.95:1。
+- 已断言 1040px 桌面场景、1100px / 640px review 页响应式规则、局部横向滚动、2px 焦点环、
+  `prefers-reduced-motion` 和无 `transition: all`。
+- 生产 token 范围由 Renderer 主题与 New Conversation 结构测试锁定；`pnpm typecheck`、`pnpm test`、
+  `pnpm build:desktop`、`pnpm docs:test`、`pnpm docs:check`、Markdown 本地链接和 whitespace 检查通过。
+
+即使用户已在内置浏览器打开本稿，Browser 安全策略仍禁止自动刷新或捕获 `file://` 页面，因此本次
+没有伪造浏览器截图或声称完成真实视觉验收。用户可手动刷新当前 HTML 评审；生产实现仍需按
+Desktop UI 验收流程检查真实 Electron App、键盘焦点、双主题和 1040×700 / 1440×920 参考窗口。

--- a/docs/prototypes/new-conversation-dialog-colors/index.html
+++ b/docs/prototypes/new-conversation-dialog-colors/index.html
@@ -1,0 +1,682 @@
+<!doctype html>
+<html lang="zh-CN" data-theme="day" data-view="scene">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
+  <meta name="description" content="Rovai AI 创建新对话 Dialog 的三套下拉框配色候选；Dialog 主色保持当前生产样式。">
+  <title>Rovai AI · 创建新对话下拉框配色</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --canvas: #eceeef;
+      --surface: #fbfbfa;
+      --surface-raised: #ffffff;
+      --surface-subtle: #f0f2f4;
+      --surface-muted: #e7eaed;
+      --surface-hover: #e8eaea;
+      --ink: #171b20;
+      --muted: #616a73;
+      --faint: #6e7382;
+      --line: #dfe4e8;
+      --line-strong: #c7cfd6;
+      --brand: #526f88;
+      --brand-hover: #3d5874;
+      --brand-contrast: #ffffff;
+      --brand-soft: #e9eef3;
+      --brand-ink: #405f7e;
+      --success: #3e775c;
+      --success-soft: #e7f1ea;
+      --attention: #8a6226;
+      --attention-soft: #f8edda;
+      --danger: #a24c46;
+      --focus: #526f88;
+      --focus-soft: rgb(82 111 136 / 16%);
+      --overlay: rgb(28 32 43 / 42%);
+      --shadow-dialog: 0 18px 56px rgb(38 45 58 / 14%);
+      --rail: #f3f4f4;
+      --rail-ink: #626b72;
+      --identity-1: #a65f4a;
+      --identity-2: #39777a;
+      --identity-3: #74628f;
+      --identity-4: #4f729b;
+      --review-canvas: #f5f6f7;
+      --review-panel: #ffffff;
+      --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      color: var(--ink);
+      background: var(--review-canvas);
+      font: 13px/1.6 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif;
+      font-synthesis: none;
+      text-rendering: optimizeLegibility;
+    }
+
+    :root[data-theme="night"] {
+      color-scheme: dark;
+      --canvas: #0d1114;
+      --surface: #151a1e;
+      --surface-raised: #1b2227;
+      --surface-subtle: #1a2024;
+      --surface-muted: #242d33;
+      --surface-hover: #1d252b;
+      --ink: #e7ecef;
+      --muted: #abb5bc;
+      --faint: #919da6;
+      --line: #333e46;
+      --line-strong: #53616b;
+      --brand: #7897ae;
+      --brand-hover: #b1c8d8;
+      --brand-contrast: #091116;
+      --brand-soft: #22303a;
+      --brand-ink: #c0d4e1;
+      --success: #82b695;
+      --success-soft: #1a2b22;
+      --attention: #d2ac70;
+      --attention-soft: #302719;
+      --danger: #d6857f;
+      --focus: #8fb3cb;
+      --focus-soft: rgb(143 179 203 / 18%);
+      --overlay: rgb(0 0 0 / 58%);
+      --shadow-dialog: 0 22px 64px rgb(0 0 0 / 42%);
+      --rail: #11161a;
+      --rail-ink: #a6b1b8;
+      --identity-1: #c98572;
+      --identity-2: #70b0ae;
+      --identity-3: #a89ac8;
+      --identity-4: #80abd1;
+      --review-canvas: #0d1114;
+      --review-panel: #151a1e;
+    }
+
+    .palette-scope {
+      --dialog-surface: #ffffff;
+      --dialog-control: #fbfbfa;
+      --dialog-soft: #e7eaed;
+      --dialog-band: #f0f2f4;
+      --dialog-line: #dfe4e8;
+      --dialog-line-strong: #c7cfd6;
+      --dialog-marker: #d3a45f;
+      --picker-surface: #fbfbfa;
+      --picker-soft: #e7eaed;
+      --picker-menu: #ffffff;
+      --picker-line-strong: #c7cfd6;
+      --picker-hover: #e7eaed;
+    }
+    .palette-scope[data-palette="reference"] {
+      --dialog-caption: "当前";
+    }
+    .palette-scope[data-palette="a"] {
+      --picker-surface: #f1f5f8;
+      --picker-soft: #e1eaf0;
+      --picker-menu: #f8fafc;
+      --picker-line-strong: #aebfca;
+      --picker-hover: #e4edf3;
+      --dialog-caption: "A";
+    }
+    .palette-scope[data-palette="b"] {
+      --picker-surface: #f3f5f6;
+      --picker-soft: #e6eaec;
+      --picker-menu: #fafbfb;
+      --picker-line-strong: #b6c0c6;
+      --picker-hover: #e8ecee;
+      --dialog-caption: "B";
+    }
+    .palette-scope[data-palette="c"] {
+      --picker-surface: #ffffff;
+      --picker-soft: #e9eef3;
+      --picker-menu: #ffffff;
+      --picker-line-strong: #8296a4;
+      --picker-hover: #edf2f5;
+      --dialog-caption: "C";
+    }
+
+    :root[data-theme="night"] .palette-scope {
+      --dialog-surface: #1b2227;
+      --dialog-control: #151a1e;
+      --dialog-soft: #242d33;
+      --dialog-band: #1a2024;
+      --dialog-line: #333e46;
+      --dialog-line-strong: #53616b;
+      --dialog-marker: #d2aa72;
+      --picker-surface: #151a1e;
+      --picker-soft: #242d33;
+      --picker-menu: #1b2227;
+      --picker-line-strong: #53616b;
+      --picker-hover: #242d33;
+    }
+    :root[data-theme="night"] .palette-scope[data-palette="a"] {
+      --picker-surface: #1c2931;
+      --picker-soft: #22343e;
+      --picker-menu: #1b242a;
+      --picker-line-strong: #5b7180;
+      --picker-hover: #243641;
+    }
+    :root[data-theme="night"] .palette-scope[data-palette="b"] {
+      --picker-surface: #20262a;
+      --picker-soft: #283137;
+      --picker-menu: #1b2227;
+      --picker-line-strong: #5d686f;
+      --picker-hover: #2a3237;
+    }
+    :root[data-theme="night"] .palette-scope[data-palette="c"] {
+      --picker-surface: #1b2227;
+      --picker-soft: #22303a;
+      --picker-menu: #1b2227;
+      --picker-line-strong: #6a8190;
+      --picker-hover: #24323b;
+    }
+
+    * { box-sizing: border-box; }
+    body { min-width: 0; margin: 0; }
+    button, input { color: inherit; font: inherit; }
+    button { -webkit-tap-highlight-color: transparent; }
+    button:focus-visible, input:focus-visible { outline: 2px solid var(--focus); outline-offset: 2px; }
+    button:active:not(:disabled) { transform: translateY(1px); }
+    button:disabled { opacity: .52; cursor: default; }
+    [hidden] { display: none !important; }
+    ::selection { color: var(--ink); background: var(--brand-soft); }
+    code, .token-values { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+    .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
+    .icon { display: block; width: 16px; height: 16px; fill: none; stroke: currentColor; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1.55; }
+
+    .review-shell { width: min(1420px, 100%); margin: 0 auto; padding: 24px 30px 30px; }
+    .review-header { display: flex; align-items: center; justify-content: space-between; gap: 20px; margin-bottom: 24px; }
+    .review-brand { display: flex; align-items: center; gap: 10px; font-weight: 700; }
+    .review-brand-mark { width: 27px; height: 27px; color: var(--brand); }
+    .review-brand-divider { width: 1px; height: 15px; margin: 0 2px 0 6px; background: var(--line-strong); }
+    .review-brand small { color: var(--muted); font-size: 12px; font-weight: 450; }
+    .segmented { display: inline-flex; align-items: center; gap: 2px; padding: 3px; border: 1px solid var(--line-strong); border-radius: 8px; background: var(--review-panel); }
+    .segmented button { display: inline-flex; min-height: 30px; align-items: center; justify-content: center; gap: 6px; padding: 0 11px; border: 0; border-radius: 5px; color: var(--muted); background: transparent; cursor: pointer; font-size: 11.5px; }
+    .segmented button:hover { color: var(--ink); background: var(--surface-hover); }
+    .segmented button[aria-pressed="true"] { color: var(--brand-ink); background: var(--brand-soft); font-weight: 680; }
+    .segmented .icon { width: 14px; height: 14px; }
+    .intro { display: flex; align-items: flex-end; justify-content: space-between; gap: 24px; margin-bottom: 18px; }
+    .intro h1 { margin: 0 0 6px; font-size: 25px; font-weight: 690; letter-spacing: -.025em; line-height: 1.28; }
+    .intro p { margin: 0; color: var(--muted); font-size: 13px; }
+    .scope { color: var(--muted); font-size: 11px; white-space: nowrap; }
+
+    .candidate-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; margin-bottom: 18px; }
+    .candidate { display: grid; min-width: 0; min-height: 108px; grid-template-columns: 54px minmax(0, 1fr); gap: 13px; align-items: center; padding: 13px 14px; border: 1px solid var(--line-strong); border-radius: 10px; color: var(--ink); background: var(--review-panel); text-align: left; cursor: pointer; }
+    .candidate:hover { border-color: var(--brand); }
+    .candidate[aria-pressed="true"] { border-color: var(--brand); box-shadow: 0 0 0 1px var(--brand); }
+    .candidate-swatches { display: grid; width: 52px; height: 66px; align-content: center; gap: 6px; padding: 8px 7px; overflow: hidden; border: 1px solid var(--dialog-line-strong); border-radius: 7px; background: var(--dialog-surface); }
+    .candidate-swatches::before,
+    .candidate-swatches::after { height: 18px; content: ""; border: 1px solid var(--picker-line-strong); border-radius: 4px; background: var(--picker-surface); box-shadow: inset 7px 0 0 var(--picker-soft); }
+    .candidate-copy { display: grid; min-width: 0; gap: 3px; }
+    .candidate-title { display: flex; align-items: baseline; flex-wrap: wrap; gap: 7px; font-size: 13.5px; font-weight: 680; }
+    .candidate-letter { color: var(--muted); font: 650 10px/1 var(--mono); }
+    .recommended { color: var(--brand-ink); font-size: 9.5px; font-weight: 650; }
+    .candidate-desc { color: var(--muted); font-size: 10.5px; line-height: 1.45; }
+    .token-values { color: var(--faint); font-size: 9px; letter-spacing: -.02em; }
+
+    .preview-toolbar { display: flex; min-height: 38px; align-items: center; justify-content: space-between; gap: 12px 20px; margin: 0 0 10px; }
+    .active-choice { display: flex; min-width: 0; align-items: center; gap: 9px; }
+    .active-choice-dot { width: 13px; height: 13px; flex: 0 0 auto; border: 1px solid var(--picker-line-strong); border-radius: 4px; background: var(--picker-surface); }
+    .active-choice strong { font-size: 12.5px; }
+    .active-choice span:last-child { overflow: hidden; color: var(--muted); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
+
+    .scene-scroll { overflow-x: auto; border: 1px solid var(--line-strong); border-radius: 11px; background: var(--canvas); }
+    .scene { position: relative; display: grid; min-width: 1040px; height: 730px; grid-template-columns: 270px minmax(0, 1fr); grid-template-rows: 50px minmax(0, 1fr); overflow: hidden; background: var(--canvas); }
+    .mock-rail { grid-row: 1 / -1; display: flex; min-height: 0; flex-direction: column; padding: 18px 13px 14px; border-right: 1px solid var(--line); background: var(--rail); }
+    .mock-rail-brand { display: flex; align-items: center; gap: 9px; padding: 0 8px 18px; color: var(--ink); font-size: 12.5px; font-weight: 680; }
+    .mock-rail-brand svg { width: 22px; height: 22px; color: var(--brand); }
+    .mock-create { display: flex; min-height: 34px; align-items: center; gap: 9px; padding: 0 9px; border-radius: 7px; color: var(--brand-ink); background: var(--brand-soft); font-size: 11.5px; font-weight: 650; }
+    .mock-create span { display: grid; width: 20px; height: 20px; place-items: center; border: 1px solid color-mix(in srgb, var(--brand) 35%, var(--line)); border-radius: 5px; }
+    .mock-rail-heading { margin: 17px 8px 6px; color: var(--faint); font-size: 9.5px; font-weight: 700; letter-spacing: .08em; }
+    .mock-nav-row { height: 31px; margin: 1px 0; padding: 6px 9px; border-radius: 7px; color: var(--rail-ink); font-size: 11px; }
+    .mock-nav-row.active { position: relative; color: var(--brand-ink); background: var(--surface-hover); }
+    .mock-nav-row.active::before { position: absolute; top: 7px; bottom: 7px; left: 0; width: 2px; border-radius: 2px; content: ""; background: var(--brand); }
+    .mock-rail-foot { margin-top: auto; padding: 10px 9px 0; border-top: 1px solid var(--line); color: var(--muted); font-size: 10.5px; }
+    .mock-topbar { grid-column: 2; display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 0 18px; border-bottom: 1px solid var(--line); background: var(--surface); }
+    .mock-breadcrumb { display: flex; align-items: center; gap: 8px; color: var(--faint); font-size: 11.5px; }
+    .mock-breadcrumb strong { color: var(--ink); font-weight: 520; }
+    .mock-top-actions { display: flex; gap: 16px; color: var(--muted); font-size: 10.5px; }
+    .mock-workspace { grid-column: 2; min-height: 0; overflow: hidden; padding: 38px 48px; background: var(--surface-raised); }
+    .mock-date { display: flex; align-items: center; gap: 12px; color: var(--faint); font-size: 9px; }
+    .mock-date::before, .mock-date::after { height: 1px; flex: 1; content: ""; background: var(--line); }
+    .mock-message { display: flex; max-width: 610px; gap: 10px; margin-top: 25px; }
+    .mock-avatar { display: grid; width: 30px; height: 30px; flex: 0 0 30px; place-items: center; border: 1px solid var(--line-strong); border-radius: 50%; color: var(--muted); background: var(--surface-subtle); font-size: 10px; font-weight: 700; }
+    .mock-message-copy { display: grid; gap: 5px; padding-top: 1px; }
+    .mock-message-copy strong { font-size: 10.5px; }
+    .mock-message-copy p { margin: 0; color: var(--muted); font-size: 12px; }
+    .mock-composer { position: absolute; right: 44px; bottom: 28px; left: 314px; height: 86px; padding: 13px; border: 1px solid var(--line-strong); border-radius: 8px; color: var(--faint); background: var(--surface-raised); font-size: 11.5px; }
+    .scene-scrim { position: absolute; z-index: 20; inset: 0; background: var(--overlay); backdrop-filter: blur(2px); }
+
+    .new-camp-dialog { position: absolute; z-index: 21; top: 50%; left: 50%; width: min(760px, calc(100% - 48px)); max-height: calc(100% - 32px); overflow: hidden; transform: translate(-50%, -50%); border: 1px solid var(--dialog-line-strong); border-top: 3px solid var(--brand); border-radius: 12px; color: var(--ink); background: var(--dialog-surface); box-shadow: var(--shadow-dialog); animation: dialog-in 170ms cubic-bezier(.16, 1, .3, 1) both; }
+    .new-camp-dialog, .mini-dialog { --faint: #606b74; }
+    :root[data-theme="night"] .new-camp-dialog,
+    :root[data-theme="night"] .mini-dialog { --faint: #919da6; }
+    .new-camp-dialog-layout { display: grid; max-height: calc(730px - 32px); grid-template-rows: auto minmax(0, 1fr) auto; }
+    .new-camp-dialog-header { display: grid; grid-template-columns: 38px minmax(0, 1fr) 32px; align-items: flex-start; gap: 12px; padding: 16px 24px 14px; border-bottom: 1px solid var(--dialog-line); }
+    .new-camp-dialog-header-icon { display: grid; width: 38px; height: 38px; place-items: center; border: 1px solid color-mix(in srgb, var(--brand) 32%, var(--dialog-line)); border-radius: 9px; color: var(--brand); background: color-mix(in srgb, var(--brand) 9%, var(--dialog-surface)); }
+    .new-camp-dialog-header-icon svg { width: 20px; height: 20px; }
+    .new-camp-dialog-header-copy { min-width: 0; }
+    .new-camp-eyebrow { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; color: var(--brand-ink); font: 700 10.5px/1 var(--mono); letter-spacing: .55px; }
+    .new-camp-eyebrow i { width: 7px; height: 7px; border-radius: 50%; background: var(--dialog-marker); }
+    .new-camp-dialog-header h2 { margin: 0; font-size: 20px; line-height: 1.3; letter-spacing: -.15px; }
+    .new-camp-dialog-header p { max-width: 560px; margin: 4px 0 0; color: var(--muted); font-size: 12.5px; line-height: 1.5; }
+    .dialog-close { display: grid; width: 32px; height: 32px; place-items: center; padding: 0; border: 0; border-radius: 7px; color: var(--muted); background: var(--dialog-soft); cursor: pointer; font-size: 18px; }
+    .dialog-close:hover { color: var(--ink); background: color-mix(in srgb, var(--dialog-soft) 78%, var(--ink) 7%); }
+    .new-camp-dialog-body { min-height: 0; overflow-y: auto; padding: 0 24px; scrollbar-color: var(--dialog-line-strong) transparent; }
+    .new-camp-section { padding: 14px 0 16px; border-bottom: 1px solid var(--dialog-line); }
+    .new-camp-section:last-child { border-bottom: 0; }
+    .new-camp-section-heading { display: grid; grid-template-columns: 22px minmax(0, 1fr); gap: 9px; align-items: start; margin-bottom: 8px; }
+    .new-camp-section-heading > span { display: grid; width: 22px; height: 22px; place-items: center; border-radius: 6px; color: var(--brand-ink); background: var(--brand-soft); font: 700 10.5px/1 var(--mono); }
+    .new-camp-section-heading > div { display: grid; min-width: 0; gap: 2px; }
+    .new-camp-section-heading strong { font-size: 13px; line-height: 1.35; }
+    .new-camp-section-heading em { color: var(--faint); font-style: normal; font-weight: 500; }
+    .new-camp-section-heading small { color: var(--faint); font-size: 11.5px; line-height: 1.45; }
+    .new-camp-picker { position: relative; }
+    .new-camp-picker-trigger { display: flex; width: 100%; min-width: 0; min-height: 48px; align-items: center; gap: 11px; padding: 8px 11px; border: 1px solid var(--picker-line-strong); border-radius: 7px; color: var(--ink); background: var(--picker-surface); text-align: left; cursor: pointer; }
+    .new-camp-picker-trigger:hover { border-color: color-mix(in srgb, var(--picker-line-strong) 55%, var(--brand) 45%); background: var(--picker-hover); }
+    .new-camp-picker-trigger[aria-expanded="true"] { border-color: var(--focus); box-shadow: 0 0 0 2px var(--focus-soft); }
+    .new-camp-picker-trigger > span:nth-child(2) { display: grid; min-width: 0; flex: 1; gap: 2px; }
+    .new-camp-picker-trigger strong { overflow: hidden; font-size: 12.5px; text-overflow: ellipsis; white-space: nowrap; }
+    .new-camp-picker-trigger small { overflow: hidden; color: var(--faint); font-size: 10.5px; text-overflow: ellipsis; white-space: nowrap; }
+    .new-camp-picker-icon { display: grid; width: 30px; height: 30px; flex: 0 0 auto; place-items: center; border-radius: 7px; color: var(--muted); background: var(--picker-soft); }
+    .new-camp-picker-icon .icon { width: 17px; height: 17px; }
+    .new-camp-git-metadata { display: inline-flex; min-height: 24px; align-items: center; padding: 3px 7px; border-radius: 6px; color: var(--success); background: var(--success-soft); font: 650 10.5px/1.2 var(--mono); white-space: nowrap; }
+    .new-camp-chevron { display: block; width: 16px; height: 16px; flex: 0 0 16px; fill: none; stroke: var(--faint); stroke-linecap: round; stroke-linejoin: round; stroke-width: 1.5; transition: transform 120ms ease; }
+    [aria-expanded="true"] > .new-camp-chevron, [aria-expanded="true"] .new-camp-chevron { transform: rotate(180deg); }
+    .new-camp-picker-menu { position: absolute; z-index: 8; top: calc(100% + 6px); right: 0; left: 0; max-height: 220px; overflow-y: auto; padding: 6px; border: 1px solid var(--picker-line-strong); border-radius: 9px; background: var(--picker-menu); box-shadow: var(--shadow-dialog); }
+    .new-camp-project-option { display: grid; width: 100%; min-height: 44px; grid-template-columns: 28px minmax(0, 1fr) auto; gap: 9px; align-items: center; padding: 7px 8px; border: 0; border-radius: 6px; color: var(--ink); background: transparent; text-align: left; cursor: pointer; }
+    .new-camp-project-option:hover { background: var(--picker-hover); }
+    .new-camp-project-option.selected { color: var(--brand-ink); background: var(--brand-soft); }
+    .new-camp-project-option > span:first-child { display: grid; width: 28px; height: 28px; place-items: center; border-radius: 6px; color: var(--muted); background: var(--picker-soft); }
+    .new-camp-project-option > span:nth-child(2) { display: grid; min-width: 0; gap: 2px; }
+    .new-camp-project-option strong { overflow: hidden; font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
+    .new-camp-project-option small { overflow: hidden; color: var(--faint); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
+    .new-camp-project-option b { color: var(--brand); }
+    .new-camp-project-option.choose-local { border-top: 1px solid var(--dialog-line); border-radius: 0 0 6px 6px; }
+    .member-trigger { min-height: 52px; }
+    .new-camp-member-stack { display: flex; min-width: 68px; align-items: center; padding-left: 2px; }
+    .member-avatar { position: relative; display: inline-grid; width: 32px; height: 32px; flex: 0 0 auto; overflow: hidden; place-items: center; border: 1px solid color-mix(in srgb, var(--member-color) 48%, var(--dialog-line)); border-radius: 50%; color: var(--member-color); background: color-mix(in srgb, var(--member-color) 13%, var(--picker-surface)); font-size: 11px; font-weight: 760; }
+    .member-avatar + .member-avatar { margin-left: -8px; box-shadow: 0 0 0 2px var(--picker-surface); }
+    .member-one { --member-color: var(--identity-1); }
+    .member-two { --member-color: var(--identity-2); }
+    .member-three { --member-color: var(--identity-3); }
+    .member-four { --member-color: var(--identity-4); }
+    .new-camp-runtime-status { display: flex; align-items: center; gap: 5px; color: var(--success); font-size: 10px; white-space: nowrap; }
+    .new-camp-runtime-status i { width: 7px; height: 7px; border-radius: 50%; background: currentColor; }
+    .new-camp-lead-field { position: relative; display: grid; gap: 6px; margin-top: 12px; color: var(--muted); font-size: 11.5px; font-weight: 650; }
+    .new-camp-lead-trigger { display: grid; width: 100%; min-height: 48px; grid-template-columns: 32px minmax(0, 1fr) auto 16px; align-items: center; gap: 10px; padding: 7px 10px; border: 1px solid var(--picker-line-strong); border-radius: 7px; color: var(--ink); background: var(--picker-surface); text-align: left; cursor: pointer; }
+    .new-camp-lead-trigger:hover { border-color: color-mix(in srgb, var(--picker-line-strong) 55%, var(--brand) 45%); background: var(--picker-hover); }
+    .new-camp-lead-copy { display: grid; min-width: 0; gap: 2px; }
+    .new-camp-lead-copy strong { font-size: 12px; }
+    .new-camp-lead-copy small { color: var(--faint); font-size: 10px; font-weight: 500; }
+    .new-camp-member-menu { padding: 0 5px 5px; }
+    .new-camp-member-toolbar { display: flex; min-height: 34px; align-items: center; justify-content: space-between; padding: 5px 7px; border-bottom: 1px solid var(--dialog-line); color: var(--muted); font-size: 10.5px; }
+    .new-camp-member-option { display: grid; min-height: 48px; grid-template-columns: 18px 32px minmax(0, 1fr) auto; gap: 9px; align-items: center; padding: 6px 8px; border-radius: 6px; color: var(--ink); cursor: pointer; }
+    .new-camp-member-option:hover { background: var(--picker-hover); }
+    .new-camp-lead-option-prototype { width: 100%; border: 0; background: transparent; text-align: left; }
+    .new-camp-lead-option-prototype[aria-checked="true"] { color: var(--brand-ink); background: var(--brand-soft); }
+    .new-camp-member-option input { width: 16px; height: 16px; margin: 0; accent-color: var(--brand); }
+    .new-camp-member-option .member-avatar { margin-left: 0; box-shadow: none; }
+    .new-camp-member-copy { display: grid; min-width: 0; gap: 2px; }
+    .new-camp-member-copy strong { font-size: 11.5px; }
+    .new-camp-member-copy small { color: var(--faint); font-size: 10px; }
+    .new-camp-section.optional-section { padding: 9px 0 13px; }
+    .new-camp-optional-shell { overflow: hidden; border: 1px solid var(--dialog-line); border-radius: 8px; background: var(--dialog-control); }
+    .new-camp-optional-trigger { display: grid; width: 100%; min-height: 52px; grid-template-columns: 26px minmax(0, 1fr) minmax(0, 180px) auto; gap: 10px; align-items: center; padding: 8px 11px; border: 0; color: var(--ink); background: transparent; text-align: left; cursor: pointer; }
+    .new-camp-optional-trigger:hover, .new-camp-optional-trigger[aria-expanded="true"] { background: var(--dialog-band); }
+    .new-camp-optional-icon { display: grid; width: 26px; height: 26px; place-items: center; border-radius: 7px; color: var(--muted); background: var(--dialog-soft); }
+    .new-camp-optional-icon .icon { width: 15px; height: 15px; }
+    .new-camp-optional-trigger > span:nth-child(2) { display: grid; min-width: 0; gap: 2px; }
+    .new-camp-optional-trigger strong { font-size: 12px; }
+    .new-camp-optional-trigger small { color: var(--faint); font-size: 10.5px; }
+    .new-camp-optional-trigger em { overflow: hidden; color: var(--faint); font-size: 10.5px; font-style: normal; text-align: right; text-overflow: ellipsis; white-space: nowrap; }
+    .new-camp-optional-panel { position: relative; display: grid; gap: 7px; margin: 0 10px 10px 42px; padding: 12px 0 2px 18px; border-top: 1px solid var(--dialog-line); }
+    .new-camp-optional-panel::before { position: absolute; top: 12px; bottom: 2px; left: 0; width: 1px; content: ""; background: var(--dialog-line-strong); }
+    .new-camp-name-heading { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+    .new-camp-name-heading label { color: var(--muted); font-size: 11px; font-weight: 650; }
+    .new-camp-name-heading label span { color: var(--faint); font-weight: 500; }
+    .new-camp-name-heading > span { color: var(--faint); font: 500 9px/1.2 var(--mono); }
+    .new-camp-name-input-shell { display: grid; height: 34px; grid-template-columns: minmax(0, 1fr); align-items: center; overflow: hidden; border: 1px solid var(--dialog-line-strong); border-radius: 6px; background: var(--dialog-surface); }
+    .new-camp-name-input-shell:focus-within { border-color: var(--focus); box-shadow: 0 0 0 3px var(--focus-soft); }
+    .new-camp-name-input-shell input { width: 100%; height: 32px; min-width: 0; padding: 0 9px; border: 0; outline: 0; color: var(--ink); background: transparent; font-size: 12.5px; }
+    .new-camp-name-input-shell input::placeholder { color: var(--faint); opacity: 1; }
+    .new-camp-optional-panel > small { color: var(--faint); font-size: 10.5px; }
+    .new-camp-dialog-footer { display: flex; min-height: 58px; align-items: center; justify-content: space-between; gap: 18px; padding: 10px 24px; border-top: 1px solid var(--dialog-line); background: var(--dialog-band); }
+    .new-camp-dialog-footer > div:first-child { min-width: 0; color: var(--muted); font-size: 11px; line-height: 1.45; }
+    .new-camp-dialog-footer > div:first-child strong { color: var(--ink); font-weight: 600; }
+    .new-camp-dialog-footer > div:last-child { display: flex; flex: 0 0 auto; gap: 8px; }
+    .primary-button, .quiet-button { min-height: 32px; padding: 7px 12px; border-radius: 7px; font-size: 12px; font-weight: 680; cursor: pointer; transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease; }
+    .primary-button { border: 1px solid var(--brand); color: var(--brand-contrast); background: var(--brand); }
+    .primary-button:hover { border-color: var(--brand-hover); background: var(--brand-hover); }
+    .quiet-button { border: 1px solid var(--dialog-line-strong); color: var(--ink); background: var(--dialog-control); }
+    .quiet-button:hover { background: var(--dialog-soft); }
+
+    .comparison-section { display: grid; gap: 14px; }
+    .comparison-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; }
+    .comparison-item { min-width: 0; }
+    .comparison-heading { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; margin: 0 0 8px; }
+    .comparison-heading strong { font-size: 12px; }
+    .comparison-heading span { color: var(--muted); font-size: 9.5px; }
+    .mini-stage { min-height: 398px; overflow: hidden; padding: 24px 10px; border: 1px solid var(--line-strong); border-radius: 10px; background: var(--canvas); }
+    .mini-dialog { overflow: hidden; border: 1px solid var(--dialog-line-strong); border-top: 3px solid var(--brand); border-radius: 9px; color: var(--ink); background: var(--dialog-surface); box-shadow: var(--shadow-dialog); }
+    .mini-header { display: grid; grid-template-columns: 28px minmax(0, 1fr) 20px; gap: 8px; padding: 11px 12px 10px; border-bottom: 1px solid var(--dialog-line); }
+    .mini-icon { display: grid; width: 28px; height: 28px; place-items: center; border-radius: 7px; color: var(--brand); background: color-mix(in srgb, var(--brand) 9%, var(--dialog-surface)); font-size: 15px; }
+    .mini-title { display: grid; gap: 2px; }
+    .mini-title i { display: flex; align-items: center; gap: 5px; color: var(--brand-ink); font: 700 7px/1 var(--mono); font-style: normal; }
+    .mini-title i::before { width: 5px; height: 5px; border-radius: 50%; content: ""; background: var(--dialog-marker); }
+    .mini-title strong { font-size: 11px; }
+    .mini-title small { overflow: hidden; color: var(--muted); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
+    .mini-close { display: grid; width: 20px; height: 20px; place-items: center; border-radius: 5px; color: var(--muted); background: var(--dialog-soft); font-size: 11px; }
+    .mini-body { display: grid; gap: 10px; padding: 11px 12px 13px; }
+    .mini-section { display: grid; gap: 6px; }
+    .mini-section-title { display: flex; align-items: center; gap: 6px; font-size: 8.5px; font-weight: 680; }
+    .mini-section-title span { display: grid; width: 16px; height: 16px; place-items: center; border-radius: 4px; color: var(--brand-ink); background: var(--brand-soft); font: 700 7px/1 var(--mono); }
+    .mini-control { display: flex; min-height: 38px; align-items: center; gap: 7px; padding: 6px 7px; border: 1px solid var(--picker-line-strong); border-radius: 6px; background: var(--picker-surface); }
+    .mini-control-icon { width: 23px; height: 23px; border-radius: 5px; background: var(--picker-soft); }
+    .mini-control-lines { display: grid; flex: 1; gap: 4px; }
+    .mini-control-lines::before, .mini-control-lines::after { height: 4px; border-radius: 3px; content: ""; background: color-mix(in srgb, var(--ink) 58%, transparent); }
+    .mini-control-lines::after { width: 68%; background: color-mix(in srgb, var(--muted) 42%, transparent); }
+    .mini-optional { height: 34px; border: 1px solid var(--dialog-line); border-radius: 6px; background: var(--dialog-control); }
+    .mini-footer { display: flex; min-height: 43px; align-items: center; justify-content: flex-end; gap: 6px; padding: 7px 10px; border-top: 1px solid var(--dialog-line); background: var(--dialog-band); }
+    .mini-button { width: 42px; height: 22px; border: 1px solid var(--dialog-line-strong); border-radius: 5px; background: var(--dialog-control); }
+    .mini-button.primary { border-color: var(--brand); background: var(--brand); }
+
+    .review-note { display: flex; align-items: flex-start; justify-content: space-between; gap: 24px; margin-top: 14px; padding: 13px 15px; border: 1px solid var(--line); border-radius: 9px; color: var(--muted); background: var(--review-panel); }
+    .review-note p { max-width: 800px; margin: 0; font-size: 11.5px; }
+    .review-note strong { color: var(--ink); }
+    .review-note small { max-width: 360px; font-size: 10px; text-align: right; }
+    .prototype-toast { position: fixed; z-index: 100; right: 20px; bottom: 20px; max-width: min(360px, calc(100vw - 40px)); padding: 10px 13px; border: 1px solid var(--line-strong); border-radius: 8px; color: var(--ink); background: var(--surface-raised); box-shadow: var(--shadow-dialog); font-size: 11.5px; }
+    :root[data-view="compare"] .scene-section { display: none; }
+    :root[data-view="scene"] .comparison-section { display: none; }
+
+    @keyframes dialog-in { from { opacity: 0; transform: translate(-50%, calc(-50% + 8px)) scale(.985); } }
+    @media (max-width: 1100px) {
+      .candidate-grid, .comparison-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .review-shell { padding: 20px; }
+    }
+    @media (max-width: 640px) {
+      .review-shell { padding: 16px 12px 20px; }
+      .review-header { align-items: flex-start; margin-bottom: 20px; }
+      .review-brand-divider, .review-brand small { display: none; }
+      .intro { align-items: flex-start; flex-direction: column; gap: 6px; }
+      .intro h1 { font-size: 22px; }
+      .scope { white-space: normal; }
+      .candidate-grid, .comparison-grid { grid-template-columns: minmax(0, 1fr); }
+      .candidate { min-height: 90px; }
+      .preview-toolbar { align-items: flex-start; flex-direction: column; }
+      .active-choice span:last-child { white-space: normal; }
+      .review-note { flex-direction: column; gap: 8px; }
+      .review-note small { max-width: none; text-align: left; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { scroll-behavior: auto !important; animation: none !important; transition: none !important; }
+    }
+  </style>
+</head>
+<body>
+  <svg aria-hidden="true" style="position:absolute;width:0;height:0;overflow:hidden" xmlns="http://www.w3.org/2000/svg">
+    <symbol id="i-brand" viewBox="0 0 30 30"><path d="m15 3 2.1 5.9L23 11l-5.9 2.1L15 19l-2.1-5.9L7 11l5.9-2.1Z" fill="currentColor" stroke="none"/><path d="M3 25q12-7 24 0" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/></symbol>
+    <symbol id="i-sun" viewBox="0 0 24 24"><circle cx="12" cy="12" r="4"/><path d="M12 2v2m0 16v2M2 12h2m16 0h2M5 5l1.5 1.5m11 11L19 19M5 19l1.5-1.5m11-11L19 5"/></symbol>
+    <symbol id="i-moon" viewBox="0 0 24 24"><path d="M20 15.3A9 9 0 0 1 8.7 4a9 9 0 1 0 11.3 11.3Z"/></symbol>
+    <symbol id="i-folder" viewBox="0 0 20 20"><path d="M2.5 5.2a1.7 1.7 0 0 1 1.7-1.7h4l1.7 2h5.9a1.7 1.7 0 0 1 1.7 1.7v7.1a1.7 1.7 0 0 1-1.7 1.7H4.2a1.7 1.7 0 0 1-1.7-1.7Z"/></symbol>
+    <symbol id="i-sliders" viewBox="0 0 18 18"><path d="M4 4.5h2M8 4.5h6M4 9h2M8 9h6M4 13.5h2M8 13.5h6"/></symbol>
+    <symbol id="i-chevron" viewBox="0 0 16 16"><path d="m4 6 4 4 4-4"/></symbol>
+  </svg>
+
+  <main class="review-shell">
+    <header class="review-header">
+      <div class="review-brand">
+        <svg class="review-brand-mark icon" viewBox="0 0 30 30" aria-hidden="true"><use href="#i-brand"/></svg>
+        <span>Rovai AI</span><span class="review-brand-divider"></span><small>创建新对话 · 下拉框配色</small>
+      </div>
+      <div class="segmented" role="group" aria-label="设计稿主题">
+        <button type="button" data-theme-choice="day" aria-pressed="true"><svg class="icon" aria-hidden="true"><use href="#i-sun"/></svg>日间</button>
+        <button type="button" data-theme-choice="night" aria-pressed="false"><svg class="icon" aria-hidden="true"><use href="#i-moon"/></svg>夜间</button>
+      </div>
+    </header>
+
+    <section class="intro" aria-labelledby="page-title">
+      <div><h1 id="page-title">创建新对话 · 下拉框配色</h1><p>Dialog 主色、Header、Footer 与品牌强调保持当前样式，只调整三个下拉控件及其菜单。</p></div>
+      <span class="scope">主色固定 · 3 个下拉候选 · 日夜成对</span>
+    </section>
+
+    <div class="candidate-grid" role="group" aria-label="选择配色方案">
+      <button class="candidate palette-scope" type="button" data-palette="a" data-palette-choice="a" aria-pressed="false">
+        <span class="candidate-swatches" aria-hidden="true"></span>
+        <span class="candidate-copy"><span class="candidate-title"><span class="candidate-letter">A</span>淡钢蓝</span><span class="candidate-desc">只给三个下拉框一层很浅的 Steel 洗色，和当前主按钮自然呼应。</span><span class="token-values">#F1F5F8 · #E1EAF0 · #AEBFCA</span></span>
+      </button>
+      <button class="candidate palette-scope" type="button" data-palette="b" data-palette-choice="b" aria-pressed="false">
+        <span class="candidate-swatches" aria-hidden="true"></span>
+        <span class="candidate-copy"><span class="candidate-title"><span class="candidate-letter">B</span>冷雾灰</span><span class="candidate-desc">几乎不带色相，比当前米白更冷，控件层级安静且克制。</span><span class="token-values">#F3F5F6 · #E6EAEC · #B6C0C6</span></span>
+      </button>
+      <button class="candidate palette-scope" type="button" data-palette="c" data-palette-choice="c" aria-pressed="true">
+        <span class="candidate-swatches" aria-hidden="true"></span>
+        <span class="candidate-copy"><span class="candidate-title"><span class="candidate-letter">C</span>瓷白钢边 <span class="recommended">已选方案</span></span><span class="candidate-desc">控件保持纯白，用满足 3:1 对比度的 Steel 灰边界去掉米色感。</span><span class="token-values">#FFFFFF · #E9EEF3 · #8296A4</span></span>
+      </button>
+      <button class="candidate palette-scope" type="button" data-palette="reference" data-palette-choice="reference" aria-pressed="false">
+        <span class="candidate-swatches" aria-hidden="true"></span>
+        <span class="candidate-copy"><span class="candidate-title"><span class="candidate-letter">当前</span>米白对照</span><span class="candidate-desc">复现生产下拉框的 surface / muted / line-strong，仅用于前后比较。</span><span class="token-values">#FBFBFA · #E7EAED · #C7CFD6</span></span>
+      </button>
+    </div>
+
+    <div class="preview-toolbar palette-scope" id="active-scope" data-palette="c">
+      <div class="active-choice"><span class="active-choice-dot" aria-hidden="true"></span><strong id="active-title">C · 瓷白钢边</strong><span id="active-description">下拉框保持纯白，通过更清楚的 Steel 灰边界建立层次。</span></div>
+      <div class="segmented" role="group" aria-label="预览方式">
+        <button type="button" data-view-choice="scene" aria-pressed="true">完整场景</button>
+        <button type="button" data-view-choice="compare" aria-pressed="false">并排比较</button>
+      </div>
+    </div>
+
+    <section class="scene-section" aria-label="完整 Dialog 场景预览">
+      <div class="scene-scroll">
+        <div class="scene palette-scope" id="scene" data-palette="c">
+          <aside class="mock-rail" aria-hidden="true">
+            <div class="mock-rail-brand"><svg class="icon" viewBox="0 0 30 30"><use href="#i-brand"/></svg>Rovai AI</div>
+            <div class="mock-create"><span>＋</span>创建新对话</div>
+            <div class="mock-rail-heading">快速对话</div>
+            <div class="mock-nav-row active">创建新对话配色</div>
+            <div class="mock-nav-row">运行时排查</div>
+            <div class="mock-rail-heading">rovai-ai</div>
+            <div class="mock-nav-row">当前版本实现</div>
+            <div class="mock-nav-row">UI 设计评审</div>
+            <div class="mock-rail-foot">设置 · Porcelain Day</div>
+          </aside>
+          <header class="mock-topbar" aria-hidden="true"><div class="mock-breadcrumb"><span>快速对话</span><span>›</span><strong>创建新对话配色</strong></div><div class="mock-top-actions"><span>执行 0</span><span>任务 1</span><span>队员 4</span></div></header>
+          <div class="mock-workspace" aria-hidden="true"><div class="mock-date">今天</div><article class="mock-message"><span class="mock-avatar">你</span><div class="mock-message-copy"><strong>你</strong><p>弹窗主色保持当前，只改工作目录、队员和负责人这几个下拉框。</p></div></article><article class="mock-message"><span class="mock-avatar">R</span><div class="mock-message-copy"><strong>Rovai</strong><p>Header、Footer、品牌色与可选配置都保持不变，只比较下拉控件。</p></div></article></div>
+          <div class="mock-composer" aria-hidden="true">和队伍继续前行：补充线索、调整方向或布置新任务…</div>
+          <div class="scene-scrim" aria-hidden="true"></div>
+
+          <section class="new-camp-dialog" role="dialog" aria-modal="false" aria-labelledby="dialog-title" aria-describedby="dialog-description">
+            <form class="new-camp-dialog-layout" id="prototype-form">
+              <header class="new-camp-dialog-header">
+                <span class="new-camp-dialog-header-icon" aria-hidden="true"><svg class="icon" viewBox="0 0 20 20"><path d="M10 3v14M3 10h14"/></svg></span>
+                <div class="new-camp-dialog-header-copy"><span class="new-camp-eyebrow"><i></i>NEW CAMP</span><h2 id="dialog-title">创建新对话</h2><p id="dialog-description">确定这段对话的工作环境与队员。</p></div>
+                <button class="dialog-close" type="button" data-prototype-action="关闭">×<span class="sr-only">关闭创建新对话</span></button>
+              </header>
+
+              <div class="new-camp-dialog-body">
+                <section class="new-camp-section">
+                  <div class="new-camp-section-heading"><span>01</span><div><strong>工作目录<em> · 可选</em></strong><small>选择任意安全、可读目录；不选择则创建在快速对话。</small></div></div>
+                  <div class="new-camp-picker">
+                    <button class="new-camp-picker-trigger" id="workspace-trigger" type="button" aria-haspopup="listbox" aria-expanded="false" data-menu-toggle="workspace-menu">
+                      <span class="new-camp-picker-icon" aria-hidden="true"><svg class="icon"><use href="#i-folder"/></svg></span><span><strong id="workspace-label">rovai-ai</strong><small id="workspace-detail">~/VSCodeProjects/opensource/rovai-ai</small></span><span class="new-camp-git-metadata">main · clean</span><svg class="new-camp-chevron" viewBox="0 0 16 16" aria-hidden="true"><use href="#i-chevron"/></svg>
+                    </button>
+                    <div class="new-camp-picker-menu" id="workspace-menu" role="listbox" aria-label="选择工作目录" hidden>
+                      <button class="new-camp-project-option" type="button" role="option" aria-selected="false" data-workspace="快速对话" data-workspace-detail="Rovai AI 管理的快速对话目录"><span>⌁</span><span><strong>使用快速对话</strong><small>Rovai AI 管理的快速对话目录</small></span></button>
+                      <button class="new-camp-project-option selected" type="button" role="option" aria-selected="true" data-workspace="rovai-ai" data-workspace-detail="~/VSCodeProjects/opensource/rovai-ai"><span><svg class="icon"><use href="#i-folder"/></svg></span><span><strong>rovai-ai</strong><small>~/VSCodeProjects/opensource/rovai-ai</small></span><b>✓</b></button>
+                      <button class="new-camp-project-option choose-local" type="button" role="option" aria-selected="false" data-prototype-action="选择工作目录"><span>＋</span><span><strong>选择工作目录…</strong><small>普通目录与 Git worktree 均可</small></span></button>
+                    </div>
+                  </div>
+                </section>
+
+                <section class="new-camp-section">
+                  <div class="new-camp-section-heading"><span>02</span><div><strong>队员与负责人<em id="member-count-heading"> · 已选 3 / 3</em></strong><small>默认选择全部在队的队员；结构选择不会改变队员的长期配置。</small></div></div>
+                  <div class="new-camp-picker">
+                    <button class="new-camp-picker-trigger member-trigger" type="button" aria-haspopup="listbox" aria-expanded="false" data-menu-toggle="member-menu">
+                      <span class="new-camp-member-stack" aria-hidden="true"><span class="member-avatar member-one">洛</span><span class="member-avatar member-two">芝</span><span class="member-avatar member-three">叮</span></span><span><strong id="member-summary">已选择 3 位队员</strong><small id="member-names">洛可、芝士、叮叮</small></span><svg class="new-camp-chevron" viewBox="0 0 16 16" aria-hidden="true"><use href="#i-chevron"/></svg>
+                    </button>
+                    <div class="new-camp-picker-menu new-camp-member-menu" id="member-menu" role="listbox" aria-label="选择队员" aria-multiselectable="true" hidden>
+                      <div class="new-camp-member-toolbar"><span>本次会话队员</span><span>至少保留 1 位</span></div>
+                      <label class="new-camp-member-option"><input type="checkbox" checked data-member="洛可"><span class="member-avatar member-one">洛</span><span class="new-camp-member-copy"><strong>洛可</strong><small>产品工程 · Codex CLI</small></span><span class="new-camp-runtime-status"><i></i>可用</span></label>
+                      <label class="new-camp-member-option"><input type="checkbox" checked data-member="芝士"><span class="member-avatar member-two">芝</span><span class="new-camp-member-copy"><strong>芝士</strong><small>鉴定士 · Claude Code</small></span><span class="new-camp-runtime-status"><i></i>可用</span></label>
+                      <label class="new-camp-member-option"><input type="checkbox" checked data-member="叮叮"><span class="member-avatar member-three">叮</span><span class="new-camp-member-copy"><strong>叮叮</strong><small>游学者 · Codex CLI</small></span><span class="new-camp-runtime-status"><i></i>可用</span></label>
+                    </div>
+                  </div>
+                  <div class="new-camp-lead-field"><span>负责人</span><button class="new-camp-lead-trigger" type="button" aria-haspopup="menu" aria-expanded="false" data-menu-toggle="lead-menu"><span class="member-avatar member-one">洛</span><span class="new-camp-lead-copy"><strong>洛可</strong><small>产品工程</small></span><span class="new-camp-runtime-status"><i></i>可用</span><svg class="new-camp-chevron" viewBox="0 0 16 16" aria-hidden="true"><use href="#i-chevron"/></svg></button><div class="new-camp-picker-menu" id="lead-menu" role="menu" aria-label="选择负责人" hidden><button class="new-camp-member-option new-camp-lead-option-prototype" type="button" role="menuitemradio" aria-checked="true" data-prototype-action="负责人洛可"><span aria-hidden="true">✓</span><span class="member-avatar member-one">洛</span><span class="new-camp-member-copy"><strong>洛可</strong><small>产品工程</small></span><span class="new-camp-runtime-status"><i></i>可用</span></button><button class="new-camp-member-option new-camp-lead-option-prototype" type="button" role="menuitemradio" aria-checked="false" data-prototype-action="负责人芝士"><span aria-hidden="true"></span><span class="member-avatar member-two">芝</span><span class="new-camp-member-copy"><strong>芝士</strong><small>鉴定士</small></span><span class="new-camp-runtime-status"><i></i>可用</span></button></div></div>
+                </section>
+
+                <section class="new-camp-section optional-section">
+                  <div class="new-camp-optional-shell">
+                    <button class="new-camp-optional-trigger" id="optional-trigger" type="button" aria-expanded="false" aria-controls="optional-panel"><span class="new-camp-optional-icon" aria-hidden="true"><svg class="icon"><use href="#i-sliders"/></svg></span><span><strong>可选配置</strong><small>补充对话名称，不影响上面的结构配置。</small></span><em id="optional-value">未设置</em><svg class="new-camp-chevron" viewBox="0 0 16 16" aria-hidden="true"><use href="#i-chevron"/></svg></button>
+                    <div class="new-camp-optional-panel" id="optional-panel" hidden><div class="new-camp-name-heading"><label for="camp-name">对话名称 <span>· 非必填</span></label><span id="name-count">0 / 80</span></div><div class="new-camp-name-input-shell"><input id="camp-name" maxlength="80" placeholder="输入名称..." autocomplete="off"></div><small>留空将创建为「未命名对话」。</small></div>
+                  </div>
+                </section>
+              </div>
+
+              <footer class="new-camp-dialog-footer"><div><span id="footer-workspace">rovai-ai</span> · <strong id="footer-members">3 位队员</strong><span> · 负责人：洛可</span></div><div><button class="quiet-button" type="button" data-prototype-action="取消">取消</button><button class="primary-button" type="submit">创建</button></div></footer>
+            </form>
+          </section>
+        </div>
+      </div>
+    </section>
+
+    <section class="comparison-section" aria-label="四套配色并排比较">
+      <div class="comparison-grid">
+        <article class="comparison-item palette-scope" data-palette="reference"><header class="comparison-heading"><strong>当前 · 米白</strong><span>生产对照</span></header><div class="mini-stage"><div class="mini-dialog"><div class="mini-header"><span class="mini-icon">＋</span><span class="mini-title"><i>NEW CAMP</i><strong>创建新对话</strong><small>确定工作环境与队员</small></span><span class="mini-close">×</span></div><div class="mini-body"><div class="mini-section"><div class="mini-section-title"><span>01</span>工作目录</div><div class="mini-control"><i class="mini-control-icon"></i><i class="mini-control-lines"></i></div></div><div class="mini-section"><div class="mini-section-title"><span>02</span>队员与负责人</div><div class="mini-control"><i class="mini-control-icon"></i><i class="mini-control-lines"></i></div><div class="mini-control"><i class="mini-control-icon"></i><i class="mini-control-lines"></i></div></div><div class="mini-optional"></div></div><div class="mini-footer"><i class="mini-button"></i><i class="mini-button primary"></i></div></div></div></article>
+        <article class="comparison-item palette-scope" data-palette="a"><header class="comparison-heading"><strong>A · 淡钢蓝</strong><span>候选</span></header><div class="mini-stage"><div class="mini-dialog"><div class="mini-header"><span class="mini-icon">＋</span><span class="mini-title"><i>NEW CAMP</i><strong>创建新对话</strong><small>确定工作环境与队员</small></span><span class="mini-close">×</span></div><div class="mini-body"><div class="mini-section"><div class="mini-section-title"><span>01</span>工作目录</div><div class="mini-control"><i class="mini-control-icon"></i><i class="mini-control-lines"></i></div></div><div class="mini-section"><div class="mini-section-title"><span>02</span>队员与负责人</div><div class="mini-control"><i class="mini-control-icon"></i><i class="mini-control-lines"></i></div><div class="mini-control"><i class="mini-control-icon"></i><i class="mini-control-lines"></i></div></div><div class="mini-optional"></div></div><div class="mini-footer"><i class="mini-button"></i><i class="mini-button primary"></i></div></div></div></article>
+        <article class="comparison-item palette-scope" data-palette="b"><header class="comparison-heading"><strong>B · 冷雾灰</strong><span>最克制</span></header><div class="mini-stage"><div class="mini-dialog"><div class="mini-header"><span class="mini-icon">＋</span><span class="mini-title"><i>NEW CAMP</i><strong>创建新对话</strong><small>确定工作环境与队员</small></span><span class="mini-close">×</span></div><div class="mini-body"><div class="mini-section"><div class="mini-section-title"><span>01</span>工作目录</div><div class="mini-control"><i class="mini-control-icon"></i><i class="mini-control-lines"></i></div></div><div class="mini-section"><div class="mini-section-title"><span>02</span>队员与负责人</div><div class="mini-control"><i class="mini-control-icon"></i><i class="mini-control-lines"></i></div><div class="mini-control"><i class="mini-control-icon"></i><i class="mini-control-lines"></i></div></div><div class="mini-optional"></div></div><div class="mini-footer"><i class="mini-button"></i><i class="mini-button primary"></i></div></div></div></article>
+        <article class="comparison-item palette-scope" data-palette="c"><header class="comparison-heading"><strong>C · 瓷白钢边</strong><span>已选</span></header><div class="mini-stage"><div class="mini-dialog"><div class="mini-header"><span class="mini-icon">＋</span><span class="mini-title"><i>NEW CAMP</i><strong>创建新对话</strong><small>确定工作环境与队员</small></span><span class="mini-close">×</span></div><div class="mini-body"><div class="mini-section"><div class="mini-section-title"><span>01</span>工作目录</div><div class="mini-control"><i class="mini-control-icon"></i><i class="mini-control-lines"></i></div></div><div class="mini-section"><div class="mini-section-title"><span>02</span>队员与负责人</div><div class="mini-control"><i class="mini-control-icon"></i><i class="mini-control-lines"></i></div><div class="mini-control"><i class="mini-control-icon"></i><i class="mini-control-lines"></i></div></div><div class="mini-optional"></div></div><div class="mini-footer"><i class="mini-button"></i><i class="mini-button primary"></i></div></div></div></article>
+      </div>
+    </section>
+
+    <footer class="review-note"><p><strong>已选 C「瓷白钢边」。</strong>Dialog 主色与可选配置保持不变，只让工作目录、队员和负责人下拉框使用纯白表面与更清楚的 Steel 边界。</p><small>UI-UX-PRO-MAX 定向建议 + 当前生产 token 手工推导<br>已选方案记录 · 模拟数据 · 不连接 App / Core / Runtime</small></footer>
+    <p id="selection-status" class="sr-only" role="status" aria-live="polite"></p>
+    <div class="prototype-toast" id="prototype-toast" role="status" hidden></div>
+    <noscript>请启用 JavaScript 以切换候选、主题和展开状态。这是一份离线设计稿，不会连接 Rovai AI。</noscript>
+  </main>
+
+  <script>
+    'use strict';
+    const root = document.documentElement;
+    const scene = document.getElementById('scene');
+    const activeScope = document.getElementById('active-scope');
+    const status = document.getElementById('selection-status');
+    const toast = document.getElementById('prototype-toast');
+    const variants = {
+      a: { title: 'A · 淡钢蓝', description: '弹窗主色不动，只给三个下拉框一层很浅的 Steel 洗色。' },
+      b: { title: 'B · 冷雾灰', description: '把下拉框从米白转成不带明显色相的冷灰。' },
+      c: { title: 'C · 瓷白钢边', description: '下拉框保持纯白，通过更清楚的 Steel 灰边界建立层次。' },
+      reference: { title: '当前 · 米白对照', description: '生产下拉框的 surface / muted / line-strong，仅作前后比较。' }
+    };
+    const params = new URLSearchParams(location.search);
+    const choose = (key, values, fallback) => values.includes(params.get(key)) ? params.get(key) : fallback;
+    const state = {
+      palette: choose('palette', Object.keys(variants), 'c'),
+      theme: choose('theme', ['day', 'night'], 'day'),
+      view: choose('view', ['scene', 'compare'], 'scene')
+    };
+    let toastTimer = 0;
+
+    function saveState() {
+      const next = new URLSearchParams();
+      next.set('palette', state.palette);
+      next.set('theme', state.theme);
+      next.set('view', state.view);
+      history.replaceState(null, '', `${location.pathname}?${next.toString()}`);
+    }
+
+    function syncState(announce = false) {
+      root.dataset.theme = state.theme;
+      root.dataset.view = state.view;
+      scene.dataset.palette = state.palette;
+      activeScope.dataset.palette = state.palette;
+      document.getElementById('active-title').textContent = variants[state.palette].title;
+      document.getElementById('active-description').textContent = variants[state.palette].description;
+      document.querySelectorAll('[data-palette-choice]').forEach((button) => { button.setAttribute('aria-pressed', String(button.dataset.paletteChoice === state.palette)); });
+      document.querySelectorAll('[data-theme-choice]').forEach((button) => { button.setAttribute('aria-pressed', String(button.dataset.themeChoice === state.theme)); });
+      document.querySelectorAll('[data-view-choice]').forEach((button) => { button.setAttribute('aria-pressed', String(button.dataset.viewChoice === state.view)); });
+      document.querySelectorAll('.token-values').forEach((token) => {
+        const card = token.closest('[data-palette]');
+        const key = card?.dataset.palette;
+        if (!key) return;
+        const day = {
+          a: '#F1F5F8 · #E1EAF0 · #AEBFCA', b: '#F3F5F6 · #E6EAEC · #B6C0C6', c: '#FFFFFF · #E9EEF3 · #8296A4', reference: '#FBFBFA · #E7EAED · #C7CFD6'
+        };
+        const night = {
+          a: '#1C2931 · #22343E · #5B7180', b: '#20262A · #283137 · #5D686F', c: '#1B2227 · #22303A · #6A8190', reference: '#151A1E · #242D33 · #53616B'
+        };
+        token.textContent = (state.theme === 'day' ? day : night)[key];
+      });
+      saveState();
+      if (announce) status.textContent = `已切换到${variants[state.palette].title}，${state.theme === 'day' ? '日间' : '夜间'}，${state.view === 'scene' ? '完整场景' : '并排比较'}。`;
+    }
+
+    function showToast(message) {
+      window.clearTimeout(toastTimer);
+      toast.textContent = message;
+      toast.hidden = false;
+      toastTimer = window.setTimeout(() => { toast.hidden = true; }, 2600);
+    }
+
+    document.querySelectorAll('[data-palette-choice]').forEach((button) => button.addEventListener('click', () => { state.palette = button.dataset.paletteChoice; syncState(true); }));
+    document.querySelectorAll('[data-theme-choice]').forEach((button) => button.addEventListener('click', () => { state.theme = button.dataset.themeChoice; syncState(true); }));
+    document.querySelectorAll('[data-view-choice]').forEach((button) => button.addEventListener('click', () => { state.view = button.dataset.viewChoice; syncState(true); }));
+
+    document.querySelectorAll('[data-menu-toggle]').forEach((button) => button.addEventListener('click', () => {
+      const target = document.getElementById(button.dataset.menuToggle);
+      const open = target.hidden;
+      document.querySelectorAll('.new-camp-picker-menu').forEach((menu) => { menu.hidden = true; });
+      document.querySelectorAll('[data-menu-toggle]').forEach((trigger) => { trigger.setAttribute('aria-expanded', 'false'); });
+      target.hidden = !open;
+      button.setAttribute('aria-expanded', String(open));
+    }));
+
+    document.querySelectorAll('[data-workspace]').forEach((button) => button.addEventListener('click', () => {
+      document.getElementById('workspace-label').textContent = button.dataset.workspace;
+      document.getElementById('workspace-detail').textContent = button.dataset.workspaceDetail;
+      document.getElementById('footer-workspace').textContent = button.dataset.workspace;
+      document.getElementById('workspace-menu').hidden = true;
+      document.getElementById('workspace-trigger').setAttribute('aria-expanded', 'false');
+      showToast(`设计稿已切换到「${button.dataset.workspace}」，不会读取目录。`);
+    }));
+
+    document.querySelectorAll('[data-member]').forEach((input) => input.addEventListener('change', () => {
+      const selected = [...document.querySelectorAll('[data-member]:checked')];
+      if (selected.length === 0) {
+        input.checked = true;
+        showToast('至少保留一位队员。');
+        return;
+      }
+      const names = selected.map((item) => item.dataset.member);
+      document.getElementById('member-summary').textContent = `已选择 ${selected.length} 位队员`;
+      document.getElementById('member-names').textContent = names.join('、');
+      document.getElementById('member-count-heading').textContent = ` · 已选 ${selected.length} / 3`;
+      document.getElementById('footer-members').textContent = `${selected.length} 位队员`;
+    }));
+
+    const optionalTrigger = document.getElementById('optional-trigger');
+    const optionalPanel = document.getElementById('optional-panel');
+    const nameInput = document.getElementById('camp-name');
+    optionalTrigger.addEventListener('click', () => {
+      const open = optionalPanel.hidden;
+      optionalPanel.hidden = !open;
+      optionalTrigger.setAttribute('aria-expanded', String(open));
+      if (open) requestAnimationFrame(() => nameInput.focus());
+    });
+    nameInput.addEventListener('input', () => {
+      [...nameInput.value].length > 80 && (nameInput.value = [...nameInput.value].slice(0, 80).join(''));
+      document.getElementById('name-count').textContent = `${[...nameInput.value].length} / 80`;
+      document.getElementById('optional-value').textContent = nameInput.value.trim() || '未设置';
+    });
+
+    document.querySelectorAll('[data-prototype-action]').forEach((button) => button.addEventListener('click', () => { showToast(`「${button.dataset.prototypeAction}」仅作交互示意，设计稿不会改变 Rovai AI。`); }));
+    document.getElementById('prototype-form').addEventListener('submit', (event) => { event.preventDefault(); showToast(`这是 ${variants[state.palette].title} 设计稿，没有创建 Camp。`); });
+    document.addEventListener('keydown', (event) => {
+      if (event.key !== 'Escape') return;
+      const openMenu = [...document.querySelectorAll('.new-camp-picker-menu')].find((menu) => !menu.hidden);
+      if (openMenu) {
+        openMenu.hidden = true;
+        const trigger = document.querySelector(`[data-menu-toggle="${openMenu.id}"]`);
+        trigger?.setAttribute('aria-expanded', 'false');
+        trigger?.focus();
+      } else showToast('Esc 在生产 Dialog 中会关闭并把焦点返回原入口。');
+    });
+
+    syncState();
+  </script>
+</body>
+</html>

--- a/docs/ui/themes/porcelain-day.md
+++ b/docs/ui/themes/porcelain-day.md
@@ -4,7 +4,7 @@ authority: renderer-theme
 status: accepted
 theme_id: porcelain-day
 mode: light
-last_updated: 2026-08-31
+last_updated: 2026-09-01
 ---
 
 # Porcelain Day
@@ -67,6 +67,10 @@ Light. `color-scheme: light`.
 | `--line` | `#dfe4e8` |
 | `--line-strong` | `#c7cfd6` |
 | `--control-line` | `#8b9389` |
+| `--new-camp-picker-surface` | `#ffffff` |
+| `--new-camp-picker-soft` | `#e9eef3` |
+| `--new-camp-picker-hover` | `#edf2f5` |
+| `--new-camp-picker-line-strong` | `#8296a4` |
 | `--rail` | `#f3f4f4` |
 | `--rail-ink` | `#626b72` |
 | `--rail-line` | `#dadde0` |
@@ -161,6 +165,9 @@ Light. `color-scheme: light`.
 
 ## Brand, semantic, identity, and evidence color rules
 
+- The New Conversation workspace, member and Lead dropdowns use the dedicated
+  `--new-camp-picker-*` assignments. They do not recolor the Dialog surface or the optional-configuration
+  accordion.
 - `attention` is for pending user action or approval; warm `ember` is decorative and cannot replace it.
 - `danger` is for stop, permanent deletion, forgetting and confirmed failure—not ordinary disabled state.
 - Stable IDs map to `--identity-1..8`; identity color never signals state or permission.

--- a/docs/ui/themes/steel-night.md
+++ b/docs/ui/themes/steel-night.md
@@ -4,7 +4,7 @@ authority: renderer-theme
 status: accepted
 theme_id: steel-night
 mode: dark
-last_updated: 2026-08-31
+last_updated: 2026-09-01
 ---
 
 # Steel Night
@@ -67,6 +67,10 @@ Dark. `color-scheme: dark`.
 | `--line` | `#333e46` |
 | `--line-strong` | `#53616b` |
 | `--control-line` | `#687b88` |
+| `--new-camp-picker-surface` | `#1b2227` |
+| `--new-camp-picker-soft` | `#22303a` |
+| `--new-camp-picker-hover` | `#24323b` |
+| `--new-camp-picker-line-strong` | `#6a8190` |
 | `--rail` | `#11161a` |
 | `--rail-ink` | `#a6b1b8` |
 | `--rail-line` | `#313b43` |
@@ -162,6 +166,10 @@ Night inherits the shared non-color structure from `:root`; aliases resolve agai
 | `--conversation-composer-width` | `1040px`; viewport `>= 1800px` 时为 `1440px` |
 
 ## Brand, semantic, identity, and evidence color rules
+
+The New Conversation workspace, member and Lead dropdowns use the dedicated
+`--new-camp-picker-*` assignments. They do not recolor the Dialog surface or the optional-configuration
+accordion.
 
 The same semantic separation as Day applies. Brightened identity colors retain stable ID mapping;
 they do not become statuses. Evidence and diffs remain neutral and structurally labeled. Narrative


### PR DESCRIPTION
## Summary
- keep the existing dialog, header, footer, brand, and optional-configuration colors unchanged
- apply the selected C porcelain surface and Steel boundary only to workspace, member, and Lead pickers in Day and Night themes
- retain the HTML comparison prototype and record C as the selected production treatment
- add theme contrast and picker-scope regression coverage

## Validation
- pnpm typecheck
- pnpm test
- pnpm build:desktop
- DOCS_BASE_REF=16c15a928a43c44ddd6cfd3732b3f3a686c32f9c pnpm docs:check:ci
- prototype static DOM, script, token-scope, and contrast checks