### PR TITLE
docs(release): announce DingTalk availability in v0.0.6

### DIFF
--- a/build/release-notes.md
+++ b/build/release-notes.md
@@ -1,6 +1,6 @@
 # Rovai AI v0.0.6
 
-Rovai AI 0.0.6 improves persistent Camp controls, safer resource navigation, trustworthy Runtime compaction visibility, and DingTalk channel reliability.
+Rovai AI 0.0.6 improves persistent Camp controls, safer resource navigation, trustworthy Runtime compaction visibility, and DingTalk channel management.
 
 macOS arm64 and x64 builds use the same fixed Rovai Release Signing certificate as 0.0.5. Windows x64 remains an unsigned Preview build and may show a SmartScreen warning.
 
@@ -12,6 +12,6 @@ macOS arm64 and x64 builds use the same fixed Rovai Release Signing certificate 
 - Show explicitly attributable Runtime compaction as a standalone non-Tool execution row with bounded token or summary details, neutral imminent state, and active started state.
 - Keep compaction display tied to existing native Runtime events without installing display-only hooks, plugins, or configuration overlays.
 - Add durable DingTalk multi-bot aggregation, ordered target admission, restart-safe collection, replay deduplication, bounded parent-message context, and privacy-safe diagnostics.
-- Keep DingTalk unavailable in the public channel UI until the packaged desktop and mobile real-tenant acceptance matrix is complete.
+- Open DingTalk as a selectable channel provider with typed account, connection, Bot, and management-link controls, while unsupported attachment and native-interaction capabilities remain independently gated.
 
 **Full changelog:** https://github.com/murray17/rovai-ai/compare/v0.0.5...v0.0.6


### PR DESCRIPTION
## Summary

- update v0.0.6 release notes after PR #190 opened DingTalk channel management
- describe the selectable provider and typed setup surface without claiming unsupported capabilities

## Validation

- `pnpm exec vitest run apps/desktop/src/renderer/src/ChannelSettings.test.ts apps/desktop/src/main/package-metadata.test.ts` (21 passed)
- `node --test scripts/lib/release-notes.test.mjs` (5 passed)
- `git diff --check`

## Release baseline

This refresh targets `da1dde5eda94bacd64e7a96364e27adc49194b17` and supersedes the unpublished artifacts built from `f84f642e5278740001c4a80f2f2f7c8f7c81a0a6`.