### PR TITLE
fix(runtime): remove display-only compaction hooks

### DIFF
--- a/crates/rovai-core/src/acp.rs
+++ b/crates/rovai-core/src/acp.rs
@@ -1263,21 +1263,6 @@ impl AcpHost {
                 .map(BuiltinToolProcessConfig::run_tmp),
         )
         .context("failed to configure ACP Runtime command")?;
-        #[cfg(unix)]
-        if frozen_runtime.adapter_kind == AdapterKind::CursorAgent
-            && let (Some(private_config_root), Some(builtin_tools)) =
-                (private_config_root, builtin_tools.as_ref())
-            && let Err(error) = configure_cursor_compaction_display_hook(
-                &mut command,
-                private_config_root,
-                builtin_tools,
-                cwd,
-            )
-        {
-            eprintln!(
-                "Cursor compaction display Hook is unavailable; Runtime startup continues: {error:#}"
-            );
-        }
         let detector_config_root = if compaction_detector_policy
             == CompactionDetectorPolicy::BestEffort
         {
@@ -4163,13 +4148,6 @@ fn prepare_private_host_config(
                 .join(uuid::Uuid::new_v4().to_string()),
             true,
         ),
-        #[cfg(unix)]
-        AdapterKind::CursorAgent => (
-            private_runtime_dir
-                .join("acp-host")
-                .join(uuid::Uuid::new_v4().to_string()),
-            true,
-        ),
         _ => return Ok(None),
     };
     std::fs::create_dir_all(&root).with_context(|| {
@@ -5150,140 +5128,6 @@ fn append_opencode_compaction_plugin(config: &mut Value, plugin_path: &Path) -> 
         .as_array_mut()
         .context("OpenCode Runtime config plugins must be an array")?;
     plugins.push(Value::String(plugin_path.to_string_lossy().into_owned()));
-    Ok(())
-}
-
-#[cfg(unix)]
-fn configure_cursor_compaction_display_hook(
-    command: &mut Command,
-    private_config_root: &Path,
-    builtin_tools: &BuiltinToolProcessConfig,
-    runtime_cwd: &Path,
-) -> Result<()> {
-    let source_config_root = cursor_user_config_root(runtime_cwd)?;
-    let hook_command = format!(
-        "{} __compaction-display-hook --adapter-kind cursor-agent --source-signal preCompact",
-        quote_posix_shell_word(&builtin_tools.cli_executable().to_string_lossy())
-    );
-    prepare_cursor_private_config(&source_config_root, private_config_root, &hook_command)?;
-    command.env("CURSOR_CONFIG_DIR", private_config_root);
-    Ok(())
-}
-
-#[cfg(unix)]
-fn cursor_user_config_root(runtime_cwd: &Path) -> Result<PathBuf> {
-    if let Some(configured) = std::env::var_os("CURSOR_CONFIG_DIR") {
-        return resolve_runtime_config_root(configured, runtime_cwd);
-    }
-    #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"))]
-    if let Some(configured) = std::env::var_os("XDG_CONFIG_HOME") {
-        return Ok(resolve_runtime_config_root(configured, runtime_cwd)?.join("cursor"));
-    }
-    Ok(
-        PathBuf::from(std::env::var_os("HOME").context("Cursor Runtime has no home directory")?)
-            .join(".cursor"),
-    )
-}
-
-#[cfg(unix)]
-fn resolve_runtime_config_root(configured: OsString, runtime_cwd: &Path) -> Result<PathBuf> {
-    let configured = PathBuf::from(configured);
-    if configured.is_absolute() {
-        return Ok(configured);
-    }
-    if configured == Path::new("~") {
-        return Ok(PathBuf::from(
-            std::env::var_os("HOME").context("Runtime has no home directory")?,
-        ));
-    }
-    if let Ok(relative_to_home) = configured.strip_prefix("~/") {
-        return Ok(PathBuf::from(
-            std::env::var_os("HOME").context("Runtime has no home directory")?,
-        )
-        .join(relative_to_home));
-    }
-    Ok(runtime_cwd.join(configured))
-}
-
-#[cfg(unix)]
-fn prepare_cursor_private_config(
-    source_config_root: &Path,
-    private_config_root: &Path,
-    hook_command: &str,
-) -> Result<()> {
-    use std::os::unix::fs::symlink;
-
-    if source_config_root.exists() && !source_config_root.is_dir() {
-        bail!(
-            "Cursor user configuration root is not a directory: {}",
-            source_config_root.display()
-        );
-    }
-    std::fs::create_dir_all(private_config_root).with_context(|| {
-        format!(
-            "failed to create private Cursor configuration {}",
-            private_config_root.display()
-        )
-    })?;
-    restrict_private_directory(private_config_root)?;
-    if source_config_root.is_dir() {
-        for entry in std::fs::read_dir(source_config_root)? {
-            let entry = entry?;
-            if entry.file_name() == "hooks.json" {
-                continue;
-            }
-            symlink(entry.path(), private_config_root.join(entry.file_name())).with_context(
-                || {
-                    format!(
-                        "failed to project Cursor user configuration {}",
-                        entry.path().display()
-                    )
-                },
-            )?;
-        }
-    }
-    let hooks_path = source_config_root.join("hooks.json");
-    let mut hooks = if hooks_path.exists() {
-        let text = std::fs::read_to_string(&hooks_path)
-            .with_context(|| format!("failed to read {}", hooks_path.display()))?;
-        serde_json::from_str(&text)
-            .with_context(|| format!("invalid Cursor hooks {}", hooks_path.display()))?
-    } else {
-        json!({"version": 1})
-    };
-    append_cursor_pre_compact_display_hook(&mut hooks, hook_command)?;
-    write_private_json_file(&private_config_root.join("hooks.json"), &hooks)
-}
-
-#[cfg(unix)]
-fn append_cursor_pre_compact_display_hook(
-    hooks_config: &mut Value,
-    hook_command: &str,
-) -> Result<()> {
-    let config = hooks_config
-        .as_object_mut()
-        .context("Cursor hooks configuration must be a JSON object")?;
-    match config.get("version") {
-        Some(Value::Number(version)) if version.as_u64() == Some(1) => {}
-        Some(_) => bail!("Cursor hooks configuration version is unsupported"),
-        None => {
-            config.insert("version".to_string(), json!(1));
-        }
-    }
-    let hooks = config
-        .entry("hooks")
-        .or_insert_with(|| json!({}))
-        .as_object_mut()
-        .context("Cursor hooks must be a JSON object")?;
-    let pre_compact = hooks
-        .entry("preCompact")
-        .or_insert_with(|| json!([]))
-        .as_array_mut()
-        .context("Cursor preCompact hooks must be an array")?;
-    pre_compact.push(json!({
-        "command": hook_command,
-        "timeout": 3
-    }));
     Ok(())
 }
 
@@ -9877,7 +9721,7 @@ while IFS= read -r ignored; do :; done
     }
 
     #[test]
-    fn private_host_config_is_created_for_runtime_owned_overlays_only() {
+    fn private_host_config_is_created_only_for_kiro() {
         let root = std::env::temp_dir().join(format!(
             "rovai-private-host-config-{}",
             uuid::Uuid::new_v4()
@@ -9892,77 +9736,17 @@ while IFS= read -r ignored; do :; done
         assert!(kiro_one.remove_on_shutdown);
         assert!(kiro_two.remove_on_shutdown);
 
-        #[cfg(unix)]
-        {
-            let cursor = prepare_private_host_config(&root, AdapterKind::CursorAgent)
+        assert!(
+            prepare_private_host_config(&root, AdapterKind::CursorAgent)
                 .unwrap()
-                .unwrap();
-            assert_ne!(cursor.root, kiro_one.root);
-            assert!(cursor.remove_on_shutdown);
-        }
-
+                .is_none()
+        );
         assert!(
             prepare_private_host_config(&root, AdapterKind::KimiCodeCli)
                 .unwrap()
                 .is_none()
         );
         assert!(!root.join("home").exists());
-
-        std::fs::remove_dir_all(root).unwrap();
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn cursor_private_config_preserves_user_entries_and_appends_display_hook() {
-        let root = std::env::temp_dir().join(format!(
-            "rovai-cursor-compaction-hook-{}",
-            uuid::Uuid::new_v4()
-        ));
-        let source = root.join("source");
-        let private = root.join("private");
-        std::fs::create_dir_all(source.join("hooks")).unwrap();
-        std::fs::write(
-            source.join("cli-config.json"),
-            r#"{"version":1,"editor":{"vimMode":false},"permissions":{"allow":[],"deny":[]}}"#,
-        )
-        .unwrap();
-        std::fs::write(source.join("hooks").join("audit.sh"), "exit 0\n").unwrap();
-        std::fs::write(
-            source.join("hooks.json"),
-            r#"{"version":1,"hooks":{"preCompact":[{"command":"./hooks/audit.sh"}],"stop":[{"command":"./hooks/audit.sh"}]}}"#,
-        )
-        .unwrap();
-
-        prepare_cursor_private_config(
-            &source,
-            &private,
-            "'/tmp/Rovai CLI' __compaction-display-hook --adapter-kind cursor-agent --source-signal preCompact",
-        )
-        .unwrap();
-
-        let hooks: Value =
-            serde_json::from_slice(&std::fs::read(private.join("hooks.json")).unwrap()).unwrap();
-        assert_eq!(hooks["hooks"]["preCompact"].as_array().unwrap().len(), 2);
-        assert_eq!(hooks["hooks"]["stop"].as_array().unwrap().len(), 1);
-        assert_eq!(hooks["hooks"]["preCompact"][1]["timeout"], 3);
-        assert!(
-            hooks["hooks"]["preCompact"][1]["command"]
-                .as_str()
-                .unwrap()
-                .contains("__compaction-display-hook")
-        );
-        assert!(
-            std::fs::symlink_metadata(private.join("cli-config.json"))
-                .unwrap()
-                .file_type()
-                .is_symlink()
-        );
-        assert!(
-            std::fs::symlink_metadata(private.join("hooks"))
-                .unwrap()
-                .file_type()
-                .is_symlink()
-        );
 
         std::fs::remove_dir_all(root).unwrap();
     }

--- a/crates/rovai-core/src/bin/rovai.rs
+++ b/crates/rovai-core/src/bin/rovai.rs
@@ -17,8 +17,7 @@ use rovai_core::builtin_tool_transport::{
     BUILTIN_TOOL_CONTRACT_VERSION, BUILTIN_TOOL_IPC_PROTOCOL_VERSION,
     BUILTIN_TOOL_MAX_IPC_REQUEST_BYTES, BuiltinToolArgument, BuiltinToolCliContext,
     BuiltinToolCliIdentity, BuiltinToolDescription, BuiltinToolIpcRequest,
-    BuiltinToolIpcRequestBody, BuiltinToolIpcResponse, COMPACTION_DISPLAY_IPC_KIND,
-    COMPACTION_DISPLAY_IPC_PROTOCOL_VERSION, COMPACTION_HOOK_IPC_PROTOCOL_VERSION,
+    BuiltinToolIpcRequestBody, BuiltinToolIpcResponse, COMPACTION_HOOK_IPC_PROTOCOL_VERSION,
     COMPACTION_OBSERVATION_IPC_KIND, COMPACTION_OBSERVATION_OUTBOX_SCHEMA_VERSION,
     CompactionHookIpcRequest, CompactionHookIpcResponse, CompactionObservationOutboxRecord,
     LocalIpcEndpoint, ROVAI_CLI_CONTEXT_ENV, ROVAI_RUN_TMP_ENV, builtin_tool_description,
@@ -31,7 +30,6 @@ use rovai_core::camp_message_send_teaching::{
 };
 use rovai_core::command::canonical_json_digest;
 use rovai_core::platform::local_ipc::LocalIpcClientStream;
-use rovai_core::runtime_compaction_display::RuntimeCompactionTokenSnapshot;
 use serde::Serialize;
 use serde_json::{Map, Value, json};
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader};
@@ -108,15 +106,6 @@ async fn run() -> Result<u8> {
         // Core, and uncertain acknowledgements must never block compaction or
         // the AgentRun that triggered it.
         let _ = run_compaction_hook(&args[1..]).await;
-        return Ok(0);
-    }
-    if args
-        .first()
-        .is_some_and(|arg| arg == "__compaction-display-hook")
-    {
-        // Display hooks are an active-AgentRun enhancement only. They have no
-        // recovery outbox and must never delay or change Runtime compaction.
-        let _ = run_compaction_display_hook(&args[1..]).await;
         return Ok(0);
     }
     if args.as_slice() == ["--version"] || args.as_slice() == ["version"] {
@@ -352,7 +341,6 @@ async fn run_compaction_hook(args: &[String]) -> Result<()> {
         source_event_digest,
         display_auth,
         summary_text,
-        tokens: None,
     };
     if request.summary_text.is_some()
         && serde_json::to_vec(&request)?.len() > BUILTIN_TOOL_MAX_IPC_REQUEST_BYTES
@@ -389,169 +377,6 @@ async fn run_compaction_hook(args: &[String]) -> Result<()> {
     }
     let error = last_error.context("compaction observation submission remained uncertain")?;
     Err(error)
-}
-
-async fn run_compaction_display_hook(args: &[String]) -> Result<()> {
-    let [adapter_flag, adapter_kind, signal_flag, source_signal] = args else {
-        bail!("invalid internal compaction display hook arguments");
-    };
-    if adapter_flag != "--adapter-kind"
-        || signal_flag != "--source-signal"
-        || !matches!(
-            (adapter_kind.as_str(), source_signal.as_str()),
-            ("claude-code-cli", "PostCompact") | ("cursor-agent", "preCompact")
-        )
-    {
-        bail!("invalid internal compaction display hook identity");
-    }
-
-    let context = load_context()?;
-    let (process_id, process_token) = context.process_auth()?;
-    let display_auth = context.auth()?;
-    let mut hook_input = String::new();
-    std::io::stdin()
-        .read_to_string(&mut hook_input)
-        .context("failed to read compaction display hook input")?;
-    let hook_input: Value = serde_json::from_str(&hook_input)
-        .context("compaction display hook input is not valid JSON")?;
-    if !hook_input.is_object() {
-        bail!("compaction display hook input must be an object");
-    }
-    let reported_hook_event_name = hook_input
-        .get("hook_event_name")
-        .or_else(|| hook_input.get("hookEventName"))
-        .and_then(Value::as_str)
-        .filter(|value| !value.trim().is_empty());
-    if reported_hook_event_name.is_some_and(|reported| reported != source_signal) {
-        bail!("compaction display hook signal does not match its configured source");
-    }
-    let native_session_id = if adapter_kind == "cursor-agent" {
-        hook_input
-            .get("conversation_id")
-            .or_else(|| hook_input.get("conversationId"))
-    } else {
-        hook_input
-            .get("session_id")
-            .or_else(|| hook_input.get("sessionId"))
-    }
-    .and_then(Value::as_str)
-    .map(str::trim)
-    .filter(|value| !value.is_empty())
-    .context("compaction display hook input has no Native Session identity")?
-    .to_string();
-    let trigger = hook_input
-        .get("trigger")
-        .and_then(Value::as_str)
-        .filter(|trigger| matches!(*trigger, "manual" | "auto"))
-        .context("compaction display hook trigger is invalid")?
-        .to_string();
-    let summary_text = (adapter_kind == "claude-code-cli")
-        .then(|| {
-            hook_input
-                .get("compact_summary")
-                .or_else(|| hook_input.get("compactSummary"))
-                .and_then(Value::as_str)
-                .map(str::trim)
-                .filter(|summary| !summary.is_empty())
-                .map(str::to_string)
-        })
-        .flatten();
-    let tokens = if adapter_kind == "cursor-agent" {
-        let tokens = RuntimeCompactionTokenSnapshot {
-            current: optional_hook_u64(&hook_input, "context_tokens")?,
-            context_window: optional_hook_u64(&hook_input, "context_window_size")?,
-            usage_percent: optional_hook_percentage(&hook_input, "context_usage_percent")?,
-            ..RuntimeCompactionTokenSnapshot::default()
-        };
-        (tokens.current.is_some()
-            || tokens.context_window.is_some()
-            || tokens.usage_percent.is_some())
-        .then_some(tokens)
-    } else {
-        None
-    };
-    let runtime_occurrence = hook_input
-        .get("compaction_id")
-        .or_else(|| hook_input.get("compactionId"))
-        .or_else(|| hook_input.get("generation_id"))
-        .or_else(|| hook_input.get("generationId"))
-        .or_else(|| hook_input.get("request_id"))
-        .or_else(|| hook_input.get("requestId"))
-        .or_else(|| hook_input.get("timestamp"))
-        .cloned()
-        .unwrap_or_else(|| Value::String(Uuid::new_v4().to_string()));
-    let source_event_digest = canonical_json_digest(&json!({
-        "schemaVersion": 1,
-        "adapterKind": adapter_kind,
-        "nativeSessionId": native_session_id,
-        "hookEventName": source_signal,
-        "trigger": trigger,
-        "runtimeOccurrence": runtime_occurrence,
-        "tokens": tokens,
-    }))?;
-    let mut request = CompactionHookIpcRequest {
-        kind: COMPACTION_DISPLAY_IPC_KIND.to_string(),
-        ipc_protocol_version: COMPACTION_DISPLAY_IPC_PROTOCOL_VERSION,
-        process_id,
-        process_token,
-        request_id: Uuid::new_v4().to_string(),
-        adapter_kind: adapter_kind.clone(),
-        host_instance_id: String::new(),
-        native_session_id,
-        hook_event_name: source_signal.clone(),
-        trigger,
-        source_event_digest,
-        display_auth: Some(display_auth),
-        summary_text,
-        tokens,
-    };
-    if request.summary_text.is_some()
-        && serde_json::to_vec(&request)?.len() > BUILTIN_TOOL_MAX_IPC_REQUEST_BYTES
-    {
-        request.summary_text = None;
-    }
-    if serde_json::to_vec(&request)?.len() > BUILTIN_TOOL_MAX_IPC_REQUEST_BYTES {
-        bail!("compaction display hook request is too large");
-    }
-
-    let mut last_error = None;
-    for attempt in 0..COMPACTION_HOOK_ATTEMPTS {
-        match send_compaction_hook(&context.core_endpoint, &request).await {
-            Ok(response) if response.accepted => return Ok(()),
-            Ok(_) => {
-                last_error = Some(anyhow::anyhow!(
-                    "compaction display hook request was rejected"
-                ))
-            }
-            Err(error) => last_error = Some(error),
-        }
-        if attempt + 1 < COMPACTION_HOOK_ATTEMPTS {
-            tokio::time::sleep(Duration::from_millis(50)).await;
-        }
-    }
-    let error = last_error.context("compaction display submission remained unavailable")?;
-    Err(error)
-}
-
-fn optional_hook_u64(input: &Value, field: &str) -> Result<Option<u64>> {
-    let Some(value) = input.get(field) else {
-        return Ok(None);
-    };
-    value
-        .as_u64()
-        .map(Some)
-        .with_context(|| format!("compaction display hook {field} is invalid"))
-}
-
-fn optional_hook_percentage(input: &Value, field: &str) -> Result<Option<f64>> {
-    let Some(value) = input.get(field) else {
-        return Ok(None);
-    };
-    value
-        .as_f64()
-        .filter(|value| value.is_finite() && (0.0..=100.0).contains(value))
-        .map(Some)
-        .with_context(|| format!("compaction display hook {field} is invalid"))
 }
 
 fn stage_compaction_observation(

--- a/crates/rovai-core/src/builtin_tool_transport.rs
+++ b/crates/rovai-core/src/builtin_tool_transport.rs
@@ -7,10 +7,7 @@ use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 
-use crate::{
-    command::canonical_json_digest, runtime_compaction_display::RuntimeCompactionTokenSnapshot,
-    team_tool_catalog::builtin_tool_definitions,
-};
+use crate::{command::canonical_json_digest, team_tool_catalog::builtin_tool_definitions};
 
 pub const BUILTIN_TOOL_CONTRACT_VERSION: u32 = 21;
 pub const BUILTIN_TOOL_IPC_PROTOCOL_VERSION: u32 = 2;
@@ -24,9 +21,7 @@ pub const ROVAI_AGENT_CLI_ENV: &str = "ROVAI_AGENT_CLI";
 pub const ROVAI_CLI_CONTEXT_ENV: &str = "ROVAI_CLI_CONTEXT";
 pub const ROVAI_RUN_TMP_ENV: &str = "ROVAI_RUN_TMP";
 pub const COMPACTION_HOOK_IPC_PROTOCOL_VERSION: u32 = 1;
-pub const COMPACTION_DISPLAY_IPC_PROTOCOL_VERSION: u32 = 1;
 pub const COMPACTION_OBSERVATION_IPC_KIND: &str = "compaction_observation";
-pub const COMPACTION_DISPLAY_IPC_KIND: &str = "compaction_display";
 pub const COMPACTION_OBSERVATION_OUTBOX_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -152,8 +147,6 @@ pub struct CompactionHookIpcRequest {
     pub display_auth: Option<BuiltinToolAuth>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub summary_text: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tokens: Option<RuntimeCompactionTokenSnapshot>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/rovai-core/src/claude.rs
+++ b/crates/rovai-core/src/claude.rs
@@ -372,14 +372,6 @@ impl ClaudeCodeCliRuntimeAdapter {
         };
         let mut inline_settings = serde_json::json!({});
         rovai_core::camp_fast::merge_claude_inline_settings(&mut inline_settings, fast_override)?;
-        #[cfg(unix)]
-        if let Some(config) = request.builtin_tools.as_ref() {
-            let hook_command = format!(
-                "{} __compaction-display-hook --adapter-kind claude-code-cli --source-signal PostCompact",
-                quote_posix_shell_word(&config.cli_executable().to_string_lossy())
-            );
-            append_claude_compaction_display_hook(&mut inline_settings, &hook_command)?;
-        }
         let mut command = Command::new(executable);
         configure_active_runtime_command(&mut command);
         if let Some(config) = &request.builtin_tools {
@@ -1744,37 +1736,6 @@ fn launch_session_arguments(
     Ok(args)
 }
 
-#[cfg(unix)]
-fn append_claude_compaction_display_hook(settings: &mut Value, hook_command: &str) -> Result<()> {
-    let settings = settings
-        .as_object_mut()
-        .context("Claude inline settings must be a JSON object")?;
-    let hooks = settings
-        .entry("hooks")
-        .or_insert_with(|| serde_json::json!({}))
-        .as_object_mut()
-        .context("Claude inline settings hooks must be a JSON object")?;
-    let post_compact = hooks
-        .entry("PostCompact")
-        .or_insert_with(|| serde_json::json!([]))
-        .as_array_mut()
-        .context("Claude inline settings PostCompact hooks must be an array")?;
-    post_compact.push(serde_json::json!({
-        "matcher": "manual|auto",
-        "hooks": [{
-            "type": "command",
-            "command": hook_command,
-            "timeout": 3
-        }]
-    }));
-    Ok(())
-}
-
-#[cfg(unix)]
-fn quote_posix_shell_word(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "'\"'\"'"))
-}
-
 fn session_arguments(
     resumable_session_id: Option<&str>,
     native_session_id: &str,
@@ -1959,48 +1920,6 @@ mod tests {
                 "--append-system-prompt",
                 "bootstrap-latest",
             ]
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn appends_additive_post_compact_display_hook_to_inline_settings() {
-        let mut settings = json!({
-            "fastMode": true,
-            "hooks": {
-                "PostCompact": [{"matcher": "manual", "hooks": []}],
-                "Stop": [{"hooks": []}]
-            }
-        });
-        append_claude_compaction_display_hook(
-            &mut settings,
-            "'/tmp/Rovai CLI' __compaction-display-hook --adapter-kind claude-code-cli --source-signal PostCompact",
-        )
-        .unwrap();
-
-        assert_eq!(settings["fastMode"], true);
-        assert_eq!(settings["hooks"]["Stop"].as_array().unwrap().len(), 1);
-        assert_eq!(
-            settings["hooks"]["PostCompact"].as_array().unwrap().len(),
-            2
-        );
-        assert_eq!(
-            settings["hooks"]["PostCompact"][1]["matcher"],
-            "manual|auto"
-        );
-        assert_eq!(
-            settings["hooks"]["PostCompact"][1]["hooks"][0]["type"],
-            "command"
-        );
-        assert!(
-            settings["hooks"]["PostCompact"][1]["hooks"][0]["command"]
-                .as_str()
-                .unwrap()
-                .contains("__compaction-display-hook")
-        );
-        assert_eq!(
-            quote_posix_shell_word("/tmp/Rovai's CLI"),
-            "'/tmp/Rovai'\"'\"'s CLI'"
         );
     }
 

--- a/crates/rovai-core/src/main.rs
+++ b/crates/rovai-core/src/main.rs
@@ -23,8 +23,8 @@ use antigravity::{
 };
 use anyhow::{Context, Result};
 use builtin_tool_runtime::{
-    AuthorizedBuiltinToolInvocation, BuiltinToolLeaseRegistry, BuiltinToolProcessConfig,
-    builtin_tool_endpoint, bundled_cli_executable, request_digest,
+    BuiltinToolLeaseRegistry, BuiltinToolProcessConfig, builtin_tool_endpoint,
+    bundled_cli_executable, request_digest,
 };
 use claude::{
     ClaudeCodeCliRuntimeAdapter, ClaudeCodeDeliveredFailure, ClaudeCodeInputAccepted,
@@ -76,7 +76,6 @@ use rovai_core::{
         BUILTIN_TOOL_CONTRACT_VERSION, BUILTIN_TOOL_IPC_PROTOCOL_VERSION,
         BUILTIN_TOOL_MAX_IPC_REQUEST_BYTES, BuiltinToolError, BuiltinToolInvocationEnvelope,
         BuiltinToolIpcRequest, BuiltinToolIpcRequestBody, BuiltinToolIpcResponse,
-        COMPACTION_DISPLAY_IPC_KIND, COMPACTION_DISPLAY_IPC_PROTOCOL_VERSION,
         COMPACTION_HOOK_IPC_PROTOCOL_VERSION, COMPACTION_OBSERVATION_IPC_KIND,
         CompactionHookIpcRequest, CompactionHookIpcResponse, builtin_tool_catalog_digest,
         builtin_tool_description, recovery_for_error_code,
@@ -214,7 +213,6 @@ use rovai_core::{
     runtime_compaction_display::{
         RUNTIME_COMPACTION_DISPLAY_EVENT, RuntimeCompactionCompletionEvidence,
         RuntimeCompactionDisplayEvent, RuntimeCompactionDisplayPhase,
-        RuntimeCompactionTokenSnapshot,
     },
     runtime_discovery::{
         RuntimeDiscoveryObservation, RuntimeDiscoveryStatus, RuntimeExecutableCandidate,
@@ -4412,12 +4410,8 @@ impl Core {
         request: CompactionHookIpcRequest,
     ) -> CompactionHookIpcResponse {
         let rejected = || CompactionHookIpcResponse { accepted: false };
-        let expected_protocol_version = match request.kind.as_str() {
-            COMPACTION_OBSERVATION_IPC_KIND => COMPACTION_HOOK_IPC_PROTOCOL_VERSION,
-            COMPACTION_DISPLAY_IPC_KIND => COMPACTION_DISPLAY_IPC_PROTOCOL_VERSION,
-            _ => return rejected(),
-        };
-        if request.ipc_protocol_version != expected_protocol_version
+        if request.kind != COMPACTION_OBSERVATION_IPC_KIND
+            || request.ipc_protocol_version != COMPACTION_HOOK_IPC_PROTOCOL_VERSION
             || uuid::Uuid::parse_str(&request.request_id).is_err()
             || !self
                 .builtin_tool_leases
@@ -4434,12 +4428,6 @@ impl Core {
         {
             return rejected();
         }
-        if request.kind == COMPACTION_DISPLAY_IPC_KIND {
-            return self
-                .handle_compaction_display_hook_ipc(request, adapter_kind)
-                .await;
-        }
-
         let native_session_id = request.native_session_id.as_str();
         let hook_event_name = request.hook_event_name.as_str();
         let compact_trigger = request.trigger.as_str();
@@ -4448,9 +4436,23 @@ impl Core {
         else {
             return rejected();
         };
-        let display_target = self
-            .active_compaction_display_target(&request, adapter_kind)
-            .await;
+        let display_target = match request.display_auth.as_ref() {
+            Some(auth)
+                if auth.process_id == request.process_id
+                    && auth.process_token == request.process_token =>
+            {
+                self.builtin_tool_leases
+                    .authenticate(auth)
+                    .await
+                    .ok()
+                    .filter(|target| {
+                        !target.native_binding.binding_replaced
+                            && target.native_binding.native_session_id.as_deref()
+                                == Some(request.native_session_id.as_str())
+                    })
+            }
+            Some(_) | None => None,
+        };
         let display_event = observation_hook_compaction_display_event(
             adapter_kind,
             &request.source_event_digest,
@@ -4509,74 +4511,6 @@ impl Core {
             );
         }
         CompactionHookIpcResponse { accepted }
-    }
-
-    async fn handle_compaction_display_hook_ipc(
-        &self,
-        request: CompactionHookIpcRequest,
-        adapter_kind: AdapterKind,
-    ) -> CompactionHookIpcResponse {
-        let rejected = || CompactionHookIpcResponse { accepted: false };
-        let Some(display_event) = display_only_hook_compaction_display_event(
-            adapter_kind,
-            &request.source_event_digest,
-            &request.hook_event_name,
-            &request.trigger,
-            request.summary_text.as_deref(),
-            request.tokens.as_ref(),
-        ) else {
-            return rejected();
-        };
-        let Some(target) = self
-            .active_compaction_display_target(&request, adapter_kind)
-            .await
-        else {
-            return rejected();
-        };
-        match persist_runtime_compaction_display(
-            self,
-            &self.output,
-            &target.agent_run_id,
-            target.execution_epoch,
-            Some(&target.run_tmp),
-            display_event,
-            &request.hook_event_name,
-        )
-        .await
-        {
-            Ok(()) => CompactionHookIpcResponse { accepted: true },
-            Err(error) => {
-                eprintln!(
-                    "{} local compaction display was skipped: {error:#}",
-                    adapter_kind.as_str()
-                );
-                rejected()
-            }
-        }
-    }
-
-    async fn active_compaction_display_target(
-        &self,
-        request: &CompactionHookIpcRequest,
-        adapter_kind: AdapterKind,
-    ) -> Option<AuthorizedBuiltinToolInvocation> {
-        let auth = request.display_auth.as_ref()?;
-        if auth.process_id != request.process_id || auth.process_token != request.process_token {
-            return None;
-        }
-        let target = self.builtin_tool_leases.authenticate(auth).await.ok()?;
-        if target.native_binding.binding_replaced {
-            return None;
-        }
-        let execution = {
-            let database = self.database.lock().await;
-            ExecutionRuntimeService::default()
-                .load_agent_run_execution(&database, &target.agent_run_id, target.execution_epoch)
-                .ok()??
-        };
-        (execution.runtime.adapter_kind == adapter_kind
-            && execution.native_session_id.as_deref() == Some(request.native_session_id.as_str()))
-        .then_some(target)
     }
 
     async fn handle_builtin_operation(
@@ -15765,58 +15699,6 @@ fn observation_hook_compaction_display_event(
     Some(event)
 }
 
-fn display_only_hook_compaction_display_event(
-    adapter_kind: AdapterKind,
-    compaction_id: &str,
-    hook_event_name: &str,
-    trigger: &str,
-    summary_text: Option<&str>,
-    tokens: Option<&RuntimeCompactionTokenSnapshot>,
-) -> Option<RuntimeCompactionDisplayEvent> {
-    if !matches!(trigger, "manual" | "auto") {
-        return None;
-    }
-    let (phase, completion_evidence) = match (adapter_kind, hook_event_name) {
-        (AdapterKind::ClaudeCodeCli, "PostCompact") => (
-            RuntimeCompactionDisplayPhase::Completed,
-            RuntimeCompactionCompletionEvidence::NativeTerminal,
-        ),
-        (AdapterKind::CursorAgent, "preCompact") => (
-            RuntimeCompactionDisplayPhase::Imminent,
-            RuntimeCompactionCompletionEvidence::PreCompactionOnly,
-        ),
-        _ => return None,
-    };
-    let mut event =
-        RuntimeCompactionDisplayEvent::new(compaction_id, adapter_kind.as_str(), phase)?;
-    event.completion_evidence = Some(completion_evidence);
-    match adapter_kind {
-        AdapterKind::ClaudeCodeCli => event.set_summary_text(summary_text),
-        AdapterKind::CursorAgent => {
-            let tokens = tokens.map(|tokens| RuntimeCompactionTokenSnapshot {
-                current: tokens.current,
-                context_window: tokens.context_window,
-                usage_percent: tokens.usage_percent,
-                ..RuntimeCompactionTokenSnapshot::default()
-            });
-            if tokens.as_ref().is_some_and(|tokens| {
-                tokens.usage_percent.is_some_and(|usage_percent| {
-                    !usage_percent.is_finite() || !(0.0..=100.0).contains(&usage_percent)
-                })
-            }) {
-                return None;
-            }
-            event.tokens = tokens.filter(|tokens| {
-                tokens.current.is_some()
-                    || tokens.context_window.is_some()
-                    || tokens.usage_percent.is_some()
-            });
-        }
-        _ => unreachable!(),
-    }
-    Some(event)
-}
-
 async fn persist_runtime_compaction_display(
     core: &Core,
     output: &mpsc::UnboundedSender<String>,
@@ -18649,9 +18531,7 @@ async fn handle_builtin_tool_connection(core: Arc<Core>, stream: LocalIpcStream)
                 .as_ref()
                 .and_then(|value| value.get("kind"))
                 .and_then(Value::as_str)
-                .is_some_and(|kind| {
-                    kind == COMPACTION_OBSERVATION_IPC_KIND || kind == COMPACTION_DISPLAY_IPC_KIND
-                })
+                == Some(COMPACTION_OBSERVATION_IPC_KIND)
             {
                 let response = match value.and_then(|value| {
                     serde_json::from_value::<CompactionHookIpcRequest>(value).ok()
@@ -19095,103 +18975,6 @@ mod tests {
             )
             .is_none()
         );
-    }
-
-    #[test]
-    fn display_only_hooks_map_claude_summary_and_cursor_tokens_without_admission() {
-        let cursor_tokens = RuntimeCompactionTokenSnapshot {
-            before: Some(180_000),
-            after: Some(90_000),
-            current: Some(91_000),
-            context_window: Some(128_000),
-            usage_percent: Some(71.09375),
-        };
-        let claude = display_only_hook_compaction_display_event(
-            AdapterKind::ClaudeCodeCli,
-            "compact-claude",
-            "PostCompact",
-            "manual",
-            Some(" compact summary "),
-            Some(&cursor_tokens),
-        )
-        .unwrap();
-        assert_eq!(claude.phase, RuntimeCompactionDisplayPhase::Completed);
-        assert_eq!(
-            claude.completion_evidence,
-            Some(RuntimeCompactionCompletionEvidence::NativeTerminal)
-        );
-        assert_eq!(claude.summary_text.as_deref(), Some("compact summary"));
-        assert!(claude.tokens.is_none());
-
-        let cursor = display_only_hook_compaction_display_event(
-            AdapterKind::CursorAgent,
-            "compact-cursor",
-            "preCompact",
-            "auto",
-            Some("must not be copied"),
-            Some(&cursor_tokens),
-        )
-        .unwrap();
-        assert_eq!(cursor.phase, RuntimeCompactionDisplayPhase::Imminent);
-        assert_eq!(
-            cursor.completion_evidence,
-            Some(RuntimeCompactionCompletionEvidence::PreCompactionOnly)
-        );
-        assert_eq!(
-            cursor.tokens,
-            Some(RuntimeCompactionTokenSnapshot {
-                current: Some(91_000),
-                context_window: Some(128_000),
-                usage_percent: Some(71.09375),
-                ..RuntimeCompactionTokenSnapshot::default()
-            })
-        );
-        assert!(cursor.summary_text.is_none());
-
-        let invalid_tokens = RuntimeCompactionTokenSnapshot {
-            usage_percent: Some(100.1),
-            ..RuntimeCompactionTokenSnapshot::default()
-        };
-        assert!(
-            display_only_hook_compaction_display_event(
-                AdapterKind::CursorAgent,
-                "compact-cursor",
-                "preCompact",
-                "manual",
-                None,
-                Some(&invalid_tokens),
-            )
-            .is_none()
-        );
-
-        for invalid in [
-            display_only_hook_compaction_display_event(
-                AdapterKind::ClaudeCodeCli,
-                "compact-claude",
-                "PreCompact",
-                "manual",
-                None,
-                None,
-            ),
-            display_only_hook_compaction_display_event(
-                AdapterKind::CursorAgent,
-                "compact-cursor",
-                "preCompact",
-                "other",
-                None,
-                None,
-            ),
-            display_only_hook_compaction_display_event(
-                AdapterKind::QwenCode,
-                "compact-qwen",
-                "PostCompact",
-                "manual",
-                None,
-                None,
-            ),
-        ] {
-            assert!(invalid.is_none());
-        }
     }
 
     #[cfg(feature = "slow-tests")]

--- a/crates/rovai-core/src/runtime_platform_admission.rs
+++ b/crates/rovai-core/src/runtime_platform_admission.rs
@@ -8,7 +8,7 @@ use crate::{agent_profile::AdapterKind, platform::HostPlatformKey};
 /// that evidence even when their Adapter identity exists in the Product Catalog.
 /// Every register revision receives a new digest.
 pub const MACOS_RUNTIME_COMPATIBILITY_EVIDENCE_REVISION: &str =
-    "sha256:45e50403128c6422b270c4cc6e724d03cdf0b52dfb459c34508c7c056d5b7c89";
+    "sha256:b7a1a834eade0ee784d51da722cbf32a0f69be2f6f596e82e466e6c66e5aea90";
 
 /// Immutable digest of the sanitized, adapter-scoped Windows x64 evidence.
 /// The source qualifies only the Runtime rows named in that evidence; shared

--- a/docs/architecture/native-session-bootstrap-redelivery.md
+++ b/docs/architecture/native-session-bootstrap-redelivery.md
@@ -117,24 +117,24 @@ pre edge，避免等待不存在的 completed Hook。其余 Runtime 有可靠 co
 
 ## 执行台 Compaction 展示旁路
 
-Compaction observation 仍只拥有 Bootstrap redelivery。作为独立、本地、无副作用的产品投影，Core 可在同一个已准入 signal
-旁，或从明确的 display-only Hook 生成 `runtime.compaction.display`，但仅当捕获瞬间还能由 active ACP Prompt route 或
-Built-in Tool active lease 精确取得
-`agentRunId + executionEpoch`。warm Session 已 detach、Hook IPC lease 已换代、Run 已取消/终态或 observation 是 outbox replay
-时，不补挂到当前或后续 Run。展示写入失败也不改变 observation Applied/Duplicate/Fenced 结果。
+Compaction observation 仍只拥有 Bootstrap redelivery。作为独立、本地、无副作用的产品投影，Core 只能在 Rovai 现有入口已经
+捕获的同一个原生 signal 旁生成 `runtime.compaction.display`，且捕获瞬间必须还能由 active ACP Prompt route 或现有
+observation Hook 的 Built-in Tool active lease 精确取得 `agentRunId + executionEpoch`。warm Session 已 detach、Hook IPC
+lease 已换代、Run 已取消/终态或 observation 是 outbox replay 时，不补挂到当前或后续 Run。展示写入失败也不改变
+observation Applied/Duplicate/Fenced 结果。
+
+执行台展示不得为尚未接入的 Runtime 安装 Hook、Plugin 或配置 Overlay，也不得修改 Runtime 启动参数、环境或用户配置来制造
+新的展示信号。现有本地 Hook IPC 只识别 `compaction_observation`；`display_auth` 只把同一次 live observation 安全归属到当前
+AgentRun，`summary_text` 只携带现有 Qoder/Qwen Hook 已经明确给出的摘要。两者都不改变 observation 的 Bootstrap 语义。
 
 旁路只复制 Runtime 明确给出的字段：Kiro `summary`，Kimi exact completion 的 message/token 三个整数，Grok structured
-`tokens_before/tokens_after/elapsed_ms`，以及 Qoder/Qwen live Hook 的显式 `compact_summary`。Copilot 只表达 pre edge，OpenCode
-只表达完成，CodeBuddy 只表达 post-compaction Session boundary；缺失值保持缺失。`summary_preview`、trigger、Session ID、时间差、
-token drop 与普通文本不能补造展示数据。Codex 不进入本 detector policy；其 app-server `contextCompaction` item 由执行 Evidence
-入口直接截获为同一 display schema，仍不推进 Bootstrap revision。
+`tokens_before/tokens_after/elapsed_ms`，以及 Qoder/Qwen live observation Hook 的显式 `compact_summary`。Copilot 只表达 pre
+edge，OpenCode 只表达完成，CodeBuddy 只表达 post-compaction Session boundary；缺失值保持缺失。`summary_preview`、trigger、
+Session ID、时间差、token drop 与普通文本不能补造展示数据。Codex 不进入本 detector policy；其 app-server
+`contextCompaction` item 由执行 Evidence 入口直接截获为同一 display schema，仍不推进 Bootstrap revision。
 
-Claude Code 与 Cursor 的 display-only Hook 不进入上面的 signal admission：Claude 本次进程通过 additive `--settings`
-注册 `PostCompact(manual|auto)`，只映射 `compact_summary` 为 completed 展示；Cursor ACP Host 通过进程私有
-`CURSOR_CONFIG_DIR` 保留用户配置并追加 native `preCompact`，只映射当前 token、窗口与占用率为 imminent 展示。两者都必须
-通过 active Built-in Tool lease、当前 Run 的 adapter 与 Native Session 三重校验；relay 不建立 observation outbox，Core 不查询
-observer lease，也不调用 Bootstrap command。Cursor 的这段 wiring 不改变其 `not_qualified` 产品状态或 Disabled detector
-policy。
+Claude Code 与 Cursor Agent 当前没有执行台 Compaction 展示入口；本次需求不新增其协议接入。Antigravity 也只允许在现有
+Adapter 已经收到明确原生事件时投影，不为填满 Runtime 矩阵新增 detector 或启动配置。
 
 该事件使用本地 Execution Evidence/Managed Blob 以支持长 summary 惰性读取，但 Canonical Activity classifier 明确返回
 non-activity，public execution query 明确排除，Main 的飞书/钉钉 Host 与局域网执行台也不因它唤醒。它不是公共 Evidence、

--- a/docs/architecture/runtime-catalog-boundaries.md
+++ b/docs/architecture/runtime-catalog-boundaries.md
@@ -229,8 +229,8 @@ accepted-send suppression 与真实 tool→final 三条专项 Smoke 通过后启
 `cursor/ask_question` 与 `cursor/create_plan` 只能进入唯一 Active Prompt；当前分别返回 skipped/rejected。
 三个已知 private notification 保持私有，未知 Cursor request 返回 Method not found。External MCP、cold
 continuation、Missing-Send、Usage、Bootstrap Compaction detector 和细粒度 Activity 都没有真实资格证据，保持禁用或
-run-level。ACP Host 已准备进程私有 `CURSOR_CONFIG_DIR` display-only `preCompact` 映射，只复制明确 token 字段到本地执行台；
-它不建立 observation、不启用 detector，也不能替代真实 Cursor AgentRun 资格证据。
+run-level。执行台展示不为 Cursor 修改启动环境、创建配置 Overlay 或追加 Hook；Cursor 当前没有 Compaction 展示入口，
+本次需求不新增其协议接入，也不能替代真实 Cursor AgentRun 资格证据。
 Cursor Host 完成 Run 后停止，不跨 Run 延伸未证明的进程状态。
 
 项目 `.cursor/skills` 是 Rovai managed delivery target；该结论只建立可清理文件投影，不把上游文档中的

--- a/docs/contracts/run-process-detail-surface-v29.md
+++ b/docs/contracts/run-process-detail-surface-v29.md
@@ -16,25 +16,22 @@ last_updated: 2026-09-03
 
 ## 本地展示事件
 
-Core 可在 Runtime 已准入的精确信号旁，或由 Claude/Cursor 的 display-only Hook 生成
-`runtime.compaction.display` / schema 1。事件只允许绑定信号捕获当时仍可证明的
+Core 只能在 Rovai 现有入口已经捕获的 Runtime 精确信号旁生成 `runtime.compaction.display` / schema 1。事件只允许绑定
+信号捕获当时仍可证明的
 `agentRunId + executionEpoch`；没有 exact active lease/route、Runtime 或 Native Session 不一致、Run 已换 epoch、已取消或
 已终态时静默跳过展示。
 Bootstrap redelivery observation、digest、observer lease、v1 IPC 和 uncertain recovery outbox 保持原协议；outbox replay 不补挂
 展示事件。Codex `item/started|completed` 的 `item.type=contextCompaction` 必须在普通 activity 投影前拦截；缺少非空
 item ID 时降为不可展示的 native 事件，不能变成 Tool。
 
-Claude Code 只把本次启动的 additive `PostCompact(manual|auto)` Hook 映射为
-`completed + native_terminal`，并只复制非空 `compact_summary`。Cursor Agent 只把进程私有配置中的
-`preCompact(manual|auto)` 映射为 `imminent + pre_compaction_only`，并逐字段复制
-`context_tokens/context_window_size/context_usage_percent`。这两条 Hook 使用 active Built-in Tool lease 进行本地展示授权，
-不创建 observer lease、不调用 `submit_compaction_observation`、不写 observation outbox，也不改变对应 Runtime 的 detector
-policy 或产品资格。
+Runtime Compact 行只投影 Rovai 当前已有入口能够捕获的原生事件。执行台展示功能不得主动为尚未接入的 Runtime 安装 Hook、
+Plugin 或配置 Overlay，也不得修改 Runtime 的启动参数、环境或用户配置。Claude Code 与 Cursor Agent 当前无展示入口；本次
+需求不新增其协议接入。
 
 展示载荷只保留 `schemaVersion`、`compactionId`、`adapterKind`、`phase`、可选 `completionEvidence`、Runtime 明确给出的
 token/message/elapsed 字段及显式 summary。不得从 token drop、文本关键词、Session ID、时间窗口或其他事件猜缺失字段。
-summary 可复用本地 Execution Evidence/Managed Blob 全文路径，但整个事件不进入公开 execution Evidence、飞书、钉钉、
-局域网执行台、世界地图或 Canonical Activity。
+现有 Qoder/Qwen observation Hook 的 `summaryText` 可复用本地 Execution Evidence/Managed Blob 全文路径，但整个事件不进入
+公开 execution Evidence、飞书、钉钉、局域网执行台、世界地图或 Canonical Activity。
 
 ## 执行台呈现
 

--- a/docs/runtime-compatibility.md
+++ b/docs/runtime-compatibility.md
@@ -142,7 +142,7 @@ login、没有发送模型 Prompt，也没有读写日常数据库。
 | Permission / workspace | 官方文档提供 agent/plan/ask 与 auto-review/force | 静态配置已实现；read-only 强制 plan 并移除高权限 flag；尚无 allow/deny 副作用证据 |
 | Skill | 官方文档列出项目 `.cursor/skills` 与 `.agents/skills` | Rovai 只拥有 `.cursor/skills` projection；Runtime load/invocation 为 DocumentationOnly |
 | MCP / continuation | 官方文档只确认 Cursor 配置面；本轮未获得 authenticated Session | External MCP、session/load/resume、warm reuse 均 Disabled；完成 Run 后停止 Host |
-| Activity / final / usage | 无 authenticated Prompt、Tool 或 terminal transcript；官方现已记录 observation-only `preCompact` 及 current/window/usage token 字段 | Activity baseline 为 `run_level`；Missing-Send、Usage/Cost 与 Bootstrap Compaction detector 均 Disabled。进程私有 display-only Hook 映射已实现，但未做真实 AgentRun Smoke，不能提高资格 |
+| Activity / final / usage | 无 authenticated Prompt、Tool 或 terminal transcript；官方现已记录 observation-only `preCompact` 及 current/window/usage token 字段 | Activity baseline 为 `run_level`；Missing-Send、Usage/Cost 与 Bootstrap Compaction detector 均 Disabled。执行台当前无展示入口，本次需求不新增其协议接入 |
 
 本轮不满足 checklist 的 First run、Command output、Approval、Cancellation、Private request、Built-in CLI、
 Process cleanup 与 continuation 必过 Smoke。macOS arm64、macOS x64、Windows x64 因而全部保持
@@ -788,12 +788,27 @@ detector。Antigravity v0.48 与 TRAE 当前 policy 为 `disabled`，因为尚�
 Runtime 的 Built-in CLI 兼容性结论。完整时序与持久边界见
 [Native Session Bootstrap Redelivery](architecture/native-session-bootstrap-redelivery.md)。
 
-执行台 display sidecar 与本节 detector 资格独立：Claude Code 通过本次进程的 additive `PostCompact` Hook 复制显式
-`compact_summary`；Cursor ACP Host 通过不修改用户文件的私有 `CURSOR_CONFIG_DIR` 追加 observation-only
-`preCompact`，复制 `context_tokens/context_window_size/context_usage_percent`。两条路径只服务当前 active AgentRun，
-不产生 Bootstrap observation/outbox。Claude/Cursor Hook 形状分别依据官方
-[Claude Code Hooks](https://code.claude.com/docs/en/hooks) 与 [Cursor Hooks](https://prod.cursor.com/docs/hooks)；当前本机
-Cursor `2025.09.18-7ae6800` 仍无 ACP，故尚无真实 Cursor display Smoke，所有平台继续 `not_qualified`。
+执行台 display sidecar 与本节 detector 资格独立，但只复用 Rovai 当前已经能够捕获的原生事件；展示功能不得为尚未接入的
+Runtime 安装 Hook、Plugin、配置 Overlay，或改变其启动环境。当前展示范围为：
+
+| Runtime | 当前展示 | 现有数据来源 | 可展开内容 |
+| --- | --- | --- | --- |
+| Codex CLI | 是 | app-server `contextCompaction` | 无 |
+| OpenCode | 是 | 已有 managed Plugin `session.compacted` | 无 |
+| GitHub Copilot | 是 | 已有 detector Hook `preCompact` | 无 |
+| Claude Code | 否 | 当前无展示入口；本次需求不新增其协议接入 | — |
+| Kiro | 是 | 已有 ACP compaction status | Runtime 明确给出 summary 时展开 |
+| Qoder | 是 | 已有 `PostCompact` observation Hook | summary |
+| CodeBuddy | 是 | 已有 `SessionStart(source=compact)` | 无 |
+| Qwen Code | 是 | 已有 `PostCompact` observation Hook | summary |
+| TRAE CLI CN | 否 | 无可靠信号 | — |
+| Cursor Agent | 否 | 当前无展示入口；本次需求不新增其协议接入 | — |
+| Kimi Code | 是 | 已有 ACP compaction lifecycle | token、消息数量 |
+| Grok Build | 是 | 已有 native extension | token、耗时 |
+| Antigravity | 条件性 | 仅现有 Adapter 已收到的明确事件；不新增 Hook | 当前无额外数据 |
+
+因此当前明确接受 Claude 暂不显示 Compact 摘要、Cursor 暂不显示 Compact token；这不改变 Cursor 全平台
+`not_qualified`、任何 Runtime 的 detector policy 或 Bootstrap observation/outbox。
 
 ## External MCP 兼容性
 

--- a/docs/versions/v1.38/README.md
+++ b/docs/versions/v1.38/README.md
@@ -33,9 +33,9 @@ last_updated: 2026-09-03
   Bot 仍按既有后台语义运行。该边界只关闭新的用户管理入口，不伪装成后端代码清理。
 - 飞书连接、队员发布、项目选择、排队/执行卡、最近输出、局域网执行台及既有数据完全保持开放。
 - 执行台新增 active AgentRun 专用的 Runtime Compaction 本地事件行。它不是 Tool、不增加操作数，只在明确 token 或 summary
-  存在时展开；`imminent` 是中性记录，只有 `started` 占用活动态。Claude `PostCompact` 映射显式 summary，Cursor
-  `preCompact` 映射显式 token 快照；两者只走 display-only Hook，不改变 Bootstrap redelivery observation、detector policy、
-  渠道、局域网执行台和世界地图边界。
+  存在时展开；`imminent` 是中性记录，只有 `started` 占用活动态。展示只复用 Rovai 已有入口捕获的事件，不为展示安装
+  Runtime Hook、Plugin 或配置 Overlay；Claude 与 Cursor 当前无展示入口，本次需求不新增其协议接入。Bootstrap redelivery
+  observation、detector policy、渠道、局域网执行台和世界地图边界不变。
 - 发布前收紧飞书后台维护：active Host 只由 Run started/terminal 与当前执行卡 Run 的 live event 唤醒；首次恢复
   Pump 不先扫描全部历史群。Core outstanding、watchdog、Delivery、latest-wins、精确 roster 刷新和 Web 执行台不变。
 - 下列“重新开放清单”同时记录实现与验收状态；渠道页 gate 在 packaged 桌面端/手机端完整矩阵通过前保持不变。
@@ -83,9 +83,9 @@ last_updated: 2026-09-03
 | Version lifecycle | 已更新 | v1.37 冻结为 historical；本概览、实施计划与版本索引建立唯一 current v1.38 |
 | Decisions | 已更新 | [V1.38-D01](decisions.md#v1-38-d01)固定飞书同等体验宗旨，并选择 credential-bound callback + SQLite deadline 作为多 Bot target proof 与恢复边界 |
 | Contracts | 已更新 | [Channel Host Maintenance v5](../../contracts/channel-host-maintenance-v5.md)继续拥有按需调度；[DingTalk Channel v11](../../contracts/dingtalk-channel-v11.md)拥有多 Bot durable 聚合；[Run Process Detail Surface v29](../../contracts/run-process-detail-surface-v29.md)拥有本地 Compaction 行 |
-| Architecture | 已更新 | [飞书渠道架构](../../architecture/feishu-channel.md)与[钉钉渠道架构](../../architecture/dingtalk-channel.md)保持渠道边界；[Native Session Bootstrap Redelivery](../../architecture/native-session-bootstrap-redelivery.md)区分 observation 与本地 display sidecar |
+| Architecture | 已更新 | [飞书渠道架构](../../architecture/feishu-channel.md)与[钉钉渠道架构](../../architecture/dingtalk-channel.md)保持渠道边界；[Native Session Bootstrap Redelivery](../../architecture/native-session-bootstrap-redelivery.md)限定本地 display sidecar 只复用现有捕获入口 |
 | UI | 已更新 | [渠道设置](../../ui/components/channel-settings.md)拥有 Provider gate；[Camp 会话工作区](../../ui/components/conversation-workspace.md)拥有非 Tool Compaction 行与 disclosure 规则 |
 | Runtime Activity | 已更新 | `runtime.compaction.display` 明确是 local non-activity，不进入 Canonical Activity、世界地图或 Tool 计数 |
-| Runtime compatibility | 已更新 | Claude/Cursor 增加 display-only 字段映射说明；不改变任何 Runtime 的平台准入、模型、工具兼容性或 Compaction detector policy |
+| Runtime compatibility | 已更新 | 展示矩阵明确 Claude/Cursor 当前无入口且本次不新增其协议接入；不改变任何 Runtime 的平台准入、模型、工具兼容性或 Compaction detector policy |
 | Documentation routing | 已更新 | 版本索引保持 v1.38；[文档导航](../../README.md)、合同索引和当前决定导航切换到 Channel Host Maintenance v5 |
 | Root README | 确认无需更新 | 根 README 未承诺钉钉公开可用，产品定位与安装方式不变 |

--- a/docs/versions/v1.38/implementation-plan.md
+++ b/docs/versions/v1.38/implementation-plan.md
@@ -20,9 +20,8 @@ last_updated: 2026-09-03
 - [x] 飞书首次恢复 Pump 跳过历史群全量 roster 网络扫描，仍执行一次 Core 恢复；精确刷新和运行期 fallback 保留。
 - [x] Runtime 已捕获的 Compaction 信号可为同一 active AgentRun 生成本地 display sidecar；Codex
   `contextCompaction` 在普通 activity 前截获，其他 Runtime 不扩 detector policy、不猜缺失字段。
-- [x] Claude additive `PostCompact` 只投影非空 `compact_summary`；Cursor 进程私有 `preCompact` 只投影明确
-  current/window/usage token 字段。两条 display-only Hook 均由 active Run/adapter/Native Session fence 授权，不建立
-  observation、outbox、跨 Run 状态或新 detector policy。
+- [x] 展示只复用当前已有 Runtime 入口；不修改 Runtime 启动参数或环境，不安装仅用于展示的 Hook、Plugin 或配置 Overlay。
+  Claude 与 Cursor 当前无展示入口，本次需求不新增其协议接入。
 - [x] 执行台使用非 Tool 的 28px 四轨 Compaction 行；只有 token/summary 可展开，长 summary 复用 Managed Blob，
   公共渠道、局域网执行台、世界地图与 Bootstrap outbox 均排除；`imminent` 为中性 recorded，只有 `started` 算 active，
   图标沿用普通 command muted 色。
@@ -54,9 +53,9 @@ last_updated: 2026-09-03
   父消息投影、安全诊断，以及既有项目卡、FIFO、执行/排队 recall owner。
 - `apps/desktop/src/renderer/src/ChannelSettings.test.ts`：开放 Provider 过滤、固定钉钉预告、disabled/ARIA、legacy
   Snapshot 不泄露和飞书回退。
-- `crates/rovai-core/src/acp.rs`、`claude.rs`、`codex.rs`、`main.rs`、`bin/rovai.rs`、`execution_evidence.rs`、
-  `read_model.rs`：精确信号字段映射、Claude/Cursor display-only Hook、Codex 先行截获、active Run fencing、Managed Blob
-  和 public/non-activity 隔离。
+- `crates/rovai-core/src/acp.rs`、`codex.rs`、`main.rs`、`bin/rovai.rs`、`execution_evidence.rs`、`read_model.rs`：
+  现有精确信号字段映射、Codex 先行截获、observation active Run 归属、Managed Blob 和 public/non-activity 隔离；
+  `acp.rs` 的私有 Host 配置测试同时约束只有 Kiro 获得现有 Overlay。
 - `apps/desktop/src/renderer/src/App.test.ts`、`execution-tool-grouping.test.ts`、Main channel tests：同 ID 原位更新、
   token/summary disclosure、静态行、Tool 计数边界和公共 wake 隔离。
 - `pnpm typecheck`、Renderer/Vitest 全量、`pnpm build:desktop`：类型、现有渠道交互与生产构建回归。
@@ -81,13 +80,17 @@ last_updated: 2026-09-03
   留给具备 nested sandbox 权限的 CI/本机复验。
 - packaged App 与钉钉真实租户双端矩阵仍未执行，Renderer gate 保持关闭。
 
-## Compaction 跟进验证（2026-09-03）
+## Compaction 选择性撤回验证（2026-09-03）
 
-- 已通过 `cargo fmt --all --check` 与 `cargo clippy -p rovai-core --all-targets -- -D warnings`；`rovai-core`
-  binary tests 为 192 passed / 4 个 manual Runtime smoke ignored，`rovai` CLI tests 为 32 passed。
+- 已通过 `cargo fmt --all --check`、`cargo check -p rovai-core --all-targets` 与
+  `cargo clippy -p rovai-core --all-targets -- -D warnings`；`rovai-core` binary tests 为 189 passed / 4 个 manual
+  Runtime smoke ignored，`rovai` CLI tests 为 32 passed，slow tests 为 297 passed。
 - `cargo test -p rovai-core --lib` 为 477 passed / 1 failed；唯一失败仍是未改动的 macOS nested sandbox owner，
-  当前执行环境的 `sandbox-exec` 返回 exit 71。Runtime compatibility 冻结摘要、Compaction admission、Claude/Cursor
-  Hook 映射与本地 display persistence 均已通过。
-- 已通过 `pnpm typecheck`、`pnpm test`、Compaction grouping 定向 Vitest 10/10 与 `pnpm build:desktop`。
-- 当前安装的 Cursor `2025.09.18-7ae6800` 不具备 ACP，未把 display-only wiring 记作真实 Runtime Smoke；Cursor
-  全平台资格与 detector policy 保持原状态。
+  最小 `/usr/bin/sandbox-exec -p '(version 1)(allow default)' /usr/bin/true` 在当前执行环境同样返回
+  `sandbox_apply: Operation not permitted`（exit 71），因此不把全量 Rust lib 记为通过。
+- 已通过 `pnpm typecheck`、`pnpm test`（Vitest 137 files / 1433 tests；Node/协议 220 passed、1 个 Windows-only
+  skip）、Compaction grouping 定向 Vitest 10/10 与 `pnpm build:desktop`。
+- 已通过 `pnpm docs:test`、`pnpm docs:check` 与
+  `DOCS_BASE_REF=b9870c0c28b2487ddfac723fe2e932c0e3fabfac pnpm docs:check:ci`。
+- 源码审计确认不存在展示专用 CLI/IPC、Claude `PostCompact` 注入或 Cursor 配置 Overlay；现有 observation 路径、
+  Codex 先行截获、`imminent` 中性状态、仅 `started` 算 active 以及普通 command muted 图标颜色均保留。


### PR DESCRIPTION
## Summary

- remove the Claude PostCompact display Hook injection
- remove the Cursor preCompact private config overlay
- remove the display-only CLI and IPC path while preserving compaction observation redelivery
- keep the imminent/started activity semantics and muted command-style icon
- align current architecture, contract, compatibility, and version documentation

## Validation

- cargo fmt, check, and clippy passed
- rovai-core binary: 189 passed, 4 ignored
- rovai CLI: 32 passed
- slow Rust suite: 297 passed
- Rust lib: 477 passed, 1 unchanged macOS sandbox failure reproduced by minimal sandbox-exec with exit 71
- pnpm test: Vitest 1433 passed; Node/protocol 220 passed, 1 Windows-only skip
- pnpm typecheck and build:desktop passed
- documentation test and governance gates passed