### PR TITLE
chore(release): prepare v0.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "rovai-core"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/rovai-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.5"
+version = "0.0.6"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rovai/desktop",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "license": "MIT",
   "type": "module"

--- a/apps/desktop/src/main/package-metadata.test.ts
+++ b/apps/desktop/src/main/package-metadata.test.ts
@@ -9,7 +9,7 @@ const packageMetadata = JSON.parse(readFileSync(
 describe('desktop package metadata', () => {
   it('keeps the visible brand separate from Electron helper bundle identity', () => {
     expect(packageMetadata.productName).toBe('Rovai AI')
-    expect(packageMetadata.version).toBe('0.0.5')
+    expect(packageMetadata.version).toBe('0.0.6')
     expect(packageMetadata.build.productName).toBe('Rovai AI')
     expect(packageMetadata.build.mac.executableName).toBeUndefined()
     expect(packageMetadata.build.win.executableName).toBe('Rovai-ai')

--- a/build/release-notes.md
+++ b/build/release-notes.md
@@ -1,19 +1,17 @@
-# Rovai AI v0.0.5
+# Rovai AI v0.0.6
 
-Rovai AI 0.0.5 expands the daily Camp workflow with continuous input, faster supported runtimes, richer files and images, and Feishu channel collaboration.
+Rovai AI 0.0.6 improves persistent Camp controls, safer resource navigation, trustworthy Runtime compaction visibility, and DingTalk channel reliability.
 
-macOS arm64 and x64 builds use the same fixed Rovai Release Signing certificate as 0.0.4. Windows x64 remains an unsigned Preview build and may show a SmartScreen warning.
+macOS arm64 and x64 builds use the same fixed Rovai Release Signing certificate as 0.0.5. Windows x64 remains an unsigned Preview build and may show a SmartScreen warning.
 
 ## What's Changed
 
-- Queue and edit the next Camp message while a run is active, then continue automatically with its routing and execution choices frozen at publication.
-- Add per-member Fast preferences with automatic runtime capability detection and safe fallback when a runtime does not support Fast execution.
-- Open changed, referenced, and external files in resizable preview tabs while preserving inline links, reading anchors, and exact file locations.
-- Persist and display structured Runtime images with consistent message timing and retention across Camp switches.
-- Refine execution into compact avatar rails and detail popovers with live refresh, complete output, clearer initiators, and reliable stopped or cancelled terminal states.
-- Add Feishu bot publishing, group and topic project selection, reply and execution cards, adaptive host maintenance, and a bot-gated LAN execution console.
-- Keep DingTalk unavailable in the public channel UI while its remaining consistency and real-client acceptance work is completed.
-- Improve Desktop startup, shutdown, navigation refresh, composer input recovery, approvals, scrollbars, and model catalog refresh behavior.
-- Fix Windows Quick Chat workspace paths and strengthen channel, attachment, cancellation, and Camp-open reliability.
+- Keep execution, task, and member detail popovers open while you work elsewhere, with explicit dismissal from the active entry, close button, or Escape.
+- Fix the shared-memory review drawer layering so its content stays visible and interactive above the page overlay.
+- Recognize local resources only from explicit Markdown links or whole inline-code references, with clearer file-type and web-link icons and the existing safe-open boundary preserved.
+- Show explicitly attributable Runtime compaction as a standalone non-Tool execution row with bounded token or summary details, neutral imminent state, and active started state.
+- Keep compaction display tied to existing native Runtime events without installing display-only hooks, plugins, or configuration overlays.
+- Add durable DingTalk multi-bot aggregation, ordered target admission, restart-safe collection, replay deduplication, bounded parent-message context, and privacy-safe diagnostics.
+- Keep DingTalk unavailable in the public channel UI until the packaged desktop and mobile real-tenant acceptance matrix is complete.
 
-**Full changelog:** https://github.com/murray17/rovai-ai/compare/v0.0.4...v0.0.5
+**Full changelog:** https://github.com/murray17/rovai-ai/compare/v0.0.5...v0.0.6

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rovai-ai",
   "productName": "Rovai AI",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "type": "module",
   "description": "A desktop workspace for long-lived agent teams, shared Camps, visible execution, and collaborative memory.",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rovai/contracts",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/scripts/accept-app-updates-ui.mjs
+++ b/scripts/accept-app-updates-ui.mjs
@@ -56,7 +56,7 @@ try {
     outputDir,
     verified: {
       isolatedPackagedApplication: true,
-      packagedVersion: '0.0.5',
+      packagedVersion: '0.0.6',
       typedIdleUpdaterSnapshot: true,
       productAndBundleName: 'Rovai AI',
       existingSettingsVisualWorld: true,
@@ -93,12 +93,12 @@ async function openAboutUpdates(cdp) {
   assert(selected, 'About & Updates Settings entry was unavailable')
   await waitForSelector(cdp, '.about-updates-settings')
   await waitForExpression(cdp,
-    `document.querySelector('.about-version-value code')?.textContent === 'v0.0.5'`)
+    `document.querySelector('.about-version-value code')?.textContent === 'v0.0.6'`)
 }
 
 async function assertAboutUpdates(cdp, context) {
   const updaterSnapshot = await evaluate(cdp, 'window.rovai.appUpdates.get()', true)
-  assert(updaterSnapshot?.currentVersion === '0.0.5'
+  assert(updaterSnapshot?.currentVersion === '0.0.6'
     && updaterSnapshot.status === 'idle'
     && updaterSnapshot.availableRelease === null
     && updaterSnapshot.lastCheckSource === null
@@ -136,7 +136,7 @@ async function assertAboutUpdates(cdp, context) {
   assert(state.heading === '关于与更新', `${context} omitted the page heading`)
   assert(state.description === 'Rovai AI 会在正式打包版本中主动检查更新；下载、安装和重启始终由你确认。',
     `${context} used the wrong description`)
-  assert(state.product === 'Rovai AI' && state.version === 'v0.0.5',
+  assert(state.product === 'Rovai AI' && state.version === 'v0.0.6',
     `${context} used the wrong product/version: ${JSON.stringify(state)}`)
   assert(state.action === '检查更新' && state.actionTag === 'BUTTON' && state.actionFocused,
     `${context} did not expose a keyboard-focusable check action`)


### PR DESCRIPTION
## Summary

- bump Desktop, contracts, and Rust workspace versions to 0.0.6
- update packaged-app acceptance expectations for 0.0.6
- publish release notes for changes since v0.0.5

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm build:desktop`
- `pnpm test` (1456 Vitest + 220 Node/protocol passed; 1 Windows-only skipped)
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `pnpm test:rust:pr` (478 library + 32 CLI + 297 slow tests passed)

## Release signing

- macOS arm64 and x64 remain bound to the fixed **Rovai Release Signing** certificate used by v0.0.5
- Windows x64 remains an unsigned Preview build