### PR TITLE
feat(renderer): refine resource reference links

### DIFF
--- a/apps/desktop/src/renderer/src/CampWorkspace.current-user-markdown.test.ts
+++ b/apps/desktop/src/renderer/src/CampWorkspace.current-user-markdown.test.ts
@@ -201,9 +201,8 @@ describe('Agent Current User Mention Markdown rendering', () => {
     expect(markup).toContain('<h3 data-markdown-heading="请确认">请确认</h3>')
     expect(markup).toContain('<ul>')
     expect(markup).toContain('<code>方案 B</code>')
-    expect(markup).toContain(
-      '<a href="https://example.com/migration" target="_blank" rel="noreferrer noopener">迁移说明</a>'
-    )
+    expect(markup).toContain('<a class="markdown-web-reference" href="https://example.com/migration"')
+    expect(markup).toContain('<span class="resource-reference-label">迁移说明</span>')
     expect(markup).toContain('<pre><code class="language-sh">pnpm test')
     expect(markup).toContain('<table>')
     expect(markup).toContain('请 @沐瓦 与 @所有队员 审阅。')
@@ -260,8 +259,9 @@ describe('Agent Current User Mention Markdown rendering', () => {
     expect(markup).toContain('aria-label="查看沐瓦的基础信息"')
     expect(markup).toContain('class="message-mention-token skill-mention"')
     expect(markup).toContain('aria-label="Skill /review"')
-    expect(markup).toContain('title="docs/versions/v1.30/README.md">v1.30 方案</a>')
-    expect(markup).toContain('<span class="inline-code-file-reference-label">src/app.ts:20</span>')
+    expect(markup).toContain('title="docs/versions/v1.30/README.md"')
+    expect(markup).toContain('<span class="file-reference-label">v1.30 方案</span>')
+    expect(markup).toContain('<span class="file-reference-label is-code">src/app.ts:20</span>')
     expect(markup).not.toContain('<code>src/app.ts:20</code>')
     expect(markup.replace(/<[^>]*>/gu, '')).not.toContain('docs/versions/v1.30/README.md')
     expect(markup).not.toContain('NON_AUTHORITATIVE_BODY_CACHE')
@@ -276,7 +276,8 @@ describe('Agent Current User Mention Markdown rendering', () => {
       { kind: 'text', text: source }
     ])
     for (const markup of [user, currentUser]) {
-      expect(markup).toContain('title="docs/plan.md">方案</a>')
+      expect(markup).toContain('title="docs/plan.md"')
+      expect(markup).toContain('<span class="file-reference-label">方案</span>')
       expect(markup.replace(/<[^>]*>/gu, '')).not.toContain('docs/plan.md')
     }
     expect(currentUser).toContain('message-mention-token current-user')
@@ -319,7 +320,8 @@ describe('Agent leading Member Mention Markdown rendering', () => {
     expect(markup).toContain('<h3 data-markdown-heading="事实复核">事实复核</h3>')
     expect(markup).toContain('<ul>')
     expect(markup).toContain('<code>行内代码</code>')
-    expect(markup).toContain('title="docs/plan.md">验收说明</a>')
+    expect(markup).toContain('title="docs/plan.md"')
+    expect(markup).toContain('<span class="file-reference-label">验收说明</span>')
     expect(markup).toContain('<pre><code class="language-sh">pnpm test')
     expect(markup).toContain('<table>')
     expect(markup).not.toContain('NON_AUTHORITATIVE_BODY_CACHE')

--- a/apps/desktop/src/renderer/src/FilePreviewTabIcon.tsx
+++ b/apps/desktop/src/renderer/src/FilePreviewTabIcon.tsx
@@ -1,16 +1,85 @@
 import type { FilePreviewKind } from '@contracts'
+import {
+  resourceReferenceVisualKind,
+  type ResourceReferenceVisualKind
+} from './file-reference-presentation'
+
+function ResourceReferenceGlyph({ kind }: { kind: ResourceReferenceVisualKind }): React.JSX.Element {
+  switch (kind) {
+    case 'web':
+      return <><circle cx="12" cy="12" r="9" /><path d="M3 12h18M12 3c2.4 2.5 3.5 5.5 3.5 9S14.4 18.5 12 21M12 3C9.6 5.5 8.5 8.5 8.5 12S9.6 18.5 12 21" /></>
+    case 'markdown':
+      return <><path d="M4 4.5h7a3 3 0 0 1 3 3v12a4 4 0 0 0-4-2.5H4zM20 4.5h-3.5A2.5 2.5 0 0 0 14 7" /><path d="M7 9.5v4m0-4 2 2 2-2v4" /></>
+    case 'html':
+      return <><rect x="3" y="4" width="18" height="16" rx="2" /><path d="M3 8.5h18M6 6.2h.01M9 6.2h.01m1 6-2 2 2 2m4-4 2 2-2 2" /></>
+    case 'code':
+      return <><path d="m8 6-5 6 5 6m8-12 5 6-5 6m-3-15-2 18" /></>
+    case 'config':
+      return <><path d="M5 4h14v16H5zM8 8h8M8 12h8M8 16h8" /><circle cx="11" cy="8" r="1.2" /><circle cx="14" cy="12" r="1.2" /><circle cx="10" cy="16" r="1.2" /></>
+    case 'text':
+      return <><path d="M6 3.5h8l4 4V20H6zM14 3.5v4h4M9 12h6m-6 3h6m-6 3h4" /></>
+    case 'image':
+      return <><rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="8" cy="8" r="1.5" /><path d="m3 17 5-5 4 4 3-3 6 6" /></>
+    case 'svg':
+      return <><path d="M7 5h10v4H7zM5 15h4v4H5zm10 0h4v4h-4zM12 9v4m-5 2v-2h10v2" /><circle cx="12" cy="13" r="1" /></>
+    case 'patch':
+      return <><path d="M6 3.5h8l4 4V20H6zM14 3.5v4h4M9 11h6m-3-3v6m-3 4h6" /></>
+    case 'folder':
+      return <><path d="M3 6.5h7l2 2h9v10.5H3z" /></>
+    case 'pdf':
+      return <><path d="M6 3.5h8l4 4V20H6zM14 3.5v4h4" /><path d="M8 16v-4h1.6a1.4 1.4 0 0 1 0 2.8H8m5.2 1.2v-4h1.2c1.6 0 2.6.8 2.6 2s-1 2-2.6 2h-1.2" /></>
+    case 'document':
+      return <><path d="M6 3.5h8l4 4V20H6zM14 3.5v4h4M9 11h6M9 14h6M9 17h4" /></>
+    case 'spreadsheet':
+      return <><rect x="4" y="4" width="16" height="16" rx="2" /><path d="M4 9h16M4 14h16M10 4v16M15 4v16" /></>
+    case 'presentation':
+      return <><rect x="4" y="4" width="16" height="13" rx="2" /><path d="M8 20h8M12 17v3M8 8h8M8 11h5" /></>
+    case 'notebook':
+      return <><path d="M6 4h12v16H6zM9 4v16M3.5 7H6M3.5 11H6M3.5 15H6" /><path d="m12 9-2 2 2 2m3-4 2 2-2 2" /></>
+    case 'archive':
+      return <><path d="M6 3.5h12V20H6zM9 3.5v3h3v3H9v3h3v3H9v3h3" /><path d="M12 16h3v3h-3z" /></>
+    case 'audio':
+      return <><path d="M9 18V7l9-2v11" /><circle cx="6.5" cy="18" r="2.5" /><circle cx="15.5" cy="16" r="2.5" /></>
+    case 'video':
+      return <><rect x="3" y="5" width="18" height="14" rx="2" /><path d="m10 9 5 3-5 3z" /></>
+    case 'database':
+      return <><ellipse cx="12" cy="6" rx="7" ry="3" /><path d="M5 6v6c0 1.7 3.1 3 7 3s7-1.3 7-3V6M5 12v6c0 1.7 3.1 3 7 3s7-1.3 7-3v-6" /></>
+    case 'executable':
+      return <><rect x="4" y="4" width="16" height="16" rx="3" /><path d="M8 9h8M8 15h8M9 8v8M15 8v8" /><circle cx="12" cy="12" r="2" /></>
+    case 'file':
+      return <><path d="M6 3.5h8l4 4V20H6zM14 3.5v4h4" /></>
+  }
+}
+
+export function ResourceReferenceIcon({
+  kind,
+  className,
+  fileType
+}: {
+  kind: ResourceReferenceVisualKind
+  className: string
+  fileType?: FilePreviewKind | 'file_change'
+}): React.JSX.Element {
+  const typeAttribute = fileType
+    ? { 'data-file-type': fileType }
+    : { 'data-resource-type': kind }
+  return (
+    <svg className={className} {...typeAttribute} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <ResourceReferenceGlyph kind={kind} />
+    </svg>
+  )
+}
+
+export function FileReferenceIcon({ rawReference }: { rawReference: string }): React.JSX.Element {
+  const kind = resourceReferenceVisualKind(rawReference)
+  return <ResourceReferenceIcon kind={kind} className="resource-reference-icon file-reference-icon" />
+}
 
 export function FilePreviewTabIcon({ kind }: { kind: FilePreviewKind | 'file_change' }): React.JSX.Element {
-  const glyph = kind === 'markdown'
-    ? <><path d="M3 3.5h6a3 3 0 0 1 3 3v14a4 4 0 0 0-4-2H3Zm18 0h-6a3 3 0 0 0-3 3v14a4 4 0 0 1 4-2h5Z" /></>
-    : kind === 'code'
-      ? <><path d="m8 7-5 5 5 5m8-10 5 5-5 5m-3-14-2 18" /></>
-      : kind === 'html'
-        ? <><rect x="3" y="4" width="18" height="16" rx="2" /><path d="M3 9h18M6 6.5h.01M9 6.5h.01m.5 6-2 2 2 2m5-4 2 2-2 2" /></>
-        : kind === 'image' || kind === 'svg'
-          ? <><rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="8" cy="8" r="1.5" /><path d="m3 17 5-5 4 4 3-3 6 6" /></>
-          : kind === 'patch' || kind === 'file_change'
-            ? <><path d="M5 3h9l5 5v13H5ZM14 3v5h5M8 11h6m-3-3v6m-3 3h6" /></>
-            : <><path d="M5 3h9l5 5v13H5ZM14 3v5h5M8 12h8m-8 4h6" /></>
-  return <svg className="file-preview-tab-icon" data-file-type={kind} viewBox="0 0 24 24" aria-hidden="true" focusable="false">{glyph}</svg>
+  const resourceKind: ResourceReferenceVisualKind = kind === 'file_change'
+    ? 'patch'
+    : kind === 'paged_text'
+      ? 'text'
+      : kind
+  return <ResourceReferenceIcon kind={resourceKind} className="file-preview-tab-icon" fileType={kind} />
 }

--- a/apps/desktop/src/renderer/src/FileReferenceLink.test.ts
+++ b/apps/desktop/src/renderer/src/FileReferenceLink.test.ts
@@ -14,20 +14,22 @@ const examples = [
 
 const renderers = [{
   name: 'user message text',
+  rendersWebLinks: false,
   render: (source: string) => renderToStaticMarkup(createElement(FileReferenceText, {
     text: source,
     onActivate: () => undefined
   }))
 }, {
   name: 'safe Markdown',
+  rendersWebLinks: true,
   render: (source: string) => renderToStaticMarkup(createElement(SafeMarkdown, {
     children: source,
     onFileReference: () => undefined
   }))
 }]
 
-describe.each(renderers)('file-link presentation in $name', ({ render }) => {
-  it('shows descriptions once, keeps targets in tooltips, and distinguishes code file links', () => {
+describe.each(renderers)('file-link presentation in $name', ({ render, rendersWebLinks }) => {
+  it('shows descriptions once, keeps relative targets in tooltips, and uses true file-type icons', () => {
     const markup = render(examples)
     const visibleText = markup.replace(/<[^>]*>/gu, '')
     expect(markup.match(/<a /gu)).toHaveLength(5)
@@ -44,14 +46,17 @@ describe.each(renderers)('file-link presentation in $name', ({ render }) => {
       expect(visibleText).not.toContain(`[${label}]`)
     }
     expect(markup.match(/class="(?:message|markdown)-file-reference inline-code-file-reference"/gu)).toHaveLength(1)
-    expect(markup.match(/<svg /gu)).toHaveLength(1)
+    expect(markup.match(/<svg /gu)).toHaveLength(5)
     expect(markup).toContain('aria-hidden="true"')
-    expect(markup).toContain('<span class="inline-code-file-reference-label">apps/desktop/src/renderer/src/FilePreviewPane.tsx:1</span>')
+    for (const kind of ['markdown', 'html', 'code', 'image', 'svg']) {
+      expect(markup).toContain(`data-resource-type="${kind}"`)
+    }
+    expect(markup).toContain('<span class="file-reference-label is-code">apps/desktop/src/renderer/src/FilePreviewPane.tsx:1</span>')
     expect(markup).not.toContain('<code>')
     expect(visibleText.match(/apps\/desktop\/src\/renderer\/src\/FilePreviewPane.tsx:1/gu)).toHaveLength(1)
   })
 
-  it('does not nest file links inside labels or web URLs, or activate code blocks', () => {
+  it('does not scan labels, code blocks, web URLs, or ordinary path-shaped prose as files', () => {
     const markup = render([
       '[src/label.ts](src/target.ts:20)',
       'https://example.com/src/remote.ts',
@@ -66,17 +71,19 @@ describe.each(renderers)('file-link presentation in $name', ({ render }) => {
       '请查看 src/bare.ts:20。'
     ].join('\n'))
     expect(markup).toContain('title="src/target.ts:20"')
-    expect(markup).toContain('title="src/bare.ts:20"')
+    expect(markup).not.toContain('title="src/bare.ts:20"')
     expect(markup).not.toContain('title="src/label.ts"')
     expect(markup).not.toContain('title="src/secret')
     expect(markup).not.toContain('title="https:')
-    expect(markup.match(/class="(?:message|markdown)-file-reference"/gu)).toHaveLength(2)
+    expect(markup.match(/class="(?:message|markdown)-file-reference"/gu)).toHaveLength(1)
+    expect(markup.match(/data-resource-type="web"/gu) ?? []).toHaveLength(rendersWebLinks ? 2 : 0)
   })
 
   it('keeps labels separate from targets with spaces, escapes and line fragments', () => {
     const markup = render('请看 [**规划** 与 `配置`](<docs/my plan.md#L3> "额外说明") 和 [Windows](C:/work/app.ts:20)。')
     expect(markup).toContain('title="docs/my plan.md#L3"')
-    expect(markup).toContain('title="C:/work/app.ts:20"')
+    expect(markup).not.toContain('title="C:/work/app.ts:20"')
+    expect(markup).toContain('data-resource-type="code"')
     const visibleText = markup.replace(/<[^>]*>/gu, '')
     expect(visibleText).toContain('规划 与 配置')
     expect(visibleText).not.toContain('docs/my plan.md')
@@ -85,8 +92,10 @@ describe.each(renderers)('file-link presentation in $name', ({ render }) => {
 
   it('keeps a visible name for empty labels and uses the same literal tilde rules', () => {
     const markup = render('[](src/app.ts) [~原样~](docs/plan.md)')
-    expect(markup).toContain('title="src/app.ts">src/app.ts</a>')
-    expect(markup).toContain('title="docs/plan.md">~原样~</a>')
+    expect(markup).toContain('title="src/app.ts"')
+    expect(markup).toContain('<span class="file-reference-label">src/app.ts</span>')
+    expect(markup).toContain('title="docs/plan.md"')
+    expect(markup).toContain('<span class="file-reference-label">~原样~</span>')
   })
 
   it('leaves field lists and unqualified filenames inert, and links a located short name only with a source', () => {

--- a/apps/desktop/src/renderer/src/FileReferenceLink.tsx
+++ b/apps/desktop/src/renderer/src/FileReferenceLink.tsx
@@ -1,7 +1,7 @@
 import { Children, isValidElement, useMemo, useRef, type JSX, type ReactNode } from 'react'
 import type { FileLocationTarget } from '@contracts'
 import { parseFileReference } from '../../file-preview-reference'
-import { FilePreviewTabIcon } from './FilePreviewTabIcon'
+import { FileReferenceIcon } from './FilePreviewTabIcon'
 import { projectMessageFileReferences } from './safe-markdown-model'
 
 export const FILE_REFERENCE_FRAGMENT = '#rovai-file-reference='
@@ -26,12 +26,13 @@ export function FileReferenceLink({
   const codeLabel = isValidElement<{ children?: ReactNode }>(onlyChild) && onlyChild.type === 'code'
     ? onlyChild
     : null
+  const parsedReference = parseFileReference(rawReference)
 
   return (
     <a
       className={codeLabel ? `${className} inline-code-file-reference` : className}
       href={`${FILE_REFERENCE_FRAGMENT}${encodeURIComponent(rawReference)}`}
-      title={rawReference}
+      title={parsedReference?.pathKind === 'relative' ? rawReference : undefined}
       onPointerDown={() => {
         const selection = window.getSelection()
         selectionAtPointerDown.current = selection?.rangeCount ? selection.getRangeAt(0).cloneRange() : null
@@ -54,12 +55,10 @@ export function FileReferenceLink({
       }}
       onAuxClick={(event) => event.preventDefault()}
     >
-      {codeLabel ? (
-        <>
-          <FilePreviewTabIcon kind="text" />
-          <span className="inline-code-file-reference-label">{codeLabel.props.children}</span>
-        </>
-      ) : children}
+      <FileReferenceIcon rawReference={rawReference} />
+      <span className={codeLabel ? 'file-reference-label is-code' : 'file-reference-label'}>
+        {codeLabel ? codeLabel.props.children : children}
+      </span>
     </a>
   )
 }

--- a/apps/desktop/src/renderer/src/SafeMarkdown.test.ts
+++ b/apps/desktop/src/renderer/src/SafeMarkdown.test.ts
@@ -4,19 +4,21 @@ import { describe, expect, it } from 'vitest'
 import { SafeMarkdown } from './SafeMarkdown'
 
 describe('SafeMarkdown file preview references', () => {
-  it('enables only explicit inline-code and high-confidence bare file references in file contexts', () => {
+  it('enables only explicit Markdown links and whole inline-code file references in file contexts', () => {
     const markup = renderToStaticMarkup(createElement(SafeMarkdown, {
       onFileReference: () => undefined,
-      children: '打开 `README.md` 或 ./src/app.ts:42。也可以点击 [`实现`](src/app.ts:4)。`Promise.all` 和 `sum()` 保持代码。\n\n```text\n./secret.txt\n```'
+      children: '打开 `README.md` 或 `./src/app.ts:42`。普通正文 ./src/bare.ts:42 保持文本。也可以点击 [`实现`](src/app.ts:4)。`Promise.all` 和 `sum()` 保持代码。\n\n```text\n./secret.txt\n```'
     }))
     expect(markup).not.toContain('title="README.md"')
     expect(markup).toContain('title="./src/app.ts:42"')
+    expect(markup).not.toContain('title="./src/bare.ts:42"')
     expect(markup).not.toContain('title="./secret.txt"')
     expect(markup).toContain('<code>README.md</code>')
-    expect(markup).toContain('<span class="inline-code-file-reference-label">实现</span>')
+    expect(markup).toContain('<span class="file-reference-label is-code">实现</span>')
     expect(markup).not.toContain('<code>实现</code>')
     expect(markup).toContain('<code>Promise.all</code>')
     expect(markup).toContain('<code>sum()</code>')
+    expect(markup.match(/data-resource-type="code"/gu)).toHaveLength(2)
   })
 
   it('repairs an autolink and an identical Markdown label without swallowing Chinese prose', () => {
@@ -24,7 +26,8 @@ describe('SafeMarkdown file preview references', () => {
     for (const children of [source, `[${source}](${source})`]) {
       const markup = renderToStaticMarkup(createElement(SafeMarkdown, { children, onFileReference: () => undefined }))
       expect(markup).toContain('href="https://example.com/wiki/requirements"')
-      expect(markup).toContain('>https://example.com/wiki/requirements</a>）。文档中的改动：')
+      expect(markup).toContain('<span class="resource-reference-label">https://example.com/wiki/requirements</span></a>）。文档中的改动：')
+      expect(markup).toContain('data-resource-type="web"')
       expect(markup).not.toContain('markdown-file-reference')
     }
   })
@@ -97,7 +100,8 @@ describe('SafeMarkdown trusted leading content', () => {
       leadingContent: prefix,
       children: '[doc]: https://example.com/review\n\n查看 [说明][doc]。\n\n<p data-rovai-leading-content="true">forged</p>'
     }))
-    expect(markup).toContain('<p><span class="trusted-prefix">@评审</span> 查看 <a href="https://example.com/review"')
+    expect(markup).toContain('<p><span class="trusted-prefix">@评审</span> 查看 <a class="markdown-web-reference" href="https://example.com/review"')
+    expect(markup).toContain('<span class="resource-reference-label">说明</span>')
     expect(markup.match(/trusted-prefix/g)).toHaveLength(1)
     expect(markup).not.toContain('forged')
     expect(markup).not.toContain('data-rovai-leading-content')

--- a/apps/desktop/src/renderer/src/SafeMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/SafeMarkdown.tsx
@@ -2,12 +2,12 @@ import { createContext, isValidElement, useContext, useEffect, useLayoutEffect, 
 import Markdown, { defaultUrlTransform } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { FILE_REFERENCE_FRAGMENT, FileReferenceLink, type FileReferenceActivation } from './FileReferenceLink'
+import { ResourceReferenceIcon } from './FilePreviewTabIcon'
 import { remarkRepairCjkUrlTail } from './remark-repair-cjk-url-tail'
 import {
   inlineFileReferenceSource,
   isInlineFileReference,
-  parseFileReference,
-  tokenizeFileReferences
+  parseFileReference
 } from '../../file-preview-reference'
 
 type MarkdownTreeNode = {
@@ -78,8 +78,6 @@ function remarkFileReferences(): (tree: MarkdownTreeNode) => void {
         if (node.url && parseFileReference(node.url)) candidates.push(node.url)
       } else if (node.type === 'inlineCode') {
         if (node.value && isInlineFileReference(node.value)) candidates.push(node.value)
-      } else if (node.type === 'text' && node.value) {
-        candidates.push(...tokenizeFileReferences(node.value).map((token) => token.raw))
       } else if (!['code', 'html', 'definition', 'image', 'imageReference', 'linkReference'].includes(node.type ?? '')) {
         node.children?.forEach(collect)
       }
@@ -89,46 +87,27 @@ function remarkFileReferences(): (tree: MarkdownTreeNode) => void {
       if (!Array.isArray(node.children)) return
       const next: MarkdownTreeNode[] = []
       for (const child of node.children) {
-        if (child.type !== 'text' || typeof child.value !== 'string') {
-          if (child.type === 'link' && typeof child.url === 'string' && parseFileReference(child.url)) {
-            next.push({ ...child, url: `${FILE_REFERENCE_FRAGMENT}${encodeURIComponent(child.url)}` })
-            continue
-          }
-          if (
-            child.type === 'inlineCode'
-            && typeof child.value === 'string'
-            && inlineFileReferenceSource(child.value, candidates) !== null
-          ) {
-            const sourceReference = inlineFileReferenceSource(child.value, candidates)!
-            next.push({
-              type: 'link',
-              url: `${FILE_REFERENCE_FRAGMENT}${encodeURIComponent(child.value)}`,
-              ...(sourceReference !== child.value
-                ? { data: { hProperties: { 'data-file-source-reference': sourceReference } } } : {}),
-              children: [{ type: 'inlineCode', value: child.value }]
-            })
-            continue
-          }
-          if (child.type !== 'link' && child.type !== 'inlineCode' && child.type !== 'code') visit(child)
-          next.push(child)
+        if (child.type === 'link' && typeof child.url === 'string' && parseFileReference(child.url)) {
+          next.push({ ...child, url: `${FILE_REFERENCE_FRAGMENT}${encodeURIComponent(child.url)}` })
           continue
         }
-        const tokens = tokenizeFileReferences(child.value)
-        if (tokens.length === 0) {
-          next.push(child)
-          continue
-        }
-        let offset = 0
-        for (const token of tokens) {
-          if (token.start > offset) next.push({ type: 'text', value: child.value.slice(offset, token.start) })
+        if (
+          child.type === 'inlineCode'
+          && typeof child.value === 'string'
+          && inlineFileReferenceSource(child.value, candidates) !== null
+        ) {
+          const sourceReference = inlineFileReferenceSource(child.value, candidates)!
           next.push({
             type: 'link',
-            url: `${FILE_REFERENCE_FRAGMENT}${encodeURIComponent(token.raw)}`,
-            children: [{ type: 'text', value: token.raw }]
+            url: `${FILE_REFERENCE_FRAGMENT}${encodeURIComponent(child.value)}`,
+            ...(sourceReference !== child.value
+              ? { data: { hProperties: { 'data-file-source-reference': sourceReference } } } : {}),
+            children: [{ type: 'inlineCode', value: child.value }]
           })
-          offset = token.end
+          continue
         }
-        if (offset < child.value.length) next.push({ type: 'text', value: child.value.slice(offset) })
+        if (child.type !== 'link' && child.type !== 'inlineCode' && child.type !== 'code') visit(child)
+        next.push(child)
       }
       node.children = next
     }
@@ -256,8 +235,9 @@ export function SafeMarkdown({
               return <code className="markdown-inert-link">{linkChildren}</code>
             }
             return (
-              <a href={href} target="_blank" rel="noreferrer noopener">
-                {linkChildren}
+              <a className="markdown-web-reference" href={href} target="_blank" rel="noreferrer noopener">
+                <ResourceReferenceIcon kind="web" className="resource-reference-icon web-reference-icon" />
+                <span className="resource-reference-label">{linkChildren}</span>
               </a>
             )
           },

--- a/apps/desktop/src/renderer/src/file-reference-presentation.test.ts
+++ b/apps/desktop/src/renderer/src/file-reference-presentation.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { resourceReferenceVisualKind, type ResourceReferenceVisualKind } from './file-reference-presentation'
+
+describe('resource-reference visual classification', () => {
+  it.each<[string, ResourceReferenceVisualKind]>([
+    ['https://example.com/docs/app.ts', 'web'],
+    ['docs/README.md#L20-L24', 'markdown'],
+    ['prototype/index.HTML?theme=night', 'html'],
+    ['src/App.tsx:20:4', 'code'],
+    ['~/.config/rovai/config.toml', 'config'],
+    ['logs/runtime.log', 'text'],
+    ['assets/camp.webp', 'image'],
+    ['build/icon.svg', 'svg'],
+    ['changes/review.diff', 'patch'],
+    ['docs/prototypes/demo/', 'folder'],
+    ['docs/spec.pdf', 'pdf'],
+    ['handoff.docx', 'document'],
+    ['results.xlsx', 'spreadsheet'],
+    ['review.pptx', 'presentation'],
+    ['analysis.ipynb', 'notebook'],
+    ['artifacts/source.tar.gz', 'archive'],
+    ['recordings/note.m4a', 'audio'],
+    ['recordings/demo.mp4', 'video'],
+    ['state/rovai.sqlite3', 'database'],
+    ['release/Rovai.dmg', 'executable'],
+    ['artifacts/unknown.bin', 'file']
+  ])('classifies %s as %s', (target, expected) => {
+    expect(resourceReferenceVisualKind(target)).toBe(expected)
+  })
+
+  it('removes line ranges, fragments, and queries before classifying', () => {
+    expect(resourceReferenceVisualKind('src/main.rs:44-46')).toBe('code')
+    expect(resourceReferenceVisualKind('docs/guide.mdx#L2-L8')).toBe('markdown')
+    expect(resourceReferenceVisualKind('assets/icon.svg?raw=1#preview')).toBe('svg')
+    expect(resourceReferenceVisualKind('C:\\work\\settings.json:10:2')).toBe('config')
+  })
+})

--- a/apps/desktop/src/renderer/src/file-reference-presentation.ts
+++ b/apps/desktop/src/renderer/src/file-reference-presentation.ts
@@ -1,0 +1,80 @@
+import { parseFileReference } from '../../file-preview-reference'
+
+export type ResourceReferenceVisualKind =
+  | 'web'
+  | 'markdown'
+  | 'html'
+  | 'code'
+  | 'config'
+  | 'text'
+  | 'image'
+  | 'svg'
+  | 'patch'
+  | 'folder'
+  | 'pdf'
+  | 'document'
+  | 'spreadsheet'
+  | 'presentation'
+  | 'notebook'
+  | 'archive'
+  | 'audio'
+  | 'video'
+  | 'database'
+  | 'executable'
+  | 'file'
+
+const EXTENSION_KINDS: Readonly<Record<string, ResourceReferenceVisualKind>> = {
+  md: 'markdown', markdown: 'markdown', mdown: 'markdown', mkd: 'markdown', mdx: 'markdown',
+  html: 'html', htm: 'html',
+  ts: 'code', tsx: 'code', mts: 'code', cts: 'code', js: 'code', jsx: 'code', mjs: 'code', cjs: 'code',
+  py: 'code', pyw: 'code', pyi: 'code', rb: 'code', rake: 'code', php: 'code', lua: 'code', rs: 'code',
+  go: 'code', java: 'code', kt: 'code', kts: 'code', swift: 'code', dart: 'code', c: 'code', h: 'code',
+  cc: 'code', cpp: 'code', cxx: 'code', hh: 'code', hpp: 'code', hxx: 'code', cs: 'code', m: 'code', mm: 'code',
+  sh: 'code', bash: 'code', zsh: 'code', fish: 'code', ps1: 'code', psm1: 'code', bat: 'code', cmd: 'code',
+  css: 'code', scss: 'code', sass: 'code', less: 'code', vue: 'code', svelte: 'code', hbs: 'code',
+  handlebars: 'code', pug: 'code', sql: 'code', pgsql: 'code', graphql: 'code', gql: 'code', cypher: 'code',
+  tf: 'code', tfvars: 'code', hcl: 'code', proto: 'code',
+  json: 'config', jsonc: 'config', json5: 'config', yaml: 'config', yml: 'config', toml: 'config', env: 'config',
+  ini: 'config', cfg: 'config', conf: 'config', properties: 'config', xml: 'config', xsd: 'config', xsl: 'config',
+  plist: 'config',
+  txt: 'text', log: 'text', csv: 'text', tsv: 'text',
+  png: 'image', jpg: 'image', jpeg: 'image', gif: 'image', webp: 'image', avif: 'image', bmp: 'image',
+  ico: 'image', tif: 'image', tiff: 'image', heic: 'image',
+  svg: 'svg',
+  diff: 'patch', patch: 'patch',
+  pdf: 'pdf',
+  doc: 'document', docx: 'document', odt: 'document', rtf: 'document',
+  xls: 'spreadsheet', xlsx: 'spreadsheet', ods: 'spreadsheet',
+  ppt: 'presentation', pptx: 'presentation', odp: 'presentation',
+  ipynb: 'notebook',
+  zip: 'archive', tar: 'archive', gz: 'archive', tgz: 'archive', bz2: 'archive', xz: 'archive', '7z': 'archive', rar: 'archive',
+  mp3: 'audio', m4a: 'audio', wav: 'audio', flac: 'audio', aac: 'audio', ogg: 'audio', opus: 'audio',
+  mp4: 'video', mov: 'video', mkv: 'video', avi: 'video', webm: 'video', m4v: 'video',
+  sqlite: 'database', sqlite3: 'database', db: 'database',
+  app: 'executable', dmg: 'executable', pkg: 'executable', exe: 'executable', msi: 'executable', deb: 'executable',
+  rpm: 'executable', apk: 'executable'
+}
+
+const CONFIG_FILE_NAMES = new Set([
+  '.editorconfig', '.env', '.gitattributes', '.gitignore', '.npmrc', '.prettierrc',
+  'dockerfile', 'makefile'
+])
+
+function fallbackPath(target: string): string {
+  return target
+    .replace(/[?#].*$/u, '')
+    .replace(/:(?:[1-9]\d*)(?::[1-9]\d*|-[1-9]\d*)?$/u, '')
+}
+
+export function resourceReferenceVisualKind(target: string): ResourceReferenceVisualKind {
+  const trimmed = target.trim()
+  if (/^https:\/\//iu.test(trimmed)) return 'web'
+
+  const path = parseFileReference(trimmed)?.pathPart ?? fallbackPath(trimmed)
+  if (/[\\/]$/u.test(path)) return 'folder'
+
+  const fileName = path.replace(/\\/gu, '/').split('/').at(-1)?.toLowerCase() ?? ''
+  if (CONFIG_FILE_NAMES.has(fileName) || fileName.startsWith('.env.')) return 'config'
+  const extension = fileName.includes('.') ? fileName.split('.').at(-1) ?? '' : ''
+  return EXTENSION_KINDS[extension] ?? 'file'
+}

--- a/apps/desktop/src/renderer/src/safe-markdown-model.test.ts
+++ b/apps/desktop/src/renderer/src/safe-markdown-model.test.ts
@@ -46,7 +46,11 @@ describe('message file-reference projection', () => {
       '',
       '外部 src/visible.ts:20'
     ].join('\n')
-    expect(projectMessageFileReferences(source).map((reference) => reference.rawReference)).toEqual(['src/visible.ts:20'])
+    expect(projectMessageFileReferences(source)).toEqual([])
+  })
+
+  it('does not scan ordinary message text for path-shaped prose', () => {
+    expect(projectMessageFileReferences('src/App.tsx:20 /compact docs/prototypes/demo/')).toEqual([])
   })
 
   it('does not interpret ordinary prose, unsafe URLs, inline code or incomplete code fences as files', () => {

--- a/apps/desktop/src/renderer/src/safe-markdown-model.ts
+++ b/apps/desktop/src/renderer/src/safe-markdown-model.ts
@@ -2,7 +2,7 @@ export * from '../../shared/execution-presentation/safe-markdown-model'
 import remarkGfm from 'remark-gfm'
 import remarkParse from 'remark-parse'
 import { unified } from 'unified'
-import { inlineFileReferenceSource, isInlineFileReference, parseFileReference, tokenizeFileReferences } from '../../file-preview-reference'
+import { inlineFileReferenceSource, isInlineFileReference, parseFileReference } from '../../file-preview-reference'
 
 type MarkdownNode = {
   type?: unknown
@@ -61,18 +61,6 @@ export function projectMessageFileReferences(source: string): MessageFileReferen
       if (typeof start === 'number' && typeof end === 'number'
         && typeof node.value === 'string' && isInlineFileReference(node.value)) {
         references.push({ start, end, rawReference: node.value, label: node.value, inlineCode: true })
-      }
-      return
-    }
-    if (node.type === 'text' && typeof start === 'number' && typeof end === 'number') {
-      for (const token of tokenizeFileReferences(source.slice(start, end))) {
-        references.push({
-          start: start + token.start,
-          end: start + token.end,
-          rawReference: token.raw,
-          label: token.raw,
-          inlineCode: false
-        })
       }
       return
     }

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1869,9 +1869,14 @@ html.file-preview-resizing .file-preview-pane { pointer-events: none; }
 .file-preview-markdown { width: 100%; overflow: auto; overscroll-behavior: contain; padding: 26px clamp(24px, 6vw, 68px) 54px; }
 .file-preview-markdown .safe-markdown { max-width: 780px; margin: 0 auto; font-size: 13px; line-height: 1.72; }
 .file-preview-markdown .safe-markdown img { display: block; max-width: 100%; height: auto; margin: 18px auto; border-radius: 7px; box-shadow: var(--shadow-card); }
-.markdown-file-reference,
+.safe-markdown .markdown-file-reference,
+.safe-markdown .markdown-web-reference,
 .message-file-reference {
-  display: inline;
+  display: inline-flex;
+  max-width: 100%;
+  min-width: 0;
+  align-items: baseline;
+  gap: .28em;
   padding: 0;
   border: 0;
   color: var(--resource-link);
@@ -1879,36 +1884,48 @@ html.file-preview-resizing .file-preview-pane { pointer-events: none; }
   font: inherit;
   text-decoration: underline;
   text-decoration-color: color-mix(in srgb, currentColor 45%, transparent);
+  text-decoration-thickness: 1px;
   text-underline-offset: 2px;
   overflow-wrap: anywhere;
+  vertical-align: baseline;
   cursor: pointer;
 }
-.markdown-file-reference:hover,
+.safe-markdown .markdown-file-reference:hover,
+.safe-markdown .markdown-web-reference:hover,
 .message-file-reference:hover { color: var(--resource-link-hover); text-decoration-color: currentColor; }
-.markdown-file-reference:focus-visible,
+.safe-markdown .markdown-file-reference:focus-visible,
+.safe-markdown .markdown-web-reference:focus-visible,
 .message-file-reference:focus-visible { border-radius: 2px; outline: 2px solid var(--focus); outline-offset: 2px; }
-.markdown-file-reference.inline-code-file-reference,
+.safe-markdown .markdown-file-reference.inline-code-file-reference,
 .message-file-reference.inline-code-file-reference {
-  font: .9em/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
   text-decoration: none;
 }
-.inline-code-file-reference .file-preview-tab-icon {
-  display: inline-block;
-  width: 1em;
-  height: 1em;
-  margin-right: .28em;
-  vertical-align: -.12em;
+.resource-reference-icon {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 14px;
+  align-self: baseline;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.5;
+  transform: translateY(2px);
+  opacity: .84;
 }
+.file-reference-label,
+.resource-reference-label { min-width: 0; overflow-wrap: anywhere; }
+.file-reference-label.is-code { font: .9em/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
 .inline-code-file-reference:hover,
 .inline-code-file-reference:active { color: var(--resource-link-hover); }
-.inline-code-file-reference:hover .inline-code-file-reference-label {
+.inline-code-file-reference:hover .file-reference-label {
   text-decoration-line: underline;
-  text-decoration-style: dashed;
+  text-decoration-style: dotted;
   text-decoration-thickness: 1px;
   text-underline-offset: 3px;
 }
-.inline-code-file-reference:active .inline-code-file-reference-label,
-.inline-code-file-reference:focus-visible .inline-code-file-reference-label { text-decoration: none; }
+.inline-code-file-reference:active .file-reference-label,
+.inline-code-file-reference:focus-visible .file-reference-label { text-decoration: none; }
 .file-preview-inline-error { max-width: 780px; margin: 0 auto 12px; color: var(--danger); font-size: 10px; }
 .file-preview-html-stage { position: relative; width: 100%; min-width: 0; min-height: 0; }
 .file-preview-html { width: 100%; height: 100%; border: 0; background: var(--conversation-surface); }
@@ -3067,9 +3084,7 @@ button.camp-world-map-live-caption { cursor: pointer; font: inherit; }
 .safe-markdown li + li { margin-top: 3px; }
 .safe-markdown blockquote { margin: 8px 0; padding: 3px 10px; border-left: 3px solid var(--line-strong); color: var(--muted); }
 .safe-markdown pre { max-width: 100%; margin: 9px 0; overflow: auto; padding: 9px 10px; border: 1px solid var(--evidence-line); border-radius: 6px; color: var(--evidence-ink); background: var(--code-block-canvas); font: 11px/1.55 ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre; }
-.message-file-reference code,
 .safe-markdown code { padding: 0 2px; border-radius: 3px; color: var(--evidence-ink); background: var(--inline-code-canvas); font: .9em/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
-.message-file-reference code,
 .safe-markdown .markdown-file-reference code { color: inherit; }
 .safe-markdown pre code { padding: 0; background: transparent; font-size: inherit; }
 .safe-markdown table { display: block; width: 100%; margin: 9px 0; overflow-x: auto; border-spacing: 0; border-collapse: collapse; font-size: 11px; }

--- a/docs/ui/components/file-preview.md
+++ b/docs/ui/components/file-preview.md
@@ -2,7 +2,7 @@
 document_type: ui-component-contract
 authority: renderer-file-preview
 status: accepted
-last_updated: 2026-08-31
+last_updated: 2026-09-03
 ---
 
 # Camp 文件预览区
@@ -14,15 +14,26 @@ last_updated: 2026-08-31
 轻下划线，Hover 加强下划线；键盘焦点使用既有 focus token，长路径可自然换行，不让正文横向溢出。
 
 - Markdown 文件链接 `[label](target)` 只显示可点击的 label；target 仅用于解析/打开，不在正文中重复常驻展示。
-- 文件链接的整个 label 为 inline-code 时，显示通用文件 SVG 与一份等宽文字，移除灰底和嵌套 `<code>`。
-  默认无下划线，Hover 加强链接色并仅为文字显示 1px 虚线底线，按下或键盘焦点时不显示底线；不记录“已打开”状态。
-  普通 inline-code、代码块、混合格式 label 和其他链接的结构与交互保持原样；裸路径继续按高置信度规则识别。
-- 链接 title 显示完整原始 target，包括行列或 fragment。复制路径与显示所在位置继续使用文件 Tab 的既有上下文菜单。
+- 整体为文件引用的 inline-code（如 `` `src/App.tsx:20` ``）成为文件入口。其等宽文字移除灰底和嵌套
+  `<code>`，默认无下划线；Hover 加强链接色并只为文字显示 1px 点状下划线，按下或键盘焦点时不显示下划线。
+  普通 inline-code、代码块和混合正文保持原样。
+- 普通正文不扫描、不猜测本地路径。`src/App.tsx:20`、`/compact` 与 `docs/prototypes/demo/` 只有在显式
+  Markdown 文件链接或整体 inline-code 中才可能成为文件入口；消息存储、整条消息复制与模型输入保持原文。
+- 每个文件入口在 label 前显示真实资源类型的 14px 单色线性 SVG，不再由 label 是否为 inline-code 决定是否显示。
+  类型至少区分 Markdown、HTML、代码、配置/数据、文本、图片、SVG、Diff/Patch、目录、PDF、文档、表格、
+  演示文稿、Notebook、压缩包、音频、视频、数据库、可执行/安装包和未知文件。不支持应用内预览的格式仍保留
+  真实类型图标，再交给系统默认应用打开。
+- HTTPS Markdown 链接与 GFM 自动链接都在 label 前显示统一网页图标；inline-code 中的 `https://` 仍是普通代码。
+  文件与网页图标均为装饰元素，对辅助技术隐藏，使用 `currentColor` 与链接文字同步变色，不用颜色区分资源类别。
+- 普通 Markdown label 使用 UI 字体；文件 inline-code 使用等宽字体。所有资源链接使用相同的 icon + label DOM
+  顺序，不嵌套第二层代码背景块。
+- 项目相对 target 可以通过 title 显示完整原始值（含行列或 fragment）；绝对 target 不增加 tooltip 或在正文中
+  重复展示。复制路径与显示所在位置继续使用文件 Tab 的既有上下文菜单。
 - 普通点击与键盘激活不受页面已有选区影响；只有本次指针操作新产生或改变的文字选区才阻止文件打开。
   不主动清除用户选区，保留拖选与系统复制行为。
-- 文件引用按 Markdown 语法节点识别，不拆开普通 URL、链接 label、图片、代码块或其他非文件 inline-code；
+- 文件引用只按 Markdown link 与整体 inline-code 语法节点识别，不拆开普通 URL、链接 label、图片、代码块或正文；
   用户消息其余文本、结构化 Mention/Skill、消息存储、整条消息复制与模型输入保持原合同。
-- 无路径的裸文件名不自动生成链接；字段列表中的斜杠不作为绝对路径起点。带行号短名仅在同条消息存在唯一
+- 无路径的文件名不自动生成链接；字段列表中的斜杠不作为绝对路径起点。带行号短名仅在同条消息存在唯一
   明确路径时复用该引用，不猜测文件目录；显式 Markdown 文件链接继续表达作者的链接意图。
 - 点击继续使用既有来源校验，打开/激活文件 Tab；同一文件去重，支持 `:44-46` 行范围，定位起始行并高亮范围。
   最终定位到具体普通文件后，无论位于 Camp 工作区内外，都直接进入相同 Preview；绝对路径、`~/`、本机 file URI、

--- a/scripts/fixtures/file-reference-navigation/main.cjs
+++ b/scripts/fixtures/file-reference-navigation/main.cjs
@@ -157,7 +157,7 @@ app.whenReady().then(async () => {
   }
   await check('dragging text inside a link does not open it, but a later single click does', async () => {
     const before = await state()
-    await selectText(`${locatedLink} .inline-code-file-reference-label`)
+    await selectText(`${locatedLink} .file-reference-label.is-code`)
     assert.equal((await state()).opens.length, before.opens.length)
     const after = await click(locatedLink)
     assert.equal(after.opens.length, before.opens.length + 1)

--- a/scripts/fixtures/file-reference-navigation/renderer.tsx
+++ b/scripts/fixtures/file-reference-navigation/renderer.tsx
@@ -56,7 +56,8 @@ const prose = '这段较长的历史消息用于验证文件预览改变会话�
 const targetBody = [
   '主实现 `src/report/run_report.py`。',
   ...Array.from({ length: 12 }, (_, index) => `段落 ${index + 1}：${prose}`),
-  '完整路径 src/report/run_report.py。',
+  '显式入口：[主实现](src/report/run_report.py)。',
+  '普通正文 src/report/run_report.py 保持文本。',
   '外部配置：[config.toml](../outside/config.toml)。',
   '定位 `run_report.py:44-46`，这里是当前阅读位置。',
   'WBS(外码)/WBS描述/成本中心/FBP/GR-手工金额；心/FBP）有值；`run_gr_reminder.py`。',


### PR DESCRIPTION
## Summary

- recognize local files only through explicit Markdown links or whole inline-code references, leaving path-shaped prose inert
- add production-colored resource-type icons for files and a unified web icon for HTTPS Markdown/GFM links
- preserve relative-only tooltips, existing safe open behavior, accessibility semantics, and user-message plain-text contracts
- update the file-preview UI contract, unit coverage, and real Electron navigation fixture

## Validation

- `pnpm typecheck`
- `pnpm test` — 138 test files / 1456 Vitest tests passed; Node suites passed with one existing platform skip
- `DOCS_BASE_REF=b9870c0c28b2487ddfac723fe2e932c0e3fabfac pnpm docs:check:ci`
- `pnpm build:desktop`
- `ELECTRON_DISABLE_SANDBOX=1 pnpm test:file-reference-navigation`
- `ELECTRON_DISABLE_SANDBOX=1 pnpm test:file-preview-layout`
- isolated development App visual QA with mock Camp data; reviewed by the user
