### PR TITLE
fix(desktop): anchor history prepend restoration

### DIFF
--- a/apps/desktop/src/renderer/src/CampWorkspace.tsx
+++ b/apps/desktop/src/renderer/src/CampWorkspace.tsx
@@ -3558,6 +3558,7 @@ export function CampWorkspace({
     const timeline = timelineScrollRef.current
     if (!timeline) return
     const campId = snapshot.camp.id
+    const readingAnchor = captureTimelineReadingAnchor(timeline)
     const previousScrollHeight = timeline.scrollHeight
     const previousScrollTop = timeline.scrollTop
     earlierMessageLoadInFlightRef.current = true
@@ -3576,7 +3577,11 @@ export function CampWorkspace({
         && !timeline.hidden
         && !conversationFindOpenRef.current
       ) {
-        timeline.scrollTop = previousScrollTop + timeline.scrollHeight - previousScrollHeight
+        if (readingAnchor.source || readingAnchor.message) {
+          restoreTimelineReadingAnchor(timeline, readingAnchor)
+        } else {
+          timeline.scrollTop = previousScrollTop + timeline.scrollHeight - previousScrollHeight
+        }
         recordTimelineReadingPosition(campId, timeline)
       }
       setEarlierMessageStatus('idle')

--- a/scripts/fixtures/camp-open-projection/main.cjs
+++ b/scripts/fixtures/camp-open-projection/main.cjs
@@ -78,6 +78,17 @@ app.whenReady().then(async () => {
     assert.ok(Math.abs(appended.anchorTop - before.anchorTop) <= 1, 'A background message cannot steal the reading position')
     assert.deepEqual(appended.cards, before.cards)
     assert.equal(appended.allEventSequencesNull, true)
+    await run('window.campOpenTest.prepareHistoryLoad()')
+    await state()
+    await run('window.campOpenTest.bookmark()')
+    const beforeHistoryLoad = await state()
+    await run('window.campOpenTest.loadEarlier()')
+    const afterHistoryLoad = await state()
+    assert.equal(afterHistoryLoad.messages.length, 61)
+    assert.equal(afterHistoryLoad.sameAnchorNode, true)
+    const historyLoadAnchorDelta = afterHistoryLoad.anchorTop - beforeHistoryLoad.anchorTop
+    assert.ok(Math.abs(historyLoadAnchorDelta) <= 1,
+      `Loading earlier messages cannot count a concurrent append as prepended height (${historyLoadAnchorDelta}px)`)
     await capture('refresh-day')
     await run("document.documentElement.dataset.theme = 'night'")
     await state()
@@ -196,7 +207,9 @@ app.whenReady().then(async () => {
     assert.deepEqual(errors, [], 'No React key, rendering or fixture API errors')
     console.log(JSON.stringify({ ok: true, messages: appended.messages.length,
       refreshAnchorDelta: refreshed.anchorTop - before.anchorTop,
-      appendAnchorDelta: appended.anchorTop - before.anchorTop, cards: appended.cards }))
+      appendAnchorDelta: appended.anchorTop - before.anchorTop,
+      historyLoadAnchorDelta,
+      cards: appended.cards }))
     window.destroy(); app.quit()
   } catch (error) {
     console.error(errors)

--- a/scripts/fixtures/camp-open-projection/renderer.tsx
+++ b/scripts/fixtures/camp-open-projection/renderer.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import type {
   AgentProfile,
   CampComposerDraftView,
+  CampOpenMessageCoverage,
   CampOpenProjection,
   NavigationCampItem,
   NavigationSnapshot
@@ -87,6 +88,7 @@ const earlier = { ...campOpenProjectionAsSnapshot(projection(60)),
   messages: messages.slice(0, 40).map(message => ({ ...message, timelineGlobalSequence: message.sequence })) }
 let current = campOpenProjectionAsSnapshot(projection(60), earlier)
 let updateSnapshot: (snapshot: typeof current) => void
+let updateMessageHistory: (coverage: CampOpenMessageCoverage | null) => void
 let closeTask: () => void
 type FixtureImageResult = { displayName: string; mediaType: string; data: string }
 const mockImageResult = (
@@ -280,10 +282,12 @@ const navigation: NavigationSnapshot = {
 
 function Fixture(): React.JSX.Element {
   const [snapshot, setSnapshot] = useState(current)
+  const [messageHistory, setMessageHistory] = useState<CampOpenMessageCoverage | null>(null)
   const [open, setOpen] = useState(false)
   const [tab, setTab] = useState<CampInspectorTab>(attachmentReviewMode ? 'members' : 'tasks')
   const [entryHost, setEntryHost] = useState<HTMLElement | null>(null)
   updateSnapshot = setSnapshot
+  updateMessageHistory = setMessageHistory
   closeTask = () => setOpen(false)
   return <div className="app-shell app-shell-camp">
     <CampNavigation view="camp" state="ready" navigation={navigation} activeCampId={campId}
@@ -296,6 +300,16 @@ function Fixture(): React.JSX.Element {
       detailEntryHostRef={setEntryHost} onFocusApprovals={() => {}} />
     <main className="content task-content">
       <CampWorkspace snapshot={snapshot} projectName="rovai-ai" agents={agents} busy={false} stopping={false}
+        messageHistory={messageHistory}
+        onLoadEarlierMessages={async () => {
+          current = { ...current, messages: [...current.messages, messages[60]] }
+          setSnapshot(current)
+          await new Promise<void>(resolve => requestAnimationFrame(() => resolve()))
+          current = { ...current, messages: [...messages.slice(0, 20), ...current.messages] }
+          setSnapshot(current)
+          setMessageHistory({ loadedCount: 61, totalCount: 61, omittedCount: 0, complete: true,
+            oldestLoadedSequence: 1, newestLoadedSequence: 61, hasEarlier: false })
+        }}
         onSend={async () => {}} onChangeLead={async () => {}} onTasksChanged={async () => {}}
         onResolveApproval={() => {}} onStop={() => {}} worldMapEnabled={false} executionPlacement="bottom"
         inspectorVisible={open} inspectorTab={tab} detailEntryHost={entryHost}
@@ -319,6 +333,18 @@ Object.assign(window, { campOpenTest: {
   refresh: (append: boolean) => {
     current = campOpenProjectionAsSnapshot({ ...projection(append ? 61 : 60), throughGlobalSequence: append ? 101 : 100 }, current)
     updateSnapshot(current)
+  },
+  prepareHistoryLoad: () => {
+    current = { ...current, messages: messages.slice(20, 60) }
+    updateSnapshot(current)
+    updateMessageHistory({ loadedCount: 40, totalCount: 61, omittedCount: 21, complete: false,
+      oldestLoadedSequence: 21, newestLoadedSequence: 60, hasEarlier: true })
+  },
+  loadEarlier: async () => {
+    element('.camp-history-text-button').click()
+    for (let index = 0; index < 6; index += 1) {
+      await new Promise<void>(resolve => requestAnimationFrame(() => resolve()))
+    }
   },
   showImages: (result: { displayName: string; mediaType: string; data: string }, count = 1) => {
     imageResult = result


### PR DESCRIPTION
## Summary

- capture the existing timeline reading anchor before requesting an earlier page
- restore that visible message anchor after the prepend commits
- keep the previous scroll-height delta only when no stable message anchor is available
- extend the production CampOpen fixture with a concurrent bottom append during history loading

## Root cause

The previous restoration treated every `scrollHeight` increase during the request as prepended history. A concurrent bottom message therefore contributed its height to the compensation and moved the reader by one extra message.

## Verification

- regression before fix: visible anchor delta `-57.0625px`
- regression after fix: visible anchor delta `-0.0625px`
- `ROVAI_CAMP_OPEN_ACCEPT_NO_SANDBOX=1 pnpm test:camp-open-projection`
- `pnpm typecheck`
- `pnpm exec vitest run` — 142 files, 1505 tests passed
- `pnpm build:desktop`
- Impeccable detector — no findings
