### PR TITLE
chore(release): prepare v0.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "rovai-core"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/rovai-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.4"
+version = "0.0.5"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rovai/desktop",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "license": "MIT",
   "type": "module"

--- a/apps/desktop/src/main/package-metadata.test.ts
+++ b/apps/desktop/src/main/package-metadata.test.ts
@@ -9,7 +9,7 @@ const packageMetadata = JSON.parse(readFileSync(
 describe('desktop package metadata', () => {
   it('keeps the visible brand separate from Electron helper bundle identity', () => {
     expect(packageMetadata.productName).toBe('Rovai AI')
-    expect(packageMetadata.version).toBe('0.0.4')
+    expect(packageMetadata.version).toBe('0.0.5')
     expect(packageMetadata.build.productName).toBe('Rovai AI')
     expect(packageMetadata.build.mac.executableName).toBeUndefined()
     expect(packageMetadata.build.win.executableName).toBe('Rovai-ai')

--- a/build/release-notes.md
+++ b/build/release-notes.md
@@ -1,19 +1,19 @@
-# Rovai AI v0.0.4
+# Rovai AI v0.0.5
 
-Rovai AI 0.0.4 makes updates proactive, expands Camp membership management, and improves long-running collaboration reliability.
+Rovai AI 0.0.5 expands the daily Camp workflow with continuous input, faster supported runtimes, richer files and images, and Feishu channel collaboration.
 
-macOS arm64 and x64 builds use the same fixed Rovai Release Signing certificate as 0.0.3. Windows x64 remains an unsigned Preview build and may show a SmartScreen warning.
+macOS arm64 and x64 builds use the same fixed Rovai Release Signing certificate as 0.0.4. Windows x64 remains an unsigned Preview build and may show a SmartScreen warning.
 
 ## What's Changed
 
-- Proactively check for new releases and surface update prompts while keeping download, installation, and restart under explicit user control.
-- Add and remove members from an existing Camp with lifecycle-safe handling for runs, deliveries, gathers, tasks, and lead replacement.
-- Ingest new managed attachments without waiting for active runs or the legacy publication gate.
-- Drop high-volume Codex command deltas before persistence to reduce event amplification and improve Camp recovery.
-- Show the latest command in live tool activity and keep completed, failed, and stopped summaries stable.
-- Preserve failed installer retries without redownloading, and keep the app usable when the native updater is unavailable.
-- Coordinate Windows upgrades with planned shutdown before the installer replaces running files.
-- Fix IME input after trailing newlines, make cut operations atomic, and simplify the new-conversation empty state.
-- Clarify Camp member invitation and multiline message guidance.
+- Queue and edit the next Camp message while a run is active, then continue automatically with its routing and execution choices frozen at publication.
+- Add per-member Fast preferences with automatic runtime capability detection and safe fallback when a runtime does not support Fast execution.
+- Open changed, referenced, and external files in resizable preview tabs while preserving inline links, reading anchors, and exact file locations.
+- Persist and display structured Runtime images with consistent message timing and retention across Camp switches.
+- Refine execution into compact avatar rails and detail popovers with live refresh, complete output, clearer initiators, and reliable stopped or cancelled terminal states.
+- Add Feishu bot publishing, group and topic project selection, reply and execution cards, adaptive host maintenance, and a bot-gated LAN execution console.
+- Keep DingTalk unavailable in the public channel UI while its remaining consistency and real-client acceptance work is completed.
+- Improve Desktop startup, shutdown, navigation refresh, composer input recovery, approvals, scrollbars, and model catalog refresh behavior.
+- Fix Windows Quick Chat workspace paths and strengthen channel, attachment, cancellation, and Camp-open reliability.
 
-**Full changelog:** https://github.com/murray17/rovai-ai/compare/v0.0.3...v0.0.4
+**Full changelog:** https://github.com/murray17/rovai-ai/compare/v0.0.4...v0.0.5

--- a/crates/rovai-core/src/git.rs
+++ b/crates/rovai-core/src/git.rs
@@ -364,7 +364,11 @@ mod tests {
     use uuid::Uuid;
 
     fn test_root(name: &str) -> PathBuf {
-        std::env::temp_dir().join(format!("rovai-git-{name}-{}", Uuid::new_v4()))
+        let temp_dir = std::env::temp_dir();
+        #[cfg(not(windows))]
+        let temp_dir = fs::canonicalize(&temp_dir)
+            .expect("the platform temporary directory should have a canonical path");
+        temp_dir.join(format!("rovai-git-{name}-{}", Uuid::new_v4()))
     }
 
     async fn run_git(path: &Path, args: &[&str]) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rovai-ai",
   "productName": "Rovai AI",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "type": "module",
   "description": "A desktop workspace for long-lived agent teams, shared Camps, visible execution, and collaborative memory.",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rovai/contracts",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/scripts/accept-app-updates-ui.mjs
+++ b/scripts/accept-app-updates-ui.mjs
@@ -56,7 +56,7 @@ try {
     outputDir,
     verified: {
       isolatedPackagedApplication: true,
-      packagedVersion: '0.0.4',
+      packagedVersion: '0.0.5',
       typedIdleUpdaterSnapshot: true,
       productAndBundleName: 'Rovai AI',
       existingSettingsVisualWorld: true,
@@ -93,12 +93,12 @@ async function openAboutUpdates(cdp) {
   assert(selected, 'About & Updates Settings entry was unavailable')
   await waitForSelector(cdp, '.about-updates-settings')
   await waitForExpression(cdp,
-    `document.querySelector('.about-version-value code')?.textContent === 'v0.0.4'`)
+    `document.querySelector('.about-version-value code')?.textContent === 'v0.0.5'`)
 }
 
 async function assertAboutUpdates(cdp, context) {
   const updaterSnapshot = await evaluate(cdp, 'window.rovai.appUpdates.get()', true)
-  assert(updaterSnapshot?.currentVersion === '0.0.4'
+  assert(updaterSnapshot?.currentVersion === '0.0.5'
     && updaterSnapshot.status === 'idle'
     && updaterSnapshot.availableRelease === null
     && updaterSnapshot.lastCheckSource === null
@@ -136,7 +136,7 @@ async function assertAboutUpdates(cdp, context) {
   assert(state.heading === '关于与更新', `${context} omitted the page heading`)
   assert(state.description === 'Rovai AI 会在正式打包版本中主动检查更新；下载、安装和重启始终由你确认。',
     `${context} used the wrong description`)
-  assert(state.product === 'Rovai AI' && state.version === 'v0.0.4',
+  assert(state.product === 'Rovai AI' && state.version === 'v0.0.5',
     `${context} used the wrong product/version: ${JSON.stringify(state)}`)
   assert(state.action === '检查更新' && state.actionTag === 'BUTTON' && state.actionFocused,
     `${context} did not expose a keyboard-focusable check action`)


### PR DESCRIPTION
## Summary

- bump Desktop, contracts, and Rust package versions to 0.0.5
- publish v0.0.5 release notes for changes since v0.0.4
- canonicalize the non-Windows Rust test temporary root so macOS path aliases do not invalidate the Windows path-compatibility test

## Validation

- pnpm install --frozen-lockfile
- pnpm typecheck
- pnpm build:desktop
- pnpm test
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- pnpm test:rust:pr (475 library, 32 CLI, and 297 slow tests passed)

## Signing

- macOS release workflow remains pinned to Rovai Release Signing fingerprint 875C6F486E223AB1889A2AD63860FBE48F7E8C0E4D94832656896BA5DA4EF82E
- Windows x64 remains an unsigned Preview build