### PR TITLE
fix(renderer): keep composer caret visible

### DIFF
--- a/apps/desktop/src/renderer/src/StructuredMentionComposer.tsx
+++ b/apps/desktop/src/renderer/src/StructuredMentionComposer.tsx
@@ -1281,17 +1281,25 @@ function restoreDomSelection(
   const focus = domPointAtOffset(editor, clamp(selectionValue.focus, 0, length))
   if (typeof selection.setBaseAndExtent === 'function') {
     selection.setBaseAndExtent(anchor.node, anchor.offset, focus.node, focus.offset)
-    return
+  } else {
+    const range = document.createRange()
+    const start = Math.min(selectionValue.anchor, selectionValue.focus)
+    const end = Math.max(selectionValue.anchor, selectionValue.focus)
+    const startPoint = domPointAtOffset(editor, clamp(start, 0, length))
+    const endPoint = domPointAtOffset(editor, clamp(end, 0, length))
+    range.setStart(startPoint.node, startPoint.offset)
+    range.setEnd(endPoint.node, endPoint.offset)
+    selection.removeAllRanges()
+    selection.addRange(range)
   }
-  const range = document.createRange()
-  const start = Math.min(selectionValue.anchor, selectionValue.focus)
-  const end = Math.max(selectionValue.anchor, selectionValue.focus)
-  const startPoint = domPointAtOffset(editor, clamp(start, 0, length))
-  const endPoint = domPointAtOffset(editor, clamp(end, 0, length))
-  range.setStart(startPoint.node, startPoint.offset)
-  range.setEnd(endPoint.node, endPoint.offset)
-  selection.removeAllRanges()
-  selection.addRange(range)
+  // Controlled edits restore the caret after React commits. Chromium does not
+  // reliably move this scroll container with a programmatically restored caret.
+  if (
+    selectionValue.anchor === selectionValue.focus
+    && clamp(selectionValue.focus, 0, length) === length
+  ) {
+    editor.scrollTop = editor.scrollHeight
+  }
 }
 
 function editorContainsPoint(editor: HTMLDivElement, node: Node): boolean {

--- a/scripts/fixtures/structured-mention-composer/main.cjs
+++ b/scripts/fixtures/structured-mention-composer/main.cjs
@@ -213,6 +213,34 @@ app.whenReady().then(async () => {
       await expectText('1、第一项\n2、第二项x\n3、另外')
     })
 
+    await run('long controlled input and paste keep the caret viewport at the end', async () => {
+      const text = '这是一段尚未发送的长消息。'.repeat(120)
+      const expectCaretViewportAtEnd = async () => {
+        const state = await expectText(text)
+        assert.ok(state.editorScrollHeight > state.editorClientHeight,
+          'The regression input must overflow the Composer editor')
+        assert.ok(state.editorScrollTop > 0,
+          'The Composer editor must scroll with its restored end caret')
+        assert.ok(
+          state.editorScrollHeight - state.editorClientHeight - state.editorScrollTop <= 2,
+          `The restored end caret must remain in the Composer viewport: ${JSON.stringify({
+            scrollTop: state.editorScrollTop,
+            scrollHeight: state.editorScrollHeight,
+            clientHeight: state.editorClientHeight
+          })}`
+        )
+      }
+
+      await reset('')
+      await insert(text)
+      await expectCaretViewportAtEnd()
+
+      await reset('')
+      await evaluate(`window.composerTest.paste(${JSON.stringify(text)})`)
+      await frames()
+      await expectCaretViewportAtEnd()
+    })
+
     await run('controlled slash input filters and replaces only the current query', async () => {
       const prefix = '请先检查模块，然后 '
       await reset(`${prefix}再继续`)

--- a/scripts/fixtures/structured-mention-composer/renderer.tsx
+++ b/scripts/fixtures/structured-mention-composer/renderer.tsx
@@ -110,7 +110,10 @@ function Harness() {
             selectedId: selected?.id ?? null,
             activeVisible: Boolean(menuBounds && selectedBounds
               && selectedBounds.top >= menuBounds.top && selectedBounds.bottom <= menuBounds.bottom),
-            menuScrollTop: menu?.scrollTop ?? 0
+            menuScrollTop: menu?.scrollTop ?? 0,
+            editorScrollTop: element?.scrollTop ?? 0,
+            editorScrollHeight: element?.scrollHeight ?? 0,
+            editorClientHeight: element?.clientHeight ?? 0
           }
         }
       }

--- a/scripts/lib/structured-mention-composer.test.mjs
+++ b/scripts/lib/structured-mention-composer.test.mjs
@@ -53,7 +53,7 @@ test('Composer edits preserve text, structured tokens and Skill query interactio
     assert.equal(code, 0, `Native Composer regression failed (${signal}):\n${stdout}\n${stderr}`)
     const report = JSON.parse(stdout.split('\n').find(line => line.startsWith('{')))
     assert.equal(report.ok, true)
-    assert.equal(report.cases.length, 18)
+    assert.equal(report.cases.length, 19)
   } finally {
     if (child && child.exitCode === null && child.signalCode === null) {
       child.kill('SIGKILL')


### PR DESCRIPTION
## Summary

- keep the controlled Composer editor scrolled to its restored caret when that collapsed caret is at the end of the draft
- leave non-terminal selections, middle-of-draft edits, and the Camp timeline scroll path unchanged
- extend the native Electron Composer fixture with long controlled input and clipboard-paste coverage

## Validation

- native Electron Composer fixture: 19 of 19 scenarios passed; the local run used fixture-only no-sandbox because this automation host rejects a nested Chromium sandbox
- pnpm exec vitest run apps/desktop/src/renderer/src/StructuredMentionComposer.test.ts apps/desktop/src/renderer/src/structured-mention-model.test.ts
- pnpm exec vitest run
- pnpm typecheck
- pnpm build:desktop