### PR TITLE
feat(channels): pause DingTalk public admission

### DIFF
--- a/apps/desktop/src/renderer/src/ChannelSettings.test.ts
+++ b/apps/desktop/src/renderer/src/ChannelSettings.test.ts
@@ -93,7 +93,10 @@ describe('Channel settings', () => {
 
     expect(markup).toContain('role="tablist" aria-label="渠道"')
     expect(markup).toContain('<strong>飞书</strong>')
-    expect(markup).not.toContain('钉钉')
+    expect(markup).toContain('<strong>钉钉</strong>')
+    expect(markup).toContain('<small>敬请期待</small>')
+    expect(markup).toContain('aria-disabled="true"')
+    expect(markup).toMatch(/channel-provider-tab is-disabled[^>]*disabled=""/u)
     expect(markup).not.toContain('Telegram')
     expect(markup).toContain('只有 Rovai Owner 可以从外部渠道触发队员')
     expect(markup).toContain('飞书中的 Owner 消息仍是外部消息身份')
@@ -110,7 +113,7 @@ describe('Channel settings', () => {
     expect(markup).toContain('>等待连接</button>')
   })
 
-  it('exposes DingTalk and keeps its published Bot management facts local', () => {
+  it('keeps DingTalk visible as a disabled coming-soon preview without exposing saved management facts', () => {
     const snapshot = unavailableSnapshot()
     snapshot.channels.push({
       kind: 'dingtalk',
@@ -146,19 +149,23 @@ describe('Channel settings', () => {
     expect(markup).toContain('<strong>飞书</strong>')
     expect(markup).toContain('<strong>钉钉</strong>')
     expect(markup).toMatch(/channel-mark-dingtalk[^>]*>\s*<img src=/u)
-    expect(markup).toContain('2 个渠道')
+    expect(markup).toContain('1 个可用渠道')
     expect(markup.match(/role="tab"/gu)).toHaveLength(2)
-    expect(markup).toContain('钉钉连接')
-    expect(markup).toContain('星海科技')
-    expect(markup).toContain('芝士')
-    expect(markup).toContain('u-app-1')
+    expect(markup).toContain('<small>敬请期待</small>')
+    expect(markup).toContain('aria-disabled="true"')
+    expect(markup).toMatch(/channel-provider-tab is-disabled[^>]*disabled=""/u)
+    expect(markup).toContain('飞书连接')
+    expect(markup).not.toContain('钉钉连接')
+    expect(markup).not.toContain('星海科技')
+    expect(markup).not.toContain('芝士')
+    expect(markup).not.toContain('u-app-1')
     expect(snapshot.channels).toHaveLength(2)
     expect(snapshot.channels[1].memberBots[0].appId).toBe('u-app-1')
     expect(markup).not.toMatch(/app secret|client secret|access token/i)
   })
 
   it.each(['not_connected', 'session_expired', 'connected'] as const)(
-    'renders DingTalk as the only available provider from a %s snapshot',
+    'does not reopen DingTalk management from a legacy %s-only snapshot',
     (status) => {
       const snapshot = unavailableSnapshot()
       snapshot.channels = [{
@@ -174,10 +181,13 @@ describe('Channel settings', () => {
         agents: [], snapshot, selectedKind: 'dingtalk', onConnect: () => undefined
       }))
 
-      expect(markup).not.toContain('当前版本没有可用的渠道')
+      expect(markup).toContain('当前版本没有可用的渠道')
       expect(markup).toContain('role="tab"')
       expect(markup).toContain('<strong>钉钉</strong>')
-      expect(markup).toContain('钉钉连接')
+      expect(markup).toContain('<small>敬请期待</small>')
+      expect(markup).toContain('aria-disabled="true"')
+      expect(markup).not.toContain('钉钉连接')
+      expect(markup).not.toContain('星海科技')
       expect(snapshot.channels[0].connection.status).toBe(status)
     }
   )

--- a/apps/desktop/src/renderer/src/ChannelSettings.tsx
+++ b/apps/desktop/src/renderer/src/ChannelSettings.tsx
@@ -226,9 +226,11 @@ export function ChannelSettingsView({
 }): React.JSX.Element {
   const members = useMemo(() => visibleChannelMembers(agents), [agents])
   const channels = snapshot?.channels ?? []
-  const channel = channels.find((candidate) => candidate.kind === selectedKind)
-    ?? channels[0]
+  const manageableChannels = channels.filter((candidate) => candidate.kind !== 'dingtalk')
+  const channel = manageableChannels.find((candidate) => candidate.kind === selectedKind)
+    ?? manageableChannels[0]
     ?? null
+  const dingtalk = channels.find((candidate) => candidate.kind === 'dingtalk')
   const providerName = channel?.displayName ?? '渠道'
 
   return (
@@ -250,9 +252,7 @@ export function ChannelSettingsView({
         />
       )}
 
-      {snapshot && !channel && <ChannelSettingsState label="当前版本没有可用的渠道。" tone="empty" />}
-
-      {channel && snapshot && (
+      {snapshot && (
         <div className="channel-settings-body">
           {error && (
             <div className="channel-settings-inline-error" role="alert">
@@ -266,11 +266,11 @@ export function ChannelSettingsView({
               id="channel-provider-heading"
               title="渠道"
               description="选择要连接和管理的平台。账号会话、应用凭据与项目路径都留在这台设备。"
-              summary={`${channels.length} 个渠道`}
+              summary={`${manageableChannels.length} 个可用渠道`}
             />
             <div className="channel-provider-strip" role="tablist" aria-label="渠道">
-              {channels.map((provider) => {
-                const selected = provider.kind === channel.kind
+              {manageableChannels.map((provider) => {
+                const selected = provider.kind === channel?.kind
                 return (
                   <button
                     className={`channel-provider-tab${selected ? ' is-selected' : ''}`}
@@ -288,48 +288,67 @@ export function ChannelSettingsView({
                   </button>
                 )
               })}
+              <button
+                className="channel-provider-tab is-disabled"
+                type="button"
+                role="tab"
+                aria-selected="false"
+                aria-disabled="true"
+                disabled
+                title="钉钉渠道敬请期待"
+              >
+                <ChannelMark kind="dingtalk" />
+                <span>
+                  <strong>{dingtalk?.displayName ?? '钉钉'}</strong>
+                  <small>敬请期待</small>
+                </span>
+              </button>
             </div>
           </section>
 
-          <section className="channel-settings-section" aria-labelledby="channel-connection-heading">
-            <ChannelSectionHeading
-              id="channel-connection-heading"
-              title={`${providerName}连接`}
-              description="连接只决定后续 Bot 的发布目标；切换连接不会迁移或停用已发布 Bot。"
-            />
-            <ChannelConnectionRow
-              channel={channel}
-              busy={busy}
-              onConnect={onConnect}
-              onDisconnect={onDisconnect}
-            />
-            <p className="channel-owner-note">
-              <OwnerShieldIcon />
-              <span>{providerName}中的 Owner 消息仍是外部消息身份，不获得本机管理权限。项目绝对路径不会发送到外部渠道。</span>
-            </p>
-          </section>
+          {!channel && <ChannelSettingsState label="当前版本没有可用的渠道。" tone="empty" />}
 
-          <section className="channel-settings-section" aria-labelledby="channel-member-bots-heading">
-            <ChannelSectionHeading
-              id="channel-member-bots-heading"
-              title="队员 Bot"
-              description="每次只发布一名队员。每名队员拥有独立 Bot 身份和隔离的长连接。"
-              summary={memberSummary(members, channel.memberBots)}
-            />
-            <ChannelMemberBotTable
-              channel={channel}
-              members={members}
-              busy={busy}
-              onPublish={onPublish}
-              onRetryPublish={onRetryPublish}
-            />
-          </section>
+          {channel && <>
+            <section className="channel-settings-section" aria-labelledby="channel-connection-heading">
+              <ChannelSectionHeading
+                id="channel-connection-heading"
+                title={`${providerName}连接`}
+                description="连接只决定后续 Bot 的发布目标；切换连接不会迁移或停用已发布 Bot。"
+              />
+              <ChannelConnectionRow
+                channel={channel}
+                busy={busy}
+                onConnect={onConnect}
+                onDisconnect={onDisconnect}
+              />
+              <p className="channel-owner-note">
+                <OwnerShieldIcon />
+                <span>{providerName}中的 Owner 消息仍是外部消息身份，不获得本机管理权限。项目绝对路径不会发送到外部渠道。</span>
+              </p>
+            </section>
+
+            <section className="channel-settings-section" aria-labelledby="channel-member-bots-heading">
+              <ChannelSectionHeading
+                id="channel-member-bots-heading"
+                title="队员 Bot"
+                description="每次只发布一名队员。每名队员拥有独立 Bot 身份和隔离的长连接。"
+                summary={memberSummary(members, channel.memberBots)}
+              />
+              <ChannelMemberBotTable
+                channel={channel}
+                members={members}
+                busy={busy}
+                onPublish={onPublish}
+                onRetryPublish={onRetryPublish}
+              />
+            </section>
+          </>}
 
           <ExecutionWebSettingsPanel />
         </div>
       )}
 
-      {(!channel || !snapshot) && <ExecutionWebSettingsPanel />}
+      {!snapshot && <ExecutionWebSettingsPanel />}
     </div>
   )
 }

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -5158,9 +5158,12 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
 .channel-section-heading > span { flex: 0 0 auto; color: var(--faint); font: 500 10px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; white-space: nowrap; }
 .channel-provider-strip { display: flex; min-width: 0; overflow-x: auto; padding: 7px 2px; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
 .channel-provider-tab { display: grid; width: min(232px, 100%); min-height: 44px; grid-template-columns: 30px minmax(0, 1fr); gap: 9px; align-items: center; padding: 6px 9px; border: 0; border-radius: 7px; color: var(--muted); background: transparent; cursor: pointer; text-align: left; }
-.channel-provider-tab:hover { color: var(--ink); background: var(--workspace-surface-hover); }
+.channel-provider-tab:hover:not(:disabled) { color: var(--ink); background: var(--workspace-surface-hover); }
 .channel-provider-tab.is-selected { color: var(--brand-ink); background: var(--brand-soft); }
 .channel-provider-tab:focus-visible { outline: 2px solid var(--focus); outline-offset: 2px; }
+.channel-provider-tab.is-disabled { color: var(--faint); background: transparent; cursor: not-allowed; }
+.channel-provider-tab.is-disabled .channel-mark { border-color: var(--line); background: var(--surface-subtle); }
+.channel-provider-tab.is-disabled .channel-mark img { filter: grayscale(1); opacity: .42; }
 .channel-provider-tab > span:last-child { display: grid; min-width: 0; gap: 2px; }
 .channel-provider-tab strong,
 .channel-provider-tab small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }

--- a/docs/ui/components/channel-settings.md
+++ b/docs/ui/components/channel-settings.md
@@ -8,22 +8,24 @@ last_updated: 2026-09-02
 
 # 渠道设置
 
-渠道设置是 Owner 在 Rovai 本机维护飞书/钉钉连接与队员 Bot 的 Renderer surface。群首次项目选择发生在对应外部会话的
+渠道设置是 Owner 在 Rovai 本机维护当前开放渠道连接与队员 Bot 的 Renderer surface。群首次项目选择发生在对应外部会话的
 Owner-only 卡片中；Renderer 不提供 Channel 项目目录或会话绑定操作。领域状态和错误按 Provider 分别见
 [Feishu Channel v15](../../contracts/feishu-channel-v15.md)与
 [DingTalk Channel v10](../../contracts/dingtalk-channel-v10.md)；本页只拥有信息层级、交互与可访问性。
 
-当前渠道页同时显示飞书与钉钉。切换 Provider 只切换本地管理投影，不合并账号、Bot、待绑定或异常计数；
-既有钉钉账号和已发布 Bot 直接按真实状态恢复，不显示“待接入”占位入口。
+当前渠道页只开放飞书管理。钉钉保留官方图标，但固定显示为置灰、不可选择的“敬请期待”入口；它使用原生
+`disabled` 与 `aria-disabled=true`，不响应鼠标、键盘或触控，也不展示已保存的钉钉账号、Bot、发布、重连或管理事实。
+已有钉钉数据和 Main/Core 实现不因这个 Renderer gate 删除或迁移，后续重新开放范围记录在
+[v1.38](../../versions/v1.38/README.md)。
 
 ## 页面结构
 
 页面沿用设置工作区的 Porcelain Day / Steel Night 世界和现有 `SettingsPageHeader`：
 
 1. `Settings / Channels` eyebrow、标题“渠道”、Owner 本机说明；
-2. 飞书与钉钉 Provider Tab，均使用打包进 App 的真实品牌图标；切换只改变当前展示，不合并账号、Bot 状态或诊断；
-3. 当前 Provider 的渠道连接，展示真实开发者用户名、企业与可选 email，提供登录、切换和断开；
-4. 队员 Bot 列表，按成员稳定顺序显示头像、名称、角色、发布状态和单行动作；
+2. 飞书可选 Provider Tab 与固定禁用的钉钉“敬请期待”Tab，均使用打包进 App 的真实品牌图标；
+3. 飞书渠道连接，展示真实开发者用户名、企业与可选 email，提供登录、切换和断开；
+4. 飞书队员 Bot 列表，按成员稳定顺序显示头像、名称、角色、发布状态和单行动作；
 5. 页面最底部显示默认折叠的“局域网执行台”全局设置，不放入单个 Bot、Camp 或队员行。
 
 窄窗口保持同一内容顺序，表格式行折为纵向信息，不产生横向滚动。共享色彩只使用现有语义 Token；头像、按钮、
@@ -32,8 +34,8 @@ Dialog、状态点和间距复用现有组件语法。
 <a id="渠道连接与二维码"></a>
 ## 渠道连接与 OAuth
 
-飞书未连接时主动作是“登录开放平台”，已连接时为“切换账号”；钉钉为“连接钉钉／重新连接”。已连接时均保留次级“断开”。连接行只展示真实 `userName`、
-`tenantName`、可选 email 与 Feishu/Lark/DingTalk brand，不显示 controller App 或“平台 Owner/企业”占位值。说明必须明确：
+飞书未连接时主动作是“登录开放平台”，已连接时为“切换账号”，并保留次级“断开”。连接行只展示真实 `userName`、
+`tenantName`、可选 email 与 Feishu/Lark brand，不显示 controller App 或“平台 Owner/企业”占位值。说明必须明确：
 连接只决定以后发布的目标，切换不会迁移或停用已发布 Bot。点击“切换账号”后，当前账号在新二维码成功完成前继续
 有效；取消或失败关闭 Dialog 后仍显示原账号，不得降级为“登录已过期”。只有切换成功才展示新账号。
 
@@ -46,17 +48,9 @@ Dialog、状态点和间距复用现有组件语法。
 `system_credential_encryption_unavailable`；身份读取超时和页面失败使用中文可操作提示，不向用户显示 `unknown` 或原始异常文本。
 连接行统一说明“开发者账号会话 · 保存在 Rovai 本地数据库”。
 
-钉钉使用同一个 modal 结构，标题“登录钉钉开放平台”，直接展示 Main 从官方登录页读取的二维码，不打开系统浏览器或独立窗口。
-扫码后清除二维码并显示确认状态；平台提示过期时提供“刷新二维码”，未取得可信过期时间不显示倒计时。
-需要组织选择/安全确认时仅扩大同一个 Dialog，在内容区嵌入 Main-owned 原生官方页面；没有可提取的 QR 时也保留这个交互入口。
-原生页不持有 Rovai bridge；随窗口缩放和内容滚动裁剪，不能覆盖标题、关闭或取消按钮。普通 QR、状态和存储说明分行呈现，
-沿用 Day/Night Token、现有图标与按钮。关闭按钮、取消和 Escape 均取消 exact attempt，只有原子保存阶段短暂禁用。
-未连接时为
-“连接钉钉”，已连接或明确失效时为“重新连接”；进行中显示“等待授权…”。设备授权按钮、提示、等待状态和备用入口均删除。
-说明开发者 Web Session 保存在 Rovai 本地数据库，本次不创建应用或读取 AppSecret。重启恢复 Cookie，平台 SSO 能自动续接
-时不打开 Dialog；只有明确失效才显示“登录已失效，请重新连接”。取消登录是无告警的 no-op；网络、超时、存储或新
-Session/Core commit 失败保留旧账号。不需要 Rovai OAuth Client 配置；旧 OAuth Profile 不能当作 Cookie 使用，提示显式重连，
-但成功提交前不删除旧数据或已发布 Bot。
+钉钉登录、重连、断开、发布和管理 Dialog 当前都不从 Renderer 挂载。Main/Core 中已有 Web Session、credential 和
+published Bot 数据保持原样，但这些事实不得绕过禁用入口重新出现在渠道页；即使 Snapshot 只含钉钉，页面也只展示
+“当前版本没有可用的渠道”和禁用预告，不把钉钉设为当前 Provider。
 
 普通发布不得进入 QR Dialog。点击列表“发布”先打开独立确认 Dialog，展示现有 `MemberAvatar`、队员名称/职责、
 应用说明、当前开发者账号和租户；“确认发布”后在同一 Dialog 逐步展示八个进行中阶段。主文案固定为：
@@ -73,11 +67,7 @@ Session/Core commit 失败保留旧账号。不需要 Rovai OAuth Client 配置�
 完成文案为“发布完成”。配置阶段说明 Rovai 正在读取当前配置并提交所需权限、事件与回调变更；等待阶段须说明平台控制面可能需要时间；
 最终核验只描述 Bot、发布版本和应用资料，不声称重新读取已经由同次 convergence 证明的权限与事件。在线配置核验与真正 WebSocket connect 不得合并成
 同一阶段。若配置没有 mutation，可以跳过第 6 阶段，但不得伪造一次最终版本发布。普通发布不得打开平台应用创建确认
-窗口。Session 失效/身份漂移时显示“重新连接飞书/钉钉”并停止发布，不存在其他发布流程。
-
-钉钉远端要求 `SELECT_APPROVER` 时，同一发布 Dialog 在 `waiting_configuration` 阶段显示“版本审批人”下拉框。候选人只
-来自当前远端返回的 bounded 列表；Owner 必须明确选择并点击“提交审批并继续发布”，Rovai 不自动选择第一人。提交后仍在
-审核时显示等待说明和原 App ID，关闭 Dialog 不撤销远端审批，也不把 waiting 状态报成失败。
+窗口。Session 失效/身份漂移时显示“重新连接飞书”并停止发布，不存在其他发布流程。
 
 若上次发布已冻结 App ID 并失败，Owner 再次点击“继续核对”沿用同一 Dialog 与进度语言，后台核对
 并接管该 App；不显示新的创建确认，也不生成第二个 App。初始版本已发布但头像仍是旧 Rovai icon 时，同一流程可以显示
@@ -99,7 +89,7 @@ Session/Core commit 失败保留旧账号。不需要 Rovai OAuth Client 配置�
 | failed，无 App ID | 需处理 / 远端创建结果待核对 | 安全失败可重试；true unknown 不提供重建入口 |
 | disabled（历史数据状态） | 已停用 | 重新发布同一 App |
 
-已发布行不打开 Rovai 管理 Dialog，也不提供停用命令。“飞书管理”或“钉钉管理”是带可访问名称的外部链接，使用 Main
+已发布行不打开 Rovai 管理 Dialog，也不提供停用命令。“飞书管理”是带可访问名称的外部链接，使用 Main
 从该 Bot 绑定账号与冻结 App ID 生成的精确 `managementUrl`，以 `_blank + noreferrer noopener` 交给 Electron 在系统
 浏览器打开。链接不依赖当前 Developer Session 的连接状态；Renderer 不拼接或接受任意 URL。关闭、停用、删除等
 远端应用治理只在官方开放平台完成。
@@ -201,6 +191,7 @@ Web 执行台延续 Porcelain Day / Steel Night 的冷瓷灰、Steel 品牌、�
 - 所有异步操作使用稳定 busy key，防止双击；失败后恢复原动作；
 - Dialog 使用 Radix focus trap、Escape/关闭、可见 label、描述和 footer actions；
 - 状态不仅靠颜色，始终有文本；loading/failed 通过 `role=status/alert` 公布；
+- 钉钉预告使用原生 disabled 语义、可见“敬请期待”文本与灰度图标；禁用状态不获得 hover/press，也不能成为当前 Tab；
 - Tab 顺序按页面视觉顺序，链接和按钮均可键盘操作，焦点不因 Snapshot 更新跳到页面起点。
 
 ## References

--- a/docs/versions/README.md
+++ b/docs/versions/README.md
@@ -1,8 +1,8 @@
 ---
 document_type: versions-index
 authority: version-lifecycle
-current_version: v1.37
-last_updated: 2026-09-01
+current_version: v1.38
+last_updated: 2026-09-02
 ---
 
 # Rovai-ai 版本记录
@@ -188,4 +188,5 @@ last_updated: 2026-09-01
 | v1.34 | `historical` | Camp 队员三态 Fast 覆盖、原生资格与执行冻结、紧凑成员胶囊 | [v1.34/README.md](v1.34/README.md) |
 | v1.35 | `historical` | 飞书队员 Bot、Owner-only Camp、原会话项目卡、动态 roster 与执行输出；channel 分支原 v1.33 编号顺延 | [v1.35/README.md](v1.35/README.md) |
 | v1.36 | `historical` | 共享 SQLite、飞书终态卡与钉钉 Web Session；钉钉单应用发布已隔离验证，Core/收发/群卡片与 packaged 验收未闭环 | [v1.36/README.md](v1.36/README.md) |
-| v1.37 | `current` | Runtime 图片、取消可用性、Agent 目标教学与飞书 LAN 只读执行台；部分真实 Runtime/渠道验收仍在进行 | [v1.37/README.md](v1.37/README.md) |
+| v1.37 | `historical` | Runtime 图片、取消可用性、Agent 目标教学与飞书 LAN 只读执行台；部分真实 Runtime/渠道验收未完成即冻结 | [v1.37/README.md](v1.37/README.md) |
+| v1.38 | `current` | 钉钉渠道暂停公开接入；渠道页保留置灰预告，重新开放所需的关键一致性与验收项进入待办 | [v1.38/README.md](v1.38/README.md) |

--- a/docs/versions/v1.37/README.md
+++ b/docs/versions/v1.37/README.md
@@ -1,7 +1,7 @@
 ---
 document_type: version-overview
 version: v1.37
-lifecycle: current
+lifecycle: historical
 authority: version-scope-and-status
 design_status: confirmed
 implementation_status: in_progress
@@ -11,7 +11,7 @@ last_updated: 2026-09-02
 
 # Rovai-ai v1.37：Runtime 图片、文件预览、取消与渠道只读执行台
 
-前置：[v1.36](../v1.36/README.md)。渠道已有代码先保存为 f0e1ce2f、b7316a57、6f9f8bd2；原钉钉 NO-GO
+前置：[v1.36](../v1.36/README.md)。后继：[v1.38](../v1.38/README.md)。渠道已有代码先保存为 f0e1ce2f、b7316a57、6f9f8bd2；原钉钉 NO-GO
 在本版本后续由用户明确重开为单 Bot 真实验收，Topic/Thread 与附件仍保持关闭。
 
 ## 范围与状态

--- a/docs/versions/v1.37/decisions.md
+++ b/docs/versions/v1.37/decisions.md
@@ -1,7 +1,7 @@
 ---
 document_type: version-decisions
 version: v1.37
-lifecycle: current
+lifecycle: historical
 last_updated: 2026-09-02
 ---
 

--- a/docs/versions/v1.38/README.md
+++ b/docs/versions/v1.38/README.md
@@ -1,0 +1,72 @@
+---
+document_type: version-overview
+version: v1.38
+lifecycle: current
+authority: version-scope-and-status
+design_status: confirmed
+implementation_status: in_progress
+model_context_change: false
+last_updated: 2026-09-02
+---
+
+# Rovai-ai v1.38：钉钉渠道暂停开放与重新开放清单
+
+前置：[v1.37](../v1.37/README.md)。本版本先收窄产品入口，不继续扩张钉钉实现；已有钉钉代码、凭据、账号、Bot
+绑定和真实验收记录保持原样，重新开放前要完成的工作集中记录在本版本，避免继续散落在对话或历史版本中。
+
+## 范围与状态
+
+- 渠道页当前只开放飞书管理。钉钉使用已打包的官方图标，固定呈现为置灰、不可选择的“敬请期待”入口；它不挂载登录、
+  重连、断开、发布、审批人选择或已发布 Bot 管理动作。
+- Renderer 不从钉钉 Snapshot 恢复管理内容。即使本机只保存钉钉 Provider，也只显示禁用预告和“当前版本没有可用的渠道”，
+  不把钉钉自动选成当前 Provider。
+- 本次不删除或迁移钉钉的 Main/Core、SQLite 数据、credential、Developer Session、Stream、Card 或 Outbox 实现；已经发布的
+  Bot 仍按既有后台语义运行。该边界只关闭新的用户管理入口，不伪装成后端代码清理。
+- 飞书连接、队员发布、项目选择、排队/执行卡、最近输出、局域网执行台及既有数据完全保持开放。
+- 下列“重新开放清单”只登记范围与优先级；除渠道页 gate 外，本版本当前不实施这些钉钉能力。
+
+## 重新开放清单
+
+### 必须先完成
+
+1. **同一群消息直接 @ 多个 Rovai Bot：** 多个 credential-bound Stream callback 必须合并成一个 durable inbound aggregate、
+   一个根 `ChannelTurnRequest` 和按目标顺序创建的多个 `AgentRun`；不得继续 `observation_mismatch` fail closed，也不得拆成多次
+   项目选择、排队或根消息。
+2. **执行卡生命周期与飞书一致：** 收到请求后立即出现“执行中”状态卡和“显示最近输出 / 打开执行台 / 停止执行”三个入口，
+   不能让平台 loading 覆盖整个执行期；真正排队时出现排队卡，admission 后撤回；终态卡可见，下一条根请求入场时真实撤回。
+3. **群项目选择闭环：** 同组织内部群第一次有效 mention 后，Owner 选择项目或 Quick Chat 必须可靠消费原卡并继续同一条请求；
+   刷新、双击、过期与 Non-owner 都保持现有 Core 授权和幂等边界。
+4. **真实租户验收：** 至少覆盖桌面端与手机端、私聊、单 Bot 内部群、多 Bot 内部群、连续两条消息排队、停止、最近输出、
+   Web 执行台、终态与下一轮撤回；合成 fixture、单独 OpenAPI 成功或 Main/Core 本地测试不能代替 packaged App 验收。
+
+### 后续一致性改进
+
+- **附件：** 当前钉钉入站只形成附件摘要，出站文件关闭；飞书可以收取和投递真实图片/文件。重新开放时需决定补齐真实附件，
+  或把该差异明确保留为产品限制并在 UI 中诚实呈现。
+- **永久正文：** 当前钉钉使用 Markdown 回复，未复现飞书的原生 A2A `@`、直接父消息摘要和超长正文分卡；需要评估可用卡片/API
+  能力并形成真实客户端验收。
+- **最近输出：** 钉钉目前只能整体展开最近输出，不能逐 Command 折叠。按既有产品选择继续不展示 command result；若平台后续
+  提供稳定原生 disclosure，再单独评估，不用自制伪折叠。
+- **可观察性：** 为真实群 callback 聚合、卡片 create/update/recall 和项目 callback 增加可诊断但不泄露正文、credential 或
+  Owner 身份的安全状态，避免再次依赖 UI 现象推断链路阶段。
+
+### 明确接受的平台差异
+
+- 钉钉没有飞书话题群等价能力，Rovai 不实现 Topic/Thread。
+- 只支持同组织内部群中通过“添加机器人”安装的应用 Bot；普通成员形态、普通群和外部群不走受支持的 Robot Stream 准入。
+- 项目选择继续使用钉钉内置通用 AI Markdown 模板的有界按钮，不要求普通用户创建模板，也不强行模拟飞书下拉框。
+- 钉钉最近输出不显示 command result；两端仍共用安全 command、`$` 前缀和超长首尾截断。
+
+## 跨版本文档影响
+
+| 范围 | 结论 | 证据或理由 |
+| --- | --- | --- |
+| Version lifecycle | 已更新 | v1.37 冻结为 historical；本概览、实施计划与版本索引建立唯一 current v1.38 |
+| Decisions | 确认无需更新 | 暂停公开入口是可逆的 Renderer 产品 gate；重新开放条件由本版本范围拥有，未改变长期领域取舍 |
+| Contracts | 确认无需更新 | 不改变 DingTalk/Feishu wire、字段、状态、幂等或恢复语义；现有 [DingTalk Channel v10](../../contracts/dingtalk-channel-v10.md) 继续描述保留实现 |
+| Architecture | 确认无需更新 | Main/Core、Stream、SQLite、Outbox 和既有已发布 Bot 运行边界均不改变，只收窄 Renderer 管理入口 |
+| UI | 已更新 | [渠道设置](../../ui/components/channel-settings.md)拥有飞书开放、钉钉禁用预告和 legacy Snapshot 回退语义 |
+| Runtime Activity | 确认无需更新 | 不改变 AgentRun activity 归类或 Canonical Activity 映射 |
+| Runtime compatibility | 确认无需更新 | 不改变任何 Runtime 的平台准入、模型或工具兼容性 |
+| Documentation routing | 已更新 | 版本索引切换到 v1.38；既有渠道 Architecture/Contract 任务路由保持有效 |
+| Root README | 确认无需更新 | 根 README 未承诺钉钉公开可用，产品定位与安装方式不变 |

--- a/docs/versions/v1.38/implementation-plan.md
+++ b/docs/versions/v1.38/implementation-plan.md
@@ -1,0 +1,38 @@
+---
+document_type: implementation-plan
+version: v1.38
+authority: implementation-and-acceptance-status
+status: in_progress
+last_updated: 2026-09-02
+---
+
+# v1.38 实施与验收
+
+## 当前交付
+
+- [x] 渠道页只把飞书作为可管理 Provider。
+- [x] 钉钉固定显示官方图标、置灰状态和“敬请期待”，使用原生 disabled/ARIA 语义，无 hover、点击或键盘动作。
+- [x] 保存的钉钉账号、连接、Bot 和管理链接不从 Renderer 暴露；`selectedKind=dingtalk` 与 DingTalk-only Snapshot 均不会
+  恢复钉钉管理界面。
+- [x] 保留钉钉 Main/Core、SQLite 数据、凭据、Stream、Card 与 Outbox，不做 destructive migration。
+- [ ] packaged Applications 视觉验收：Porcelain Day / Steel Night、最小窗口、200% zoom 与键盘顺序。
+- [ ] PR 合入最新 `main` 并从合并后的 `main` 构建、安装 `/Applications/Rovai.app`。
+
+## 重新开放待办（当前暂停）
+
+- [ ] 同消息多 Bot callback 聚合为一个根请求和多个目标 `AgentRun`，完成顺序、去重、重启与超时回归。
+- [ ] 执行中三按钮卡立即可见，平台 loading 不覆盖执行期；排队卡、终态卡、下一轮真实撤回完成桌面/手机真实验收。
+- [ ] 内部群项目选择、Quick Chat、刷新、过期、双击和 Non-owner 形成完整 callback 闭环。
+- [ ] 决定并实现或明确限制钉钉真实附件收发。
+- [ ] 评估永久正文的原生 A2A `@`、回复摘要和长正文拆分。
+- [ ] 加入 callback 聚合与 Card create/update/recall 的安全诊断投影。
+- [ ] 通过私聊、单 Bot 群、多 Bot 群、连续排队、停止、最近输出、执行台与撤回的 packaged 双端验收后，才移除
+  “敬请期待” gate。
+
+## 验证 owner
+
+- `apps/desktop/src/renderer/src/ChannelSettings.test.ts`：开放 Provider 过滤、固定钉钉预告、disabled/ARIA、legacy
+  Snapshot 不泄露和飞书回退。
+- `pnpm typecheck`、Renderer/Vitest 全量、`pnpm build:desktop`：类型、现有渠道交互与生产构建回归。
+- `pnpm docs:test`、`pnpm docs:check`、`DOCS_BASE_REF=<main base> pnpm docs:check:ci`：版本切换、当前 UI 权威和文档路由。
+- packaged App 人工检查：入口在日/夜主题均清晰置灰，真实图标比例不变，“敬请期待”可读且不产生点击反馈。


### PR DESCRIPTION
## Summary
- keep Feishu as the only manageable provider in Channel settings
- render DingTalk with the packaged official icon as a disabled, greyed "敬请期待" preview
- hide saved DingTalk account and Bot management facts without deleting backend state
- open v1.38 with a bounded DingTalk reopening backlog and freeze v1.37

## Validation
- pnpm typecheck
- pnpm test (1422 Vitest + 220 Node passed, 1 Windows-only skip)
- pnpm build:desktop
- pnpm docs:test
- pnpm docs:check
- DOCS_BASE_REF=origin/main pnpm docs:check:ci
- git diff --check
