### PR TITLE
fix(desktop): label directory attachments as DIR

### DIFF
--- a/apps/desktop/src/renderer/src/attachment-presentation.test.ts
+++ b/apps/desktop/src/renderer/src/attachment-presentation.test.ts
@@ -58,6 +58,6 @@ describe('attachment presentation classification', () => {
       agentDisplayType: 'archive'
     })
     expect(attachmentBaseName('design-export', 'directory')).toBe('design-export')
-    expect(attachmentFormatLabel('design-export', 'directory')).toBe('文件夹')
+    expect(attachmentFormatLabel('design-export', 'directory')).toBe('DIR')
   })
 })

--- a/apps/desktop/src/renderer/src/attachment-presentation.tsx
+++ b/apps/desktop/src/renderer/src/attachment-presentation.tsx
@@ -68,7 +68,7 @@ export function attachmentBaseName(displayName: string, kind: AttachmentKind): s
 }
 
 export function attachmentFormatLabel(displayName: string, kind: AttachmentKind): string {
-  if (kind === 'directory') return '文件夹'
+  if (kind === 'directory') return 'DIR'
   return attachmentExtension(displayName).toLocaleUpperCase('en-US') || 'FILE'
 }
 


### PR DESCRIPTION
## Summary

- change the shared directory attachment format badge from `文件夹` to `DIR`
- apply the label consistently to user-message, Agent-delivery, and Composer attachment cards through the centralized presentation helper
- preserve Chinese directory wording in actions, menus, drag-and-drop guidance, and errors

## Verification

- `pnpm exec vitest run apps/desktop/src/renderer/src/attachment-presentation.test.ts` (12 tests)
- `pnpm typecheck`
- Impeccable detector: no findings
- `git diff --check`
