### PR TITLE
style(desktop): add mist gray markdown code layers

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -153,9 +153,10 @@ only boundary of an input or control.
   accent. Semantic danger or attention may replace the accent when meaning requires it.
 - **Evidence:** uses the dedicated evidence and diff tokens, monospaced type where appropriate, and
   structural `+`/`-`, line numbers or labels in addition to color.
-- **Code:** narrative inline code uses its dedicated quiet canvas with `0 2px` padding and a `3px`
-  radius; fenced code uses the matching block canvas with an evidence border, while other bounded
-  evidence surfaces keep the stronger evidence canvas.
+- **Code:** shared SafeMarkdown surfaces use a quiet inline canvas with `0 2px` padding and a `3px`
+  radius; fenced code uses the matching block canvas with an evidence border. Camp message prose
+  applies its component-owned Mist Gray treatment without changing file previews, release notes or
+  Runtime process copy. Other bounded evidence surfaces keep the stronger evidence canvas.
 - **Identity:** portraits and eight stable identity tokens are a narrow exception to the neutral
   workspace. Identity treatments do not spread into background decoration.
 

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -99,6 +99,9 @@
   --shadow-card: none;
   --approval-line: #d8bd87;
   --inline-code-canvas: #e9eceb;
+  --conversation-inline-code-canvas: #eef0f1;
+  --conversation-code-block-canvas: #f4f5f5;
+  --conversation-code-line: #d9dee1;
   --shell-result-canvas: #f3f4f3;
   --code-block-canvas: #eef2f5;
   --evidence-canvas: #f4f6f3;
@@ -233,6 +236,9 @@
   --shadow-float: 0 22px 64px rgba(0, 0, 0, 0.42);
   --approval-line: #8f7447;
   --inline-code-canvas: #353b3f;
+  --conversation-inline-code-canvas: #30373b;
+  --conversation-code-block-canvas: #252c30;
+  --conversation-code-line: #3e494f;
   --shell-result-canvas: #373f43;
   --code-block-canvas: #1d252b;
   --evidence-canvas: #12191d;
@@ -3146,6 +3152,9 @@ button.camp-world-map-live-caption { cursor: pointer; font: inherit; }
 .safe-markdown code { padding: 0 2px; border-radius: 3px; color: var(--evidence-ink); background: var(--inline-code-canvas); font: .9em/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
 .safe-markdown .markdown-file-reference code { color: inherit; }
 .safe-markdown pre code { padding: 0; background: transparent; font-size: inherit; }
+.conversation-bubble :is(.final-copy, .message-bubble) .safe-markdown code { padding: 1px 4px; border-radius: 6px; background: var(--conversation-inline-code-canvas); box-decoration-break: clone; -webkit-box-decoration-break: clone; }
+.conversation-bubble :is(.final-copy, .message-bubble) .safe-markdown pre { padding: 11px 12px; border-color: var(--conversation-code-line); border-radius: 8px; background: var(--conversation-code-block-canvas); }
+.conversation-bubble :is(.final-copy, .message-bubble) .safe-markdown pre code { padding: 0; border-radius: 0; background: transparent; }
 .safe-markdown table { display: block; width: 100%; margin: 9px 0; overflow-x: auto; border-spacing: 0; border-collapse: collapse; font-size: 11px; }
 .safe-markdown th, .safe-markdown td { padding: 6px 8px; border: 1px solid var(--line); text-align: left; vertical-align: top; }
 .safe-markdown th { background: var(--surface-muted); font-weight: 700; }

--- a/apps/desktop/src/renderer/src/theme-tokens.test.ts
+++ b/apps/desktop/src/renderer/src/theme-tokens.test.ts
@@ -58,6 +58,9 @@ const requiredTokens = [
   '--focus',
   '--overlay',
   '--inline-code-canvas',
+  '--conversation-inline-code-canvas',
+  '--conversation-code-block-canvas',
+  '--conversation-code-line',
   '--shell-result-canvas',
   '--code-block-canvas',
   '--evidence-canvas',
@@ -124,6 +127,8 @@ function expectTextContrast(tokens: Record<string, string>): void {
     ['--info', '--info-soft'],
     ['--neutral', '--neutral-soft'],
     ['--evidence-ink', '--inline-code-canvas'],
+    ['--evidence-ink', '--conversation-inline-code-canvas'],
+    ['--evidence-ink', '--conversation-code-block-canvas'],
     ['--evidence-muted', '--shell-result-canvas'],
     ['--evidence-ink', '--code-block-canvas'],
     ['--evidence-ink', '--evidence-surface'],
@@ -200,6 +205,9 @@ describe('Porcelain Day + Steel Night theme tokens', () => {
     expect(day['--rail-logo']).toBe('#526f88')
     expect(day['--mention-ink']).toBe('#2f61c8')
     expect(day['--inline-code-canvas']).toBe('#e9eceb')
+    expect(day['--conversation-inline-code-canvas']).toBe('#eef0f1')
+    expect(day['--conversation-code-block-canvas']).toBe('#f4f5f5')
+    expect(day['--conversation-code-line']).toBe('#d9dee1')
     expect(day['--shell-result-canvas']).toBe('#f3f4f3')
     expect(day['--code-block-canvas']).toBe('#eef2f5')
     expect(day['--diff-add-soft']).toBe('#d9f1e2')
@@ -234,6 +242,9 @@ describe('Porcelain Day + Steel Night theme tokens', () => {
     expect(night['--brand-soft']).toBe('#22303a')
     expect(night['--mention-ink']).toBe('#9cc7e2')
     expect(night['--inline-code-canvas']).toBe('#353b3f')
+    expect(night['--conversation-inline-code-canvas']).toBe('#30373b')
+    expect(night['--conversation-code-block-canvas']).toBe('#252c30')
+    expect(night['--conversation-code-line']).toBe('#3e494f')
     expect(night['--shell-result-canvas']).toBe('#373f43')
     expect(night['--code-block-canvas']).toBe('#1d252b')
     expect(night['--diff-add-soft']).toBe('#21412e')
@@ -352,6 +363,9 @@ describe('Porcelain Day + Steel Night theme tokens', () => {
     expect(css).not.toMatch(/\.safe-markdown code\s*\{[^}]*\bborder\s*:/)
     expect(css).toMatch(/\.safe-markdown pre\s*\{[^}]*background:\s*var\(--code-block-canvas\)/)
     expect(css).toMatch(/\.safe-markdown pre code\s*\{[^}]*padding:\s*0[^}]*background:\s*transparent/)
+    expect(css).toMatch(/\.conversation-bubble :is\(\.final-copy, \.message-bubble\) \.safe-markdown code\s*\{[^}]*padding:\s*1px 4px[^}]*border-radius:\s*6px[^}]*background:\s*var\(--conversation-inline-code-canvas\)[^}]*box-decoration-break:\s*clone/)
+    expect(css).toMatch(/\.conversation-bubble :is\(\.final-copy, \.message-bubble\) \.safe-markdown pre\s*\{[^}]*padding:\s*11px 12px[^}]*border-color:\s*var\(--conversation-code-line\)[^}]*border-radius:\s*8px[^}]*background:\s*var\(--conversation-code-block-canvas\)/)
+    expect(css).toMatch(/\.conversation-bubble :is\(\.final-copy, \.message-bubble\) \.safe-markdown pre code\s*\{[^}]*padding:\s*0[^}]*border-radius:\s*0[^}]*background:\s*transparent/)
     expect(css).toContain('.conversation-bubble:hover .message-copy-button')
     expect(css).toContain('.conversation-bubble:hover .message-reply-button')
     expect(css).toContain('.composer-box:focus-within')

--- a/docs/ui/components/conversation-workspace.md
+++ b/docs/ui/components/conversation-workspace.md
@@ -2,7 +2,7 @@
 document_type: ui-component-contract
 authority: renderer-camp-workspace
 status: accepted
-last_updated: 2026-09-03
+last_updated: 2026-09-04
 ---
 
 # Camp 会话工作区
@@ -177,6 +177,12 @@ Agent 公共正文不显示“来自执行”来源条，也不投影 compact �
 工件或 footer 漂移。用户消息保持
 精确纯文本，仅对[文件链接](file-preview.md#会话内的文件链接)做展示投影：Markdown label 替代其链接语法，
 文件代码路径保留等宽样式，原始消息及整条消息复制内容不改写；Agent 正文使用清洗后的 GFM；Tool 输出使用结构化证据组件。
+
+会话消息正文的 SafeMarkdown 使用 Mist Gray 分层：行内 code 以
+`--conversation-inline-code-canvas` 为底色，保留 `1px 4px` 留白、`6px` 圆角和跨行连续底色；围栏代码块使用
+`--conversation-code-block-canvas`、`--conversation-code-line`、`11px 12px` 留白与 `8px` 圆角。块内
+`pre code` 必须继续透明且不保留行内留白或圆角。该覆盖只属于用户/Agent 消息正文，不改变文件预览、更新说明、
+Runtime 过程正文、附件卡片或其他 SafeMarkdown 表面；Day 与 Night 分别使用主题文档给出的独立 token 值。
 
 当前可操作的队员头像、显示名和 Mention 可打开同一个锚定人物信息卡，不导航。已离开、移除或
 不可解析身份保持静态。精确 token 行为见[结构化 Mention](structured-mentions.md)。

--- a/docs/ui/themes/porcelain-day.md
+++ b/docs/ui/themes/porcelain-day.md
@@ -4,7 +4,7 @@ authority: renderer-theme
 status: accepted
 theme_id: porcelain-day
 mode: light
-last_updated: 2026-09-03
+last_updated: 2026-09-04
 ---
 
 # Porcelain Day
@@ -139,6 +139,9 @@ Agent 交付文件的图形色只表达格式家族，不表达状态、身份�
 | Token | Value |
 |---|---:|
 | `--inline-code-canvas` | `#e9eceb` |
+| `--conversation-inline-code-canvas` | `#eef0f1` |
+| `--conversation-code-block-canvas` | `#f4f5f5` |
+| `--conversation-code-line` | `#d9dee1` |
 | `--shell-result-canvas` | `#f3f4f3` |
 | `--code-block-canvas` | `#eef2f5` |
 | `--evidence-canvas` | `#f4f6f3` |
@@ -187,6 +190,9 @@ Agent 交付文件的图形色只表达格式家族，不表达状态、身份�
 - Narrative inline code uses the borderless `--inline-code-canvas`; Shell command results use
   `--shell-result-canvas`; fenced code uses the bounded `--code-block-canvas` with its evidence
   border, while other evidence surfaces continue to use `--evidence-canvas`.
+- Camp message prose uses the dedicated `--conversation-inline-code-canvas`,
+  `--conversation-code-block-canvas` and `--conversation-code-line` Mist Gray layer. These tokens do
+  not alter file previews, release notes or Runtime process copy.
 
 ## Contrast requirements
 

--- a/docs/ui/themes/steel-night.md
+++ b/docs/ui/themes/steel-night.md
@@ -4,7 +4,7 @@ authority: renderer-theme
 status: accepted
 theme_id: steel-night
 mode: dark
-last_updated: 2026-09-03
+last_updated: 2026-09-04
 ---
 
 # Steel Night
@@ -139,6 +139,9 @@ Night 为相同十个格式家族提供独立亮度值；它们只表达文件�
 | Token | Value |
 |---|---:|
 | `--inline-code-canvas` | `#353b3f` |
+| `--conversation-inline-code-canvas` | `#30373b` |
+| `--conversation-code-block-canvas` | `#252c30` |
+| `--conversation-code-line` | `#3e494f` |
 | `--shell-result-canvas` | `#373f43` |
 | `--code-block-canvas` | `#1d252b` |
 | `--evidence-canvas` | `#12191d` |
@@ -188,6 +191,9 @@ they do not become statuses. Evidence and diffs remain neutral and structurally 
 inline code uses the borderless `--inline-code-canvas`; Shell command results use
 `--shell-result-canvas`; fenced code uses the bounded `--code-block-canvas` with its evidence border,
 while other evidence surfaces continue to use `--evidence-canvas`.
+Camp message prose uses the dedicated `--conversation-inline-code-canvas`,
+`--conversation-code-block-canvas` and `--conversation-code-line` Mist Gray layer; file previews,
+release notes and Runtime process copy keep the shared defaults.
 
 ## Contrast requirements
 


### PR DESCRIPTION
## Summary

- add conversation-only Mist Gray canvases for inline and fenced Markdown code
- preserve shared SafeMarkdown styling for file previews, release notes, and Runtime process copy
- document Porcelain Day and Steel Night tokens and extend contrast/style regression coverage

## Validation

- `pnpm typecheck`
- `pnpm exec vitest run apps/desktop/src/renderer/src/theme-tokens.test.ts` (28/28)
- `DOCS_BASE_REF=0ca5dab662fc0b8f678873b571bc075d28707d78 pnpm docs:check:ci`
- `pnpm test` (142 files / 1505 tests; Node 220 passed, 1 platform skip)
- `pnpm build:desktop`
- local arm64 packaged-App acceptance with a six-message mock Camp in Porcelain Day and Steel Night
