### PR TITLE
fix(desktop): auto-load earlier camp messages

### DIFF
--- a/apps/desktop/src/renderer/src/CampWorkspace.history-loader.test.ts
+++ b/apps/desktop/src/renderer/src/CampWorkspace.history-loader.test.ts
@@ -1,0 +1,102 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import type { CampSnapshot } from '@contracts'
+import {
+  CampWorkspace,
+  campHistoryKeyboardInputMovesEarlier
+} from './CampWorkspace'
+
+const createdAt = '2026-09-04T00:00:00Z'
+
+function renderHistoryLoader(hasEarlier = true): string {
+  const snapshot: CampSnapshot = {
+    schemaVersion: 34,
+    throughGlobalSequence: 1,
+    camp: {
+      id: 'camp-history-loader',
+      title: '历史消息',
+      activationState: 'active',
+      projectBindingKind: 'quick_chat',
+      projectPath: '/quick-chat',
+      defaultLeadAgentId: 'agent-1',
+      membershipGeneration: 1,
+      version: 1,
+      createdAt,
+      updatedAt: createdAt
+    },
+    members: [],
+    membershipReconciliations: [],
+    tasks: [],
+    messages: [],
+    messageDeliveries: [],
+    turns: [],
+    agentRuns: [],
+    executionEvidence: [],
+    agentRunFileChanges: [],
+    contextManifests: [],
+    approvals: [],
+    actions: [],
+    timeline: []
+  }
+
+  return renderToStaticMarkup(createElement(CampWorkspace, {
+    snapshot,
+    messageHistory: {
+      loadedCount: 20,
+      totalCount: 28,
+      omittedCount: 8,
+      complete: !hasEarlier,
+      oldestLoadedSequence: 9,
+      newestLoadedSequence: 28,
+      hasEarlier
+    },
+    onLoadEarlierMessages: async () => undefined,
+    projectName: null,
+    agents: [],
+    busy: false,
+    onSend: async () => undefined,
+    onChangeLead: async () => undefined,
+    onTasksChanged: async () => undefined,
+    onResolveApproval: () => undefined,
+    stopping: false,
+    onStop: () => undefined,
+    worldMapEnabled: false
+  }))
+}
+
+describe('Camp history loader', () => {
+  it('keeps the manual history entry as a native text button with coverage', () => {
+    const markup = renderHistoryLoader()
+    const loader = markup.match(/<div class="camp-history-loader[^>]*>[\s\S]*?<\/div>/)?.[0]
+
+    expect(loader).toContain('class="camp-history-loader is-idle"')
+    expect(loader).toContain('<button class="camp-history-text-button" type="button">')
+    expect(loader).toContain('<span aria-hidden="true">↑</span><span>加载更早消息</span>')
+    expect(loader).toContain('已显示 20 / 28 条')
+    expect(loader).not.toContain('quiet-button compact')
+    expect(loader).not.toContain('camp-history-error"')
+  })
+
+  it('hides the history entry when there are no earlier messages', () => {
+    expect(renderHistoryLoader(false)).not.toContain('camp-history-loader')
+  })
+
+  it.each([
+    ['ArrowUp', false],
+    ['PageUp', false],
+    ['Home', false],
+    [' ', true]
+  ])('recognizes %s as an upward history input', (key, shiftKey) => {
+    expect(campHistoryKeyboardInputMovesEarlier(key, shiftKey)).toBe(true)
+  })
+
+  it.each([
+    ['ArrowDown', false],
+    ['PageDown', false],
+    ['End', false],
+    [' ', false]
+  ])('does not treat %s as an upward history input', (key, shiftKey) => {
+    expect(campHistoryKeyboardInputMovesEarlier(key, shiftKey)).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/src/CampWorkspace.tsx
+++ b/apps/desktop/src/renderer/src/CampWorkspace.tsx
@@ -153,6 +153,17 @@ const EXECUTION_DRAWER_MIN_TIMELINE_HEIGHT = 112
 const EXECUTION_DRAWER_KEYBOARD_STEP = 24
 const EXECUTION_DRAWER_KEYBOARD_PAGE_STEP = 80
 const CAMP_CONVERSATION_VIEW_STORAGE_KEY = 'rovai.camp-conversation-view.v1'
+const CAMP_HISTORY_AUTOLOAD_THRESHOLD_PX = 120
+
+export function campHistoryKeyboardInputMovesEarlier(
+  key: string,
+  shiftKey: boolean
+): boolean {
+  return key === 'ArrowUp'
+    || key === 'PageUp'
+    || key === 'Home'
+    || (key === ' ' && shiftKey)
+}
 
 export function composerHasSendablePayload(
   message: string,
@@ -1402,6 +1413,7 @@ export function CampWorkspace({
   const dragActivityTimer = useRef<number | null>(null)
   const attachmentPreparationQueue = useRef<Promise<void>>(Promise.resolve())
   const timelineScrollRef = useRef<HTMLDivElement>(null)
+  const earlierMessageLoadInFlightRef = useRef(false)
   const conversationFindSurfaceRef = useRef<HTMLDivElement>(null)
   const conversationFindInputRef = useRef<HTMLInputElement>(null)
   const conversationFindRequestGeneration = useRef(0)
@@ -3538,23 +3550,59 @@ export function CampWorkspace({
   }
 
   const loadEarlierMessages = async (): Promise<void> => {
-    if (!onLoadEarlierMessages || earlierMessageStatus === 'loading') return
+    if (
+      !onLoadEarlierMessages
+      || !messageHistory?.hasEarlier
+      || earlierMessageLoadInFlightRef.current
+    ) return
     const timeline = timelineScrollRef.current
-    const previousScrollHeight = timeline?.scrollHeight ?? 0
-    const previousScrollTop = timeline?.scrollTop ?? 0
+    if (!timeline) return
+    const campId = snapshot.camp.id
+    const previousScrollHeight = timeline.scrollHeight
+    const previousScrollTop = timeline.scrollTop
+    earlierMessageLoadInFlightRef.current = true
     setEarlierMessageStatus('loading')
     try {
       await onLoadEarlierMessages()
-      setEarlierMessageStatus('idle')
-      window.requestAnimationFrame(() => {
+      await new Promise<void>((resolve) => {
         window.requestAnimationFrame(() => {
-          if (!timeline) return
-          timeline.scrollTop = previousScrollTop + timeline.scrollHeight - previousScrollHeight
+          window.requestAnimationFrame(() => resolve())
         })
       })
+
+      if (
+        timelineScrollRef.current === timeline
+        && mountedCampId.current === campId
+        && !timeline.hidden
+        && !conversationFindOpenRef.current
+      ) {
+        timeline.scrollTop = previousScrollTop + timeline.scrollHeight - previousScrollHeight
+        recordTimelineReadingPosition(campId, timeline)
+      }
+      setEarlierMessageStatus('idle')
     } catch {
-      setEarlierMessageStatus('error')
+      setEarlierMessageStatus(mountedCampId.current === campId ? 'error' : 'idle')
+    } finally {
+      earlierMessageLoadInFlightRef.current = false
     }
+  }
+
+  const maybeLoadEarlierFromUserInput = (): void => {
+    const timeline = timelineScrollRef.current
+    if (
+      !timeline
+      || conversationView !== 'conversation'
+      || conversationFindOpenRef.current
+      || earlierMessageStatus !== 'idle'
+      || !messageHistory?.hasEarlier
+      || timeline.scrollTop > CAMP_HISTORY_AUTOLOAD_THRESHOLD_PX
+    ) return
+
+    void loadEarlierMessages()
+  }
+
+  const checkHistoryAfterUserInput = (): void => {
+    window.requestAnimationFrame(maybeLoadEarlierFromUserInput)
   }
 
   const openExecutionProcess = (
@@ -3856,11 +3904,17 @@ export function CampWorkspace({
               tabIndex={-1}
               aria-label="对话时间线"
               hidden={conversationView !== 'conversation'}
-              onWheelCapture={() => captureFilePreviewAnchor()}
+              onWheelCapture={(event) => {
+                captureFilePreviewAnchor()
+                if (event.deltaY < 0) checkHistoryAfterUserInput()
+              }}
               onTouchStartCapture={() => captureFilePreviewAnchor()}
               onKeyDownCapture={(event) => {
                 if (['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', ' '].includes(event.key)) {
                   captureFilePreviewAnchor()
+                }
+                if (campHistoryKeyboardInputMovesEarlier(event.key, event.shiftKey)) {
+                  checkHistoryAfterUserInput()
                 }
               }}
               onScroll={(event) => recordTimelineReadingPosition(
@@ -3870,26 +3924,48 @@ export function CampWorkspace({
             >
               <div className="timeline-track">
               {!conversationFind.open && messageHistory?.hasEarlier && (
-                <div className="camp-history-loader" role="status" aria-live="polite">
-                  <button
-                    className="quiet-button compact"
-                    type="button"
-                    disabled={earlierMessageStatus === 'loading'}
-                    onClick={() => void loadEarlierMessages()}
-                  >
-                    {earlierMessageStatus === 'loading' ? '正在加载更早消息…' : '加载更早消息'}
-                  </button>
-                  <span>
+                <div
+                  className={`camp-history-loader is-${earlierMessageStatus}`}
+                  role={earlierMessageStatus === 'error' ? 'alert' : 'status'}
+                  aria-live={earlierMessageStatus === 'error' ? 'assertive' : 'polite'}
+                  aria-atomic="true"
+                >
+                  {earlierMessageStatus === 'error' ? (
+                    <>
+                      <span className="camp-history-error-message">较早消息暂时没有加载</span>
+                      <span className="camp-history-separator" aria-hidden="true">·</span>
+                      <button
+                        className="camp-history-text-button"
+                        type="button"
+                        onClick={() => void loadEarlierMessages()}
+                      >
+                        重试
+                      </button>
+                    </>
+                  ) : (
+                    <button
+                      className="camp-history-text-button"
+                      type="button"
+                      disabled={earlierMessageStatus === 'loading'}
+                      onClick={() => void loadEarlierMessages()}
+                    >
+                      {earlierMessageStatus === 'loading' ? (
+                        <>
+                          <span className="camp-history-spinner" aria-hidden="true" />
+                          <span>正在加载更早消息…</span>
+                        </>
+                      ) : (
+                        <>
+                          <span aria-hidden="true">↑</span>
+                          <span>加载更早消息</span>
+                        </>
+                      )}
+                    </button>
+                  )}
+                  <span className="camp-history-separator" aria-hidden="true">·</span>
+                  <span className="camp-history-count">
                     已显示 {messageHistory.loadedCount} / {messageHistory.totalCount} 条
                   </span>
-                </div>
-              )}
-              {!conversationFind.open && earlierMessageStatus === 'error' && messageHistory?.hasEarlier && (
-                <div className="camp-history-error" role="alert">
-                  <span>较早消息暂时没有加载。</span>
-                  <button className="quiet-button compact" type="button" onClick={() => void loadEarlierMessages()}>
-                    重试
-                  </button>
                 </div>
               )}
               {(() => {

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -2504,20 +2504,59 @@ button.camp-world-map-live-caption { cursor: pointer; font: inherit; }
 .camp-world-map.is-static .camp-world-map-route, .camp-world-map.is-static .camp-world-map-route[data-active], .camp-world-map.is-static .camp-world-map-agent-button::before, .camp-world-map.is-static .camp-world-map-speech, .camp-world-map.is-static .camp-world-map-ambient-encounter { animation: none; transition: none; }
 .camp-world-map.is-static .camp-world-map-agent-button::before { opacity: 0; }
 .timeline-track { position: relative; width: min(790px, 100%); min-height: 100%; margin: 0 auto; }
-.camp-history-loader,
-.camp-history-error {
+.camp-history-loader {
   display: flex;
   min-height: 36px;
   align-items: center;
   justify-content: center;
-  gap: 9px;
+  gap: 7px;
   margin: 0 auto 14px;
   color: var(--muted);
   font-size: 11px;
+  white-space: nowrap;
 }
-.camp-history-loader .quiet-button,
-.camp-history-error .quiet-button { flex: 0 0 auto; }
-.camp-history-error { color: var(--danger); }
+.camp-history-text-button {
+  display: inline-flex;
+  min-height: 28px;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 2px;
+  border: 0;
+  border-radius: 4px;
+  color: var(--brand-ink);
+  background: transparent;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 650;
+  line-height: 1.35;
+  text-decoration: none;
+  text-underline-offset: 3px;
+  transition: color 150ms ease;
+}
+.camp-history-text-button:hover:not(:disabled) {
+  color: var(--brand-hover);
+  text-decoration: underline;
+}
+.camp-history-text-button:disabled {
+  color: var(--muted);
+  font-weight: 500;
+  text-decoration: none;
+}
+.camp-history-loader.is-error,
+.camp-history-loader.is-error .camp-history-text-button { color: var(--danger); }
+.camp-history-loader.is-error .camp-history-text-button:hover { color: var(--danger); }
+.camp-history-separator { color: var(--line-strong); }
+.camp-history-count { color: var(--faint); font-variant-numeric: tabular-nums; }
+.camp-history-spinner {
+  width: 11px;
+  height: 11px;
+  flex: 0 0 11px;
+  border: 1.5px solid var(--line-strong);
+  border-top-color: var(--muted);
+  border-radius: 50%;
+  animation: camp-marker-spin 900ms linear infinite;
+}
 .empty-camp-welcome {
   display: grid;
   min-height: 100%;


### PR DESCRIPTION
## Summary

- keep the native earlier-message button and restyle the persistent history row as a quiet text action
- load one earlier page when desktop wheel or upward navigation input reaches the top 120px
- guard duplicate requests with one synchronous ref and keep loading active through the existing two-frame scroll restoration
- keep errors in the same row with an explicit retry action; leave pagination, coverage, observers, touch handling, and backend contracts unchanged

## Verification

- `pnpm typecheck`
- `pnpm exec vitest run` — 142 files, 1505 tests passed
- `pnpm build:desktop`
- `ROVAI_CAMP_OPEN_ACCEPT_NO_SANDBOX=1 pnpm test:camp-open-projection` — passed with zero refresh/append anchor delta
- Impeccable detector run; findings were pre-existing warnings elsewhere in the shared stylesheet, with no finding in this change

The broader Electron integration command cannot initialize Chromium's sandbox in the current host and exits before application code loads; the directly relevant CampOpen native acceptance passes through its repository-supported isolated no-sandbox path.
