### PR TITLE
perf(desktop): optimize execution drawer rendering

### DIFF
--- a/apps/desktop/src/renderer/src/App.test.ts
+++ b/apps/desktop/src/renderer/src/App.test.ts
@@ -122,6 +122,7 @@ import {
   executionDisclosureIsLiveOpen,
   firstSubmittedAgentRun,
   formatStopElapsed,
+  groupExecutionEventsByRunId,
   isViewingNonTerminalAgentRun,
   loadCompleteAgentRunExecutionEvidence,
   memberRuntimeConfigurationPresentation,
@@ -4516,6 +4517,68 @@ describe('task event projections', () => {
     expect(accepted).toBe(0)
   })
 
+  it('groups execution events by current Run while preserving snapshot authority and stable time order', () => {
+    const evidence = (
+      id: string,
+      agentRunId: string,
+      sequence: number,
+      occurredAt: string,
+      source: string
+    ): AgentRunExecutionEvidenceView => ({
+      id,
+      agentRunId,
+      executionEpoch: 1,
+      sequence,
+      eventType: 'agent.text.delta',
+      kind: 'narration',
+      phase: 'updated',
+      payload: { source },
+      canonical: null,
+      contentBlobId: null,
+      contentByteCount: 0,
+      isTruncated: false,
+      occurredAt
+    })
+    const sharedTime = '2026-09-03T08:00:01Z'
+    const buckets = groupExecutionEventsByRunId(
+      [{ id: 'run-a' }, { id: 'run-b' }, { id: 'run-empty' }],
+      [
+        evidence('snapshot-z', 'run-a', 2, sharedTime, 'snapshot-z'),
+        evidence('snapshot-a', 'run-a', 3, sharedTime, 'snapshot-a'),
+        evidence('snapshot-b', 'run-b', 1, sharedTime, 'snapshot-b')
+      ],
+      [{
+        id: 'snapshot-z',
+        agentRunId: 'run-a',
+        eventType: 'agent.text.delta',
+        payload: { source: 'live-duplicate' },
+        createdAt: '2026-09-03T08:00:00Z'
+      }, {
+        id: 'live-y',
+        agentRunId: 'run-a',
+        eventType: 'agent.text.delta',
+        payload: { source: 'live-y' },
+        createdAt: sharedTime
+      }, {
+        id: 'outside-camp',
+        agentRunId: 'run-outside',
+        eventType: 'agent.text.delta',
+        payload: { source: 'outside' },
+        createdAt: sharedTime
+      }]
+    )
+
+    expect(buckets.get('run-a')?.map((event) => event.id)).toEqual([
+      'snapshot-z',
+      'snapshot-a',
+      'live-y'
+    ])
+    expect(buckets.get('run-a')?.[0]?.payload).toEqual({ source: 'snapshot-z' })
+    expect(buckets.get('run-b')?.map((event) => event.id)).toEqual(['snapshot-b'])
+    expect(buckets.has('run-empty')).toBe(false)
+    expect(buckets.has('run-outside')).toBe(false)
+  })
+
   it('omits live reasoning summaries while projecting narration, plans and execution steps', () => {
     const reasoningEvent = liveRuntimeEventFromCore({
       method: 'agent.reasoning.summary.delta',
@@ -5034,6 +5097,59 @@ describe('task event projections', () => {
     expect(markup).toContain('请求受到速率限制')
     expect(markup).toContain('请稍后重试。')
     expect(markup).not.toContain('Rovai 内部错误')
+  })
+
+  it('mounts Run details only after a terminal Run is focused while keeping non-terminal details immediate', () => {
+    const run: AgentRunView = {
+      id: 'run-lazy-history', campTurnId: 'turn-1', conversationId: 'conversation-lazy',
+      agentId: 'agent-lazy', taskId: null, responsibilityKey: 'direct:agent-lazy',
+      responsibilityGeneration: 0, purpose: '检查懒挂载', completionRole: 'required',
+      status: 'succeeded', waitReason: null, cancelRequestedAt: null, cancelReasonCode: null,
+      cancelAcknowledgedAt: null, executionEpoch: 1, terminalResolutionSource: null,
+      terminalReasonCode: null, failure: null, runtimeModel: null,
+      permissionSemantics: 'runtime_managed_v2', invocationKind: 'direct',
+      triggerDeliveryGeneration: 0, a2aParentAgentRunId: null, a2aRootAgentRunId: null,
+      a2aDepth: 0, executionEvidenceCount: 1, hasUnsettledExternalEffects: false,
+      workspace: { path: '/repo' }, startingGitObservation: null, endingGitObservation: null,
+      version: 1, createdAt: '2026-09-03T08:00:00Z', startedAt: '2026-09-03T08:00:01Z',
+      endedAt: '2026-09-03T08:00:02Z', updatedAt: '2026-09-03T08:00:02Z'
+    }
+    const progress = {
+      items: [{
+        key: 'narration:lazy',
+        kind: 'narration' as const,
+        body: '仅在详情激活后渲染'
+      }]
+    }
+
+    const collapsedMarkup = renderToStaticMarkup(createElement(RunExecutionDisclosure, {
+      run, progress, campId: 'camp-1'
+    }))
+    expect(collapsedMarkup).toContain('<details class="execution-disclosure worked is-terminal">')
+    expect(collapsedMarkup).toContain('class="process-disclosure-label"')
+    expect(collapsedMarkup).not.toContain('class="process-content"')
+    expect(collapsedMarkup).not.toContain('仅在详情激活后渲染')
+
+    const focusedMarkup = renderToStaticMarkup(createElement(RunExecutionDisclosure, {
+      run, progress, campId: 'camp-1', focused: true
+    }))
+    expect(focusedMarkup).toContain('class="process-content"')
+    expect(focusedMarkup).toContain('仅在详情激活后渲染')
+
+    const waitingMarkup = renderToStaticMarkup(createElement(RunExecutionDisclosure, {
+      run: {
+        ...run,
+        id: 'run-lazy-waiting',
+        status: 'waiting' as const,
+        waitReason: 'recovery_blocked' as const,
+        endedAt: null
+      },
+      progress,
+      campId: 'camp-1'
+    }))
+    expect(waitingMarkup).toContain('class="process-content"')
+    expect(waitingMarkup).toContain('仅在详情激活后渲染')
+    expect(waitingMarkup).toContain('无法安全自动恢复')
   })
 
   it('does not present an ACP protocol kind as Copilot execution detail', () => {

--- a/apps/desktop/src/renderer/src/CampWorkspace.tsx
+++ b/apps/desktop/src/renderer/src/CampWorkspace.tsx
@@ -471,6 +471,42 @@ export function executionDisclosureIsLiveOpen(
   return NON_TERMINAL_RUNS.has(status) && focused && !cancelling
 }
 
+export function groupExecutionEventsByRunId(
+  runs: readonly Pick<AgentRunView, 'id'>[],
+  executionEvidence: readonly AgentRunExecutionEvidenceView[],
+  liveRuntimeEvents: readonly LiveRuntimeEvent[]
+): Map<string, LiveRuntimeEvent[]> {
+  const currentRunIds = new Set(runs.map((run) => run.id))
+  const grouped = new Map<string, Map<string, LiveRuntimeEvent>>()
+
+  const append = (event: LiveRuntimeEvent, authoritative: boolean): void => {
+    if (!currentRunIds.has(event.agentRunId)) return
+
+    let eventsById = grouped.get(event.agentRunId)
+    if (!eventsById) {
+      eventsById = new Map<string, LiveRuntimeEvent>()
+      grouped.set(event.agentRunId, eventsById)
+    }
+
+    if (authoritative || !eventsById.has(event.id)) {
+      eventsById.set(event.id, event)
+    }
+  }
+
+  for (const evidence of executionEvidence) {
+    append(liveRuntimeEventFromExecutionEvidence(evidence), true)
+  }
+  for (const event of liveRuntimeEvents) {
+    append(event, false)
+  }
+
+  return new Map([...grouped.entries()].map(([runId, eventsById]) => {
+    const events = [...eventsById.values()]
+    events.sort((left, right) => left.createdAt.localeCompare(right.createdAt))
+    return [runId, events]
+  }))
+}
+
 export function firstSubmittedAgentRun(
   receipt: CampMessageSendReceipt,
   runs: readonly AgentRunView[]
@@ -1853,22 +1889,20 @@ export function CampWorkspace({
     : null
   const pendingApprovals = snapshot.approvals.filter((approval) => approval.status === 'pending')
   const previousPendingApprovalCount = useRef(pendingApprovals.length)
-  const executionEvents = useMemo(() => {
-    const events = new Map<string, LiveRuntimeEvent>()
-    for (const evidence of snapshot.executionEvidence) {
-      events.set(evidence.id, liveRuntimeEventFromExecutionEvidence(evidence))
-    }
-    for (const event of liveRuntimeEvents) {
-      if (!events.has(event.id)) events.set(event.id, event)
-    }
-    return [...events.values()].sort((left, right) => left.createdAt.localeCompare(right.createdAt))
-  }, [liveRuntimeEvents, snapshot.executionEvidence])
+  const executionEventsByRunId = useMemo(
+    () => groupExecutionEventsByRunId(
+      snapshot.agentRuns,
+      snapshot.executionEvidence,
+      liveRuntimeEvents
+    ),
+    [liveRuntimeEvents, snapshot.agentRuns, snapshot.executionEvidence]
+  )
   const executionProgressByRunId = useMemo(
     () => new Map(snapshot.agentRuns.map((run) => [
       run.id,
-      buildLiveExecutionProgress(executionEvents, run.id)
+      buildLiveExecutionProgress(executionEventsByRunId.get(run.id) ?? [], run.id)
     ])),
-    [executionEvents, snapshot.agentRuns]
+    [executionEventsByRunId, snapshot.agentRuns]
   )
   const worldMapProjection = useMemo(
     () => projectCampWorldMap(snapshot.members, snapshot.agentRuns, executionProgressByRunId),
@@ -8436,46 +8470,36 @@ function RuntimeRetryNotice({ diagnostic }: {
   )
 }
 
-export function RunExecutionDisclosure({
+type RunExecutionHistoryStatus = 'idle' | 'loading' | 'ready' | 'failed'
+
+function RunExecutionContent({
   run,
   progress,
   campId,
-  truncatedEvidence = [],
-  loadedEvidenceCount = 0,
-  finalBody = null,
-  cancelling = false,
-  focused = false,
+  truncatedEvidence,
+  historicalEvidence,
+  historyStatus,
+  finalBody,
+  cancelling,
+  onLoadHistoricalEvidence,
   onResolveRecoveryBlocker,
-  resolvingRecoveryBlocker = false
+  resolvingRecoveryBlocker
 }: {
   run: AgentRunView
   progress?: LiveExecutionProgress
   campId: string
-  truncatedEvidence?: AgentRunExecutionEvidenceView[]
-  loadedEvidenceCount?: number
-  finalBody?: string | null
-  cancelling?: boolean
-  focused?: boolean
+  truncatedEvidence: AgentRunExecutionEvidenceView[]
+  historicalEvidence: AgentRunExecutionEvidenceView[] | null
+  historyStatus: RunExecutionHistoryStatus
+  finalBody: string | null
+  cancelling: boolean
+  onLoadHistoricalEvidence(): Promise<void>
   onResolveRecoveryBlocker?(run: AgentRunView): Promise<void>
-  resolvingRecoveryBlocker?: boolean
-}): JSX.Element | null {
+  resolvingRecoveryBlocker: boolean
+}): JSX.Element {
   const nonTerminal = NON_TERMINAL_RUNS.has(run.status)
-  const active = executionDisclosureIsLiveOpen(run.status, focused, cancelling)
-  const cancellingActive = nonTerminal && cancelling && focused
   const publicFailure = run.status === 'failed' ? run.failure : null
-  const hasPublicFailure = publicFailure !== null
-  const [open, setOpen] = useState(active || hasPublicFailure)
-  const [historicalEvidence, setHistoricalEvidence] = useState<AgentRunExecutionEvidenceView[] | null>(null)
-  const [historyStatus, setHistoryStatus] = useState<'idle' | 'loading' | 'ready' | 'failed'>('idle')
-  useEffect(() => {
-    setOpen((currentOpen) => executionDisclosureOpenAfterActivity(
-      currentOpen,
-      active || cancellingActive || hasPublicFailure
-    ))
-  }, [active, cancellingActive, hasPublicFailure])
-
-  const durableEvidenceCount = Math.max(0, run.executionEvidenceCount)
-  const historyNeeded = !nonTerminal && loadedEvidenceCount < durableEvidenceCount
+  const showUnsettledWarning = agentRunShowsUnsettledWarning(run)
   const historicalProgress = useMemo(() => historicalEvidence
     ? buildLiveExecutionProgress(
         historicalEvidence.map(liveRuntimeEventFromExecutionEvidence),
@@ -8511,32 +8535,8 @@ export function RunExecutionDisclosure({
         item.kind === 'diagnostic' ? item.diagnostic : latest, null)
     : null
   const completeEvidence = selectCompleteExecutionEvidence(effectiveTruncatedEvidence)
-  const hasProgress = processItems.length > 0
-  const showUnsettledWarning = agentRunShowsUnsettledWarning(run)
-  if (!nonTerminal && durableEvidenceCount === 0 && !hasProgress && truncatedEvidence.length === 0 && !showUnsettledWarning && !hasPublicFailure) {
-    return null
-  }
 
-  const loadHistoricalEvidence = async (): Promise<void> => {
-    if (!historyNeeded || historyStatus === 'loading' || historyStatus === 'ready') return
-    setHistoryStatus('loading')
-    try {
-      const evidence = await loadCompleteAgentRunExecutionEvidence(
-        (params) => window.rovai.request<AgentRunExecutionEvidencePage>(
-          'agentRunEvidence.list',
-          params
-        ),
-        campId,
-        run.id
-      )
-      setHistoricalEvidence(evidence)
-      setHistoryStatus('ready')
-    } catch {
-      setHistoryStatus('failed')
-    }
-  }
-
-  const content = (
+  return (
     <div className="process-content">
       {publicFailure && <RuntimeFailureNotice failure={publicFailure} />}
       {showUnsettledWarning && (
@@ -8631,7 +8631,7 @@ export function RunExecutionDisclosure({
       {historyStatus === 'failed' && (
         <div className="process-action history-load-error" role="status">
           <span>完整执行过程读取失败。</span>
-          <button className="quiet-button compact" type="button" onClick={() => void loadHistoricalEvidence()}>
+          <button className="quiet-button compact" type="button" onClick={() => void onLoadHistoricalEvidence()}>
             重试
           </button>
         </div>
@@ -8680,6 +8680,102 @@ export function RunExecutionDisclosure({
       )}
     </div>
   )
+}
+
+export function RunExecutionDisclosure({
+  run,
+  progress,
+  campId,
+  truncatedEvidence = [],
+  loadedEvidenceCount = 0,
+  finalBody = null,
+  cancelling = false,
+  focused = false,
+  onResolveRecoveryBlocker,
+  resolvingRecoveryBlocker = false
+}: {
+  run: AgentRunView
+  progress?: LiveExecutionProgress
+  campId: string
+  truncatedEvidence?: AgentRunExecutionEvidenceView[]
+  loadedEvidenceCount?: number
+  finalBody?: string | null
+  cancelling?: boolean
+  focused?: boolean
+  onResolveRecoveryBlocker?(run: AgentRunView): Promise<void>
+  resolvingRecoveryBlocker?: boolean
+}): JSX.Element | null {
+  const nonTerminal = NON_TERMINAL_RUNS.has(run.status)
+  const active = executionDisclosureIsLiveOpen(run.status, focused, cancelling)
+  const cancellingActive = nonTerminal && cancelling && focused
+  const publicFailure = run.status === 'failed' ? run.failure : null
+  const hasPublicFailure = publicFailure !== null
+  const [open, setOpen] = useState(active || hasPublicFailure)
+  const [historicalEvidence, setHistoricalEvidence] = useState<AgentRunExecutionEvidenceView[] | null>(null)
+  const [historyStatus, setHistoryStatus] = useState<RunExecutionHistoryStatus>('idle')
+  const shouldActivateContent = open || focused || nonTerminal
+  const [contentMounted, setContentMounted] = useState(() => shouldActivateContent)
+  useEffect(() => {
+    setOpen((currentOpen) => executionDisclosureOpenAfterActivity(
+      currentOpen,
+      active || cancellingActive || hasPublicFailure
+    ))
+  }, [active, cancellingActive, hasPublicFailure])
+  useEffect(() => {
+    if (shouldActivateContent) setContentMounted(true)
+  }, [shouldActivateContent])
+
+  const durableEvidenceCount = Math.max(0, run.executionEvidenceCount)
+  const historyNeeded = !nonTerminal && loadedEvidenceCount < durableEvidenceCount
+  const showUnsettledWarning = agentRunShowsUnsettledWarning(run)
+  const hasDisclosureWithoutProgress = nonTerminal
+    || durableEvidenceCount > 0
+    || truncatedEvidence.length > 0
+    || showUnsettledWarning
+    || hasPublicFailure
+  if (!hasDisclosureWithoutProgress) {
+    const finalKey = finalBody ? comparableMessageText(finalBody) : null
+    const hasProgress = (progress?.items ?? []).some((item) =>
+      item.kind !== 'narration' || !finalKey || comparableMessageText(item.body) !== finalKey
+    )
+    if (!hasProgress) return null
+  }
+
+  const loadHistoricalEvidence = async (): Promise<void> => {
+    if (!historyNeeded || historyStatus === 'loading' || historyStatus === 'ready') return
+    setHistoryStatus('loading')
+    try {
+      const evidence = await loadCompleteAgentRunExecutionEvidence(
+        (params) => window.rovai.request<AgentRunExecutionEvidencePage>(
+          'agentRunEvidence.list',
+          params
+        ),
+        campId,
+        run.id
+      )
+      setHistoricalEvidence(evidence)
+      setHistoryStatus('ready')
+    } catch {
+      setHistoryStatus('failed')
+    }
+  }
+
+  const shouldMountContent = contentMounted || shouldActivateContent
+  const content = shouldMountContent ? (
+    <RunExecutionContent
+      run={run}
+      progress={progress}
+      campId={campId}
+      truncatedEvidence={truncatedEvidence}
+      historicalEvidence={historicalEvidence}
+      historyStatus={historyStatus}
+      finalBody={finalBody}
+      cancelling={cancelling}
+      onLoadHistoricalEvidence={loadHistoricalEvidence}
+      onResolveRecoveryBlocker={onResolveRecoveryBlocker}
+      resolvingRecoveryBlocker={resolvingRecoveryBlocker}
+    />
+  ) : null
 
   if (cancellingActive) {
     return <div className="execution-disclosure run-live is-cancelling">{content}</div>
@@ -8694,7 +8790,10 @@ export function RunExecutionDisclosure({
       onToggle={(event) => {
         const nextOpen = event.currentTarget.open
         setOpen(nextOpen)
-        if (nextOpen) void loadHistoricalEvidence()
+        if (nextOpen) {
+          setContentMounted(true)
+          void loadHistoricalEvidence()
+        }
       }}
     >
       <summary>

--- a/apps/desktop/src/renderer/src/execution-console-layout.test.ts
+++ b/apps/desktop/src/renderer/src/execution-console-layout.test.ts
@@ -75,6 +75,11 @@ describe('execution console layout', () => {
     expect(styleBlock('.run-pulse-chip-copy')).toMatch(/margin-inline-start:\s*4px/)
   })
 
+  it('uses immediate drawer scrolling while JavaScript owns latest-position restoration', () => {
+    expect(styleBlock('.execution-drawer-body')).toMatch(/scroll-behavior:\s*auto/)
+    expect(styleBlock('.execution-drawer-body')).not.toMatch(/scroll-behavior:\s*smooth/)
+  })
+
   it('keeps the Tool group operation count visible in the right sidecar', () => {
     expect(styles).not.toMatch(
       /\.execution-drawer-inspector \.tool-group-count\s*\{[^}]*display:\s*none/

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -2251,7 +2251,7 @@ html.file-preview-resizing .file-preview-pane { pointer-events: none; }
 .execution-run-stop-state.tone-attention { color: var(--attention); }
 .execution-run-stop-state.tone-neutral { color: var(--muted); }
 .execution-drawer-action-button { min-width: 48px; }
-.execution-drawer-body { min-height: 0; overflow: auto; padding: 12px 20px 18px; overscroll-behavior: contain; scroll-behavior: smooth; }
+.execution-drawer-body { min-height: 0; overflow: auto; padding: 12px 20px 18px; overscroll-behavior: contain; scroll-behavior: auto; }
 .execution-process-timeline { position: relative; display: grid; gap: 0; margin: 0; padding: 0; list-style: none; }
 .execution-process-timeline::before { position: absolute; top: 13px; bottom: 17px; left: 6px; width: 1px; background: var(--line-strong); content: ""; }
 .execution-process-stage { position: relative; display: grid; min-width: 0; grid-template-columns: 14px minmax(0, 1fr); gap: 9px; padding: 0 0 13px; border-radius: 8px; scroll-margin: 22px; }


### PR DESCRIPTION
## Summary

- switch the execution drawer from smooth scrolling to immediate positioning while preserving existing follow-latest and reading-position behavior
- filter current Camp events and bucket them by agentRunId before building per-Run execution progress, preserving snapshot authority and stable createdAt ordering
- lazily mount terminal Run details once activated, while keeping active, focused, and default-open failure details immediate and retaining mounted Tool state after re-collapse
- move detail-only progress derivation and heavy Markdown, Tool, Diff, compaction, and diagnostic rendering behind the lazy boundary

## Validation

- pnpm typecheck
- pnpm exec vitest run — 140 files, 1480 tests
- pnpm build:desktop
- git diff --check

## Scope

No changes to camps.open, execution-evidence APIs, pagination, global live-event retention, historical request triggering, or Tool-level state architecture.