### PR TITLE
fix(renderer): keep timeline positions in memory

### DIFF
--- a/apps/desktop/src/renderer/src/CampWorkspace.timeline-position-memory.test.ts
+++ b/apps/desktop/src/renderer/src/CampWorkspace.timeline-position-memory.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import {
+  rememberedCampTimelineReadingPosition,
+  rememberCampTimelineReadingPosition
+} from './CampWorkspace'
+
+describe('Camp timeline reading position memory', () => {
+  it('stores copies and retains only the 50 most recently written Camps', () => {
+    const campId = (index: number): string => `timeline-memory-test-${index}`
+
+    for (let index = 0; index < 50; index += 1) {
+      rememberCampTimelineReadingPosition(campId(index), {
+        scrollTop: index * 10,
+        followingLatest: false
+      })
+    }
+
+    const remembered = rememberedCampTimelineReadingPosition(campId(0))
+    expect(remembered).toEqual({ scrollTop: 0, followingLatest: false })
+    if (remembered) remembered.scrollTop = 999
+    expect(rememberedCampTimelineReadingPosition(campId(0))).toEqual({
+      scrollTop: 0,
+      followingLatest: false
+    })
+
+    rememberCampTimelineReadingPosition(campId(0), {
+      scrollTop: 720,
+      followingLatest: true
+    })
+    rememberCampTimelineReadingPosition(campId(50), {
+      scrollTop: -20,
+      followingLatest: false
+    })
+
+    expect(rememberedCampTimelineReadingPosition(campId(1))).toBeNull()
+    expect(rememberedCampTimelineReadingPosition(campId(0))).toEqual({
+      scrollTop: 720,
+      followingLatest: true
+    })
+    expect(rememberedCampTimelineReadingPosition(campId(50))).toEqual({
+      scrollTop: 0,
+      followingLatest: false
+    })
+
+    rememberCampTimelineReadingPosition(campId(50), {
+      scrollTop: Number.NaN,
+      followingLatest: true
+    })
+    expect(rememberedCampTimelineReadingPosition(campId(50))).toEqual({
+      scrollTop: 0,
+      followingLatest: true
+    })
+  })
+})

--- a/apps/desktop/src/renderer/src/CampWorkspace.tsx
+++ b/apps/desktop/src/renderer/src/CampWorkspace.tsx
@@ -116,14 +116,11 @@ import {
 } from './AppDialog'
 import { projectCampWorldMap } from './camp-world-map-model'
 import {
-  CAMP_TIMELINE_READING_POSITIONS_STORAGE_KEY,
   campTimelineContentChanged,
   campTimelineFollowingLatestAfterScroll,
   campTimelineIsNearBottom,
-  campTimelineReadingPositionFromStoredValue,
   followLatestCampTimeline,
   restoredCampTimelineScrollTop,
-  storedCampTimelineReadingPositionsWithUpdate,
   type CampTimelineReadingPosition,
   type CampTimelineViewportGeometry
 } from './camp-timeline-position'
@@ -155,6 +152,40 @@ const EXECUTION_DRAWER_KEYBOARD_STEP = 24
 const EXECUTION_DRAWER_KEYBOARD_PAGE_STEP = 80
 const CAMP_CONVERSATION_VIEW_STORAGE_KEY = 'rovai.camp-conversation-view.v1'
 const CAMP_HISTORY_AUTOLOAD_THRESHOLD_PX = 120
+const CAMP_TIMELINE_READING_POSITION_LIMIT = 50
+const campTimelineReadingPositions = new Map<string, CampTimelineReadingPosition>()
+
+if (typeof window !== 'undefined') {
+  try {
+    window.localStorage.removeItem('rovai.camp-timeline-reading-positions.v2')
+  } catch {
+    // Legacy cleanup is best effort; reading positions now live only in Renderer memory.
+  }
+}
+
+export function rememberedCampTimelineReadingPosition(
+  campId: string
+): CampTimelineReadingPosition | null {
+  const position = campTimelineReadingPositions.get(campId)
+  return position ? { ...position } : null
+}
+
+export function rememberCampTimelineReadingPosition(
+  campId: string,
+  position: CampTimelineReadingPosition
+): void {
+  campTimelineReadingPositions.delete(campId)
+  campTimelineReadingPositions.set(campId, {
+    scrollTop: Math.max(0, Number.isFinite(position.scrollTop) ? position.scrollTop : 0),
+    followingLatest: position.followingLatest
+  })
+
+  while (campTimelineReadingPositions.size > CAMP_TIMELINE_READING_POSITION_LIMIT) {
+    const oldestCampId = campTimelineReadingPositions.keys().next().value
+    if (!oldestCampId) break
+    campTimelineReadingPositions.delete(oldestCampId)
+  }
+}
 
 export function campHistoryKeyboardInputMovesEarlier(
   key: string,
@@ -719,36 +750,6 @@ function persistExecutionDrawerHeight(height: number | null): void {
     }
   } catch {
     // Session persistence is an enhancement; resizing remains usable if storage is unavailable.
-  }
-}
-
-function storedCampTimelineReadingPosition(
-  campId: string
-): CampTimelineReadingPosition | null {
-  if (typeof window === 'undefined') return null
-  try {
-    return campTimelineReadingPositionFromStoredValue(
-      window.localStorage.getItem(CAMP_TIMELINE_READING_POSITIONS_STORAGE_KEY),
-      campId
-    )
-  } catch {
-    return null
-  }
-}
-
-function persistCampTimelineReadingPosition(
-  campId: string,
-  position: CampTimelineReadingPosition
-): void {
-  if (typeof window === 'undefined') return
-  try {
-    const current = window.localStorage.getItem(CAMP_TIMELINE_READING_POSITIONS_STORAGE_KEY)
-    window.localStorage.setItem(
-      CAMP_TIMELINE_READING_POSITIONS_STORAGE_KEY,
-      storedCampTimelineReadingPositionsWithUpdate(current, campId, position)
-    )
-  } catch {
-    // Reading-position persistence is an enhancement; the timeline remains usable without it.
   }
 }
 
@@ -2828,7 +2829,7 @@ export function CampWorkspace({
     }
     const current = timelineReadingPosition.current
     if (!current || (campId && current.campId !== campId)) return
-    persistCampTimelineReadingPosition(current.campId, current.position)
+    rememberCampTimelineReadingPosition(current.campId, current.position)
   }, [])
 
   const recordTimelineReadingPosition = useCallback((
@@ -2881,7 +2882,7 @@ export function CampWorkspace({
     timelinePositionSaveTimer.current = window.setTimeout(() => {
       timelinePositionSaveTimer.current = null
       const current = timelineReadingPosition.current
-      if (current) persistCampTimelineReadingPosition(current.campId, current.position)
+      if (current) rememberCampTimelineReadingPosition(current.campId, current.position)
     }, 180)
   }, [conversationFind.open])
 
@@ -2942,7 +2943,7 @@ export function CampWorkspace({
       window.clearTimeout(timelinePositionSaveTimer.current)
       timelinePositionSaveTimer.current = null
     }
-    persistCampTimelineReadingPosition(campId, position)
+    rememberCampTimelineReadingPosition(campId, position)
   }, [])
 
   useLayoutEffect(() => {
@@ -2952,7 +2953,7 @@ export function CampWorkspace({
       if (scroll) {
         const current = timelineReadingPosition.current?.campId === campId
           ? timelineReadingPosition.current.position
-          : storedCampTimelineReadingPosition(campId)
+          : rememberedCampTimelineReadingPosition(campId)
         const scrollTop = restoredCampTimelineScrollTop(
           current,
           scroll.scrollHeight,

--- a/apps/desktop/src/renderer/src/camp-timeline-position.test.ts
+++ b/apps/desktop/src/renderer/src/camp-timeline-position.test.ts
@@ -3,64 +3,11 @@ import {
   campTimelineContentChanged,
   campTimelineFollowingLatestAfterScroll,
   campTimelineIsNearBottom,
-  campTimelineReadingPositionFromStoredValue,
   followLatestCampTimeline,
-  restoredCampTimelineScrollTop,
-  storedCampTimelineReadingPositionsWithUpdate
+  restoredCampTimelineScrollTop
 } from './camp-timeline-position'
 
-const CAMP_IDS = [
-  'rvcamp_01h47kvsy5fk1shh6w1g60eec0',
-  'rvcamp_01h47kvsy5fk1shh6w1g60eec1',
-  'rvcamp_01h47kvsy5fk1shh6w1g60eec2',
-  'rvcamp_01h47kvsy5fk1shh6w1g60eec3',
-] as const
-
 describe('Camp timeline reading positions', () => {
-  it('round-trips one position and replaces the same Camp entry', () => {
-    const first = storedCampTimelineReadingPositionsWithUpdate(
-      null,
-      CAMP_IDS[0],
-      { scrollTop: 240, followingLatest: false },
-      10
-    )
-    expect(campTimelineReadingPositionFromStoredValue(first, CAMP_IDS[0])).toEqual({
-      scrollTop: 240,
-      followingLatest: false
-    })
-
-    const second = storedCampTimelineReadingPositionsWithUpdate(
-      first,
-      CAMP_IDS[0],
-      { scrollTop: 720, followingLatest: true },
-      20
-    )
-    expect(campTimelineReadingPositionFromStoredValue(second, CAMP_IDS[0])).toEqual({
-      scrollTop: 720,
-      followingLatest: true
-    })
-    expect((JSON.parse(second) as { entries: unknown[] }).entries).toHaveLength(1)
-  })
-
-  it('rejects corrupt data and keeps only the newest bounded Camps', () => {
-    expect(campTimelineReadingPositionFromStoredValue('{broken', CAMP_IDS[0])).toBeNull()
-    let stored: string | null = null
-    for (let index = 1; index <= 4; index += 1) {
-      stored = storedCampTimelineReadingPositionsWithUpdate(
-        stored,
-        CAMP_IDS[index - 1],
-        { scrollTop: index * 10, followingLatest: false },
-        index,
-        3
-      )
-    }
-    expect(campTimelineReadingPositionFromStoredValue(stored, CAMP_IDS[0])).toBeNull()
-    expect(campTimelineReadingPositionFromStoredValue(stored, CAMP_IDS[3])).toEqual({
-      scrollTop: 40,
-      followingLatest: false
-    })
-  })
-
   it('restores a reading offset unless the Camp was following the latest message', () => {
     expect(restoredCampTimelineScrollTop(null, 1_000, 300)).toBe(700)
     expect(restoredCampTimelineScrollTop(

--- a/apps/desktop/src/renderer/src/camp-timeline-position.ts
+++ b/apps/desktop/src/renderer/src/camp-timeline-position.ts
@@ -14,75 +14,7 @@ export type CampTimelineContentMarker = {
   itemCount: number
 }
 
-type StoredCampTimelineReadingPosition = CampTimelineReadingPosition & {
-  campId: string
-  updatedAt: number
-}
-
-type StoredCampTimelineReadingPositions = {
-  version: 2
-  entries: StoredCampTimelineReadingPosition[]
-}
-
-export const CAMP_TIMELINE_READING_POSITIONS_STORAGE_KEY =
-  'rovai.camp-timeline-reading-positions.v2'
 export const CAMP_TIMELINE_BOTTOM_THRESHOLD = 48
-const CAMP_TIMELINE_READING_POSITION_LIMIT = 50
-
-function storedPositionsFromValue(value: string | null): StoredCampTimelineReadingPosition[] {
-  if (!value) return []
-  try {
-    const parsed = JSON.parse(value) as Partial<StoredCampTimelineReadingPositions>
-    if (parsed.version !== 2 || !Array.isArray(parsed.entries)) return []
-    return parsed.entries.filter((entry): entry is StoredCampTimelineReadingPosition =>
-      Boolean(entry)
-      && isCampId(entry.campId)
-      && typeof entry.scrollTop === 'number'
-      && Number.isFinite(entry.scrollTop)
-      && entry.scrollTop >= 0
-      && typeof entry.followingLatest === 'boolean'
-      && typeof entry.updatedAt === 'number'
-      && Number.isFinite(entry.updatedAt)
-      && entry.updatedAt >= 0
-    )
-  } catch {
-    return []
-  }
-}
-
-export function campTimelineReadingPositionFromStoredValue(
-  value: string | null,
-  campId: string
-): CampTimelineReadingPosition | null {
-  const entry = storedPositionsFromValue(value)
-    .filter((candidate) => candidate.campId === campId)
-    .sort((left, right) => right.updatedAt - left.updatedAt)[0]
-  return entry
-    ? { scrollTop: entry.scrollTop, followingLatest: entry.followingLatest }
-    : null
-}
-
-export function storedCampTimelineReadingPositionsWithUpdate(
-  value: string | null,
-  campId: string,
-  position: CampTimelineReadingPosition,
-  updatedAt = Date.now(),
-  limit = CAMP_TIMELINE_READING_POSITION_LIMIT
-): string {
-  const boundedLimit = Math.max(1, Math.floor(limit))
-  const nextEntry: StoredCampTimelineReadingPosition = {
-    campId,
-    scrollTop: Math.max(0, Number.isFinite(position.scrollTop) ? position.scrollTop : 0),
-    followingLatest: position.followingLatest,
-    updatedAt: Math.max(0, Number.isFinite(updatedAt) ? updatedAt : 0)
-  }
-  const entries = storedPositionsFromValue(value)
-    .filter((entry) => entry.campId !== campId)
-    .concat(nextEntry)
-    .sort((left, right) => right.updatedAt - left.updatedAt)
-    .slice(0, boundedLimit)
-  return JSON.stringify({ version: 2, entries } satisfies StoredCampTimelineReadingPositions)
-}
 
 export function campTimelineIsNearBottom(
   scrollTop: number,
@@ -132,4 +64,3 @@ export function restoredCampTimelineScrollTop(
   if (!position || position.followingLatest) return maximum
   return Math.min(maximum, Math.max(0, position.scrollTop))
 }
-import { isCampId } from '@contracts'


### PR DESCRIPTION
## Summary

- replace Camp timeline reading-position localStorage persistence with a Renderer-lifetime, 50-Camp in-memory cache
- remove obsolete disk serialization helpers and clear the legacy key once when the Renderer module starts
- keep the existing scroll detection, delayed save, flush, map/conversation restore, and follow-latest behavior unchanged
- cover copy isolation, replacement ordering, eviction, and scrollTop sanitization

## Validation

- pnpm exec vitest run apps/desktop/src/renderer/src/camp-timeline-position.test.ts apps/desktop/src/renderer/src/CampWorkspace.timeline-position-memory.test.ts apps/desktop/src/renderer/src/CampWorkspace.history-loader.test.ts
- pnpm exec vitest run
- pnpm typecheck
- pnpm build:desktop