### PR TITLE
Refine file reference and preview tab icons

### DIFF
--- a/apps/desktop/src/renderer/src/FilePreviewTabIcon.test.ts
+++ b/apps/desktop/src/renderer/src/FilePreviewTabIcon.test.ts
@@ -1,0 +1,53 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { ResourceReferenceIcon } from './FilePreviewTabIcon'
+import type { ResourceReferenceVisualKind } from './file-reference-presentation'
+
+const approvedGlyphMarkers: ReadonlyArray<readonly [ResourceReferenceVisualKind, string]> = [
+  ['web', 'r="8.25"'],
+  ['folder', 'M3.75 8.75'],
+  ['markdown', 'M8 14.8V9.2'],
+  ['html', 'm9.2 9.25-2 2 2 2'],
+  ['code', 'm9 8.5-3 3.5 3 3.5'],
+  ['config', 'M6.75 5.75h8.5'],
+  ['text', 'M6.8 5.5h10.4'],
+  ['image', 'm7 16 3.2-3.4'],
+  ['svg', 'm9 15 2.5-5.5'],
+  ['patch', 'M8 6.5h8'],
+  ['pdf', 'M8.2 15.2v-4.4'],
+  ['document', 'M8.4 11h6.4'],
+  ['spreadsheet', 'M9.7 5.8v12.4'],
+  ['presentation', 'M12 16.5v2.7'],
+  ['notebook', 'M8 5.5h8.3'],
+  ['archive', 'M10.4 5.5h3.2'],
+  ['audio', 'M9.2 16.5a1.9'],
+  ['video', 'm16.75 10.2 2.7-1.5'],
+  ['database', 'rx="5.8" ry="2.35"'],
+  ['executable', 'm16.4 7.9 1.4 1.4'],
+  ['file', 'M7 5.5h7.7']
+]
+
+describe('resource reference glyphs', () => {
+  it.each(approvedGlyphMarkers)('renders the approved %s geometry', (kind, marker) => {
+    const markup = renderToStaticMarkup(createElement(ResourceReferenceIcon, {
+      kind,
+      className: 'resource-icon'
+    }))
+
+    expect(markup).toContain(`data-resource-type="${kind}"`)
+    expect(markup).toContain(marker)
+    expect(markup).toContain('viewBox="0 0 24 24"')
+    expect(markup).toContain('aria-hidden="true"')
+    expect(markup).toContain('focusable="false"')
+  })
+
+  it('keeps every visual type distinct', () => {
+    const glyphs = approvedGlyphMarkers.map(([kind]) => renderToStaticMarkup(createElement(
+      ResourceReferenceIcon,
+      { kind, className: 'resource-icon' }
+    )).replace(/ data-resource-type="[^"]+"/u, ''))
+
+    expect(new Set(glyphs).size).toBe(approvedGlyphMarkers.length)
+  })
+})

--- a/apps/desktop/src/renderer/src/FilePreviewTabIcon.tsx
+++ b/apps/desktop/src/renderer/src/FilePreviewTabIcon.tsx
@@ -7,47 +7,47 @@ import {
 function ResourceReferenceGlyph({ kind }: { kind: ResourceReferenceVisualKind }): React.JSX.Element {
   switch (kind) {
     case 'web':
-      return <><circle cx="12" cy="12" r="9" /><path d="M3 12h18M12 3c2.4 2.5 3.5 5.5 3.5 9S14.4 18.5 12 21M12 3C9.6 5.5 8.5 8.5 8.5 12S9.6 18.5 12 21" /></>
-    case 'markdown':
-      return <><path d="M4 4.5h7a3 3 0 0 1 3 3v12a4 4 0 0 0-4-2.5H4zM20 4.5h-3.5A2.5 2.5 0 0 0 14 7" /><path d="M7 9.5v4m0-4 2 2 2-2v4" /></>
-    case 'html':
-      return <><rect x="3" y="4" width="18" height="16" rx="2" /><path d="M3 8.5h18M6 6.2h.01M9 6.2h.01m1 6-2 2 2 2m4-4 2 2-2 2" /></>
-    case 'code':
-      return <><path d="m8 6-5 6 5 6m8-12 5 6-5 6m-3-15-2 18" /></>
-    case 'config':
-      return <><path d="M5 4h14v16H5zM8 8h8M8 12h8M8 16h8" /><circle cx="11" cy="8" r="1.2" /><circle cx="14" cy="12" r="1.2" /><circle cx="10" cy="16" r="1.2" /></>
-    case 'text':
-      return <><path d="M6 3.5h8l4 4V20H6zM14 3.5v4h4M9 12h6m-6 3h6m-6 3h4" /></>
-    case 'image':
-      return <><rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="8" cy="8" r="1.5" /><path d="m3 17 5-5 4 4 3-3 6 6" /></>
-    case 'svg':
-      return <><path d="M7 5h10v4H7zM5 15h4v4H5zm10 0h4v4h-4zM12 9v4m-5 2v-2h10v2" /><circle cx="12" cy="13" r="1" /></>
-    case 'patch':
-      return <><path d="M6 3.5h8l4 4V20H6zM14 3.5v4h4M9 11h6m-3-3v6m-3 4h6" /></>
+      return <><circle cx="12" cy="12" r="8.25" /><path d="M3.9 12h16.2" /><path d="M12 3.75c2.45 2.35 3.85 5.15 3.85 8.25S14.45 17.9 12 20.25c-2.45-2.35-3.85-5.15-3.85-8.25S9.55 6.1 12 3.75Z" /></>
     case 'folder':
-      return <><path d="M3 6.5h7l2 2h9v10.5H3z" /></>
+      return <><path d="M3.75 8.75a2 2 0 0 1 2-2H10l1.7 1.7h6.55a2 2 0 0 1 2 2v5.8a2 2 0 0 1-2 2H5.75a2 2 0 0 1-2-2Z" /><path d="M3.75 10.4h16.5" /></>
+    case 'markdown':
+      return <><path d="M6.75 5.5h10.5a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H6.75a2 2 0 0 1-2-2v-9a2 2 0 0 1 2-2Z" /><path d="M8 14.8V9.2l2 2.45 2-2.45v5.6" /><path d="M15 9.4v4.1" /><path d="m13.8 12.3 1.2 1.3 1.2-1.3" /></>
+    case 'html':
+      return <><path d="M6.75 5.25h10.5a2 2 0 0 1 2 2v9.5a2 2 0 0 1-2 2H6.75a2 2 0 0 1-2-2v-9.5a2 2 0 0 1 2-2Z" /><path d="m9.2 9.25-2 2 2 2" /><path d="m14.8 9.25 2 2-2 2" /><path d="m13.1 8.7-2.2 5.1" /></>
+    case 'code':
+      return <><path d="m9 8.5-3 3.5 3 3.5" /><path d="m15 8.5 3 3.5-3 3.5" /><path d="m13.1 6.75-2.2 10.5" /></>
+    case 'config':
+      return <><path d="M6.75 5.75h8.5l2 2v10.5a1.75 1.75 0 0 1-1.75 1.75h-8.75A1.75 1.75 0 0 1 5 18.25V7.5a1.75 1.75 0 0 1 1.75-1.75Z" /><path d="M15.2 5.9v2.35h2.35" /><path d="M8.35 12h7.3" /><path d="M8.35 15.2h5.1" /><circle cx="9.4" cy="9.2" r="1" /></>
+    case 'text':
+      return <><path d="M6.8 5.5h10.4a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H6.8a2 2 0 0 1-2-2v-9a2 2 0 0 1 2-2Z" /><path d="M8.4 9.3h7.2" /><path d="M8.4 12.1h7.2" /><path d="M8.4 14.9h4.8" /></>
+    case 'image':
+      return <><rect x="4.75" y="5.5" width="14.5" height="13" rx="2" /><circle cx="9.2" cy="10.1" r="1.25" /><path d="m7 16 3.2-3.4 2.5 2.5 1.8-1.9 2.5 2.8" /></>
+    case 'svg':
+      return <><rect x="4.75" y="5.5" width="14.5" height="13" rx="2" /><path d="m9 15 2.5-5.5 2.5 5.5" /><path d="M10 13.2h3" /><path d="M14.8 15h2.2" /><path d="M15.9 13.9v2.2" /></>
+    case 'patch':
+      return <><path d="M8 6.5h8a2 2 0 0 1 2 2v2.5" /><path d="M16 17.5H8a2 2 0 0 1-2-2V13" /><path d="M12 9v6" /><path d="M9 12h6" /></>
     case 'pdf':
-      return <><path d="M6 3.5h8l4 4V20H6zM14 3.5v4h4" /><path d="M8 16v-4h1.6a1.4 1.4 0 0 1 0 2.8H8m5.2 1.2v-4h1.2c1.6 0 2.6.8 2.6 2s-1 2-2.6 2h-1.2" /></>
+      return <><path d="M7 5.5h7.7l2.3 2.35v10.4a1.75 1.75 0 0 1-1.75 1.75H7a1.75 1.75 0 0 1-1.75-1.75V7.25A1.75 1.75 0 0 1 7 5.5Z" /><path d="M14.6 5.75V8h2.2" /><path d="M8.2 15.2v-4.4h1.7a1.25 1.25 0 1 1 0 2.5H8.2" /><path d="M12.2 15.2v-4.4h1.1c1.55 0 2.45.8 2.45 2.2 0 1.45-.9 2.2-2.45 2.2z" /></>
     case 'document':
-      return <><path d="M6 3.5h8l4 4V20H6zM14 3.5v4h4M9 11h6M9 14h6M9 17h4" /></>
+      return <><path d="M7 5.5h7.7l2.3 2.35v10.4a1.75 1.75 0 0 1-1.75 1.75H7a1.75 1.75 0 0 1-1.75-1.75V7.25A1.75 1.75 0 0 1 7 5.5Z" /><path d="M14.6 5.75V8h2.2" /><path d="M8.4 11h6.4" /><path d="M8.4 14h6.4" /><path d="M8.4 17h4.2" /></>
     case 'spreadsheet':
-      return <><rect x="4" y="4" width="16" height="16" rx="2" /><path d="M4 9h16M4 14h16M10 4v16M15 4v16" /></>
+      return <><rect x="5" y="5.5" width="14" height="13" rx="2" /><path d="M9.7 5.8v12.4" /><path d="M14.3 5.8v12.4" /><path d="M5.3 10.1h13.4" /><path d="M5.3 14.3h13.4" /></>
     case 'presentation':
-      return <><rect x="4" y="4" width="16" height="13" rx="2" /><path d="M8 20h8M12 17v3M8 8h8M8 11h5" /></>
+      return <><rect x="5" y="6" width="14" height="10.5" rx="2" /><path d="M12 16.5v2.7" /><path d="M9.2 19.2h5.6" /><path d="m9.1 13.3 2.1-3.1 1.6 1.95 1.95-2.7" /></>
     case 'notebook':
-      return <><path d="M6 4h12v16H6zM9 4v16M3.5 7H6M3.5 11H6M3.5 15H6" /><path d="m12 9-2 2 2 2m3-4 2 2-2 2" /></>
+      return <><path d="M8 5.5h8.3a1.8 1.8 0 0 1 1.8 1.8v9.4a1.8 1.8 0 0 1-1.8 1.8H8" /><path d="M8 5.5v13" /><path d="M5.3 8.6h2" /><path d="M5.3 12h2" /><path d="M5.3 15.4h2" /><path d="M10.5 9.8h4.5" /><path d="M10.5 13.1h4.5" /></>
     case 'archive':
-      return <><path d="M6 3.5h12V20H6zM9 3.5v3h3v3H9v3h3v3H9v3h3" /><path d="M12 16h3v3h-3z" /></>
+      return <><rect x="5" y="7" width="14" height="11" rx="2" /><path d="M5 10h14" /><path d="M10.4 5.5h3.2" /><path d="M12 10.2v4.2" /><path d="M10.6 12.1H13.4" /></>
     case 'audio':
-      return <><path d="M9 18V7l9-2v11" /><circle cx="6.5" cy="18" r="2.5" /><circle cx="15.5" cy="16" r="2.5" /></>
+      return <><path d="M9.2 16.5a1.9 1.9 0 1 0 0 3.8 1.9 1.9 0 0 0 0-3.8Z" /><path d="M16.1 14.6a1.9 1.9 0 1 0 0 3.8 1.9 1.9 0 0 0 0-3.8Z" /><path d="M11.1 18.3V8.2l6-1.4v9.7" /></>
     case 'video':
-      return <><rect x="3" y="5" width="18" height="14" rx="2" /><path d="m10 9 5 3-5 3z" /></>
+      return <><rect x="4.75" y="6.2" width="12" height="11.6" rx="2" /><path d="m12.2 12-3 1.85V10.15Z" /><path d="m16.75 10.2 2.7-1.5v6.6l-2.7-1.5" /></>
     case 'database':
-      return <><ellipse cx="12" cy="6" rx="7" ry="3" /><path d="M5 6v6c0 1.7 3.1 3 7 3s7-1.3 7-3V6M5 12v6c0 1.7 3.1 3 7 3s7-1.3 7-3v-6" /></>
+      return <><ellipse cx="12" cy="7.25" rx="5.8" ry="2.35" /><path d="M6.2 7.25v8.9c0 1.3 2.6 2.35 5.8 2.35s5.8-1.05 5.8-2.35v-8.9" /><path d="M6.2 11.7c0 1.3 2.6 2.35 5.8 2.35s5.8-1.05 5.8-2.35" /></>
     case 'executable':
-      return <><rect x="4" y="4" width="16" height="16" rx="3" /><path d="M8 9h8M8 15h8M9 8v8M15 8v8" /><circle cx="12" cy="12" r="2" /></>
+      return <><rect x="5" y="5.5" width="14" height="13" rx="2" /><path d="M9.2 9.6h5.6" /><path d="M9.2 12h3.6" /><path d="M9.2 14.4h5.6" /><path d="m16.4 7.9 1.4 1.4" /></>
     case 'file':
-      return <><path d="M6 3.5h8l4 4V20H6zM14 3.5v4h4" /></>
+      return <><path d="M7 5.5h7.7l2.3 2.35v10.4a1.75 1.75 0 0 1-1.75 1.75H7a1.75 1.75 0 0 1-1.75-1.75V7.25A1.75 1.75 0 0 1 7 5.5Z" /><path d="M14.6 5.75V8h2.2" /></>
   }
 }
 

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1658,7 +1658,7 @@ html[data-rovai-platform="win32"] .bootstrap-shell-brand { padding-left: 20px; }
   background: transparent;
   cursor: pointer;
 }
-.file-preview-tab-icon { width: 14px; height: 14px; flex: 0 0 14px; fill: none; stroke: currentColor; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1.6; }
+.file-preview-tab-icon { width: 14px; height: 14px; flex: 0 0 14px; fill: none; stroke: currentColor; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1.7; opacity: .9; }
 .file-preview-tab-label {
   min-width: 0;
   flex: 1 1 0;
@@ -1914,20 +1914,20 @@ html.file-preview-resizing .file-preview-pane { pointer-events: none; }
   color: var(--resource-link);
   background: transparent;
   font: inherit;
-  text-decoration: underline;
-  text-decoration-color: color-mix(in srgb, currentColor 45%, transparent);
-  text-decoration-thickness: 1px;
-  text-underline-offset: 2px;
+  text-decoration: none;
   overflow-wrap: anywhere;
   vertical-align: baseline;
   cursor: pointer;
 }
 .safe-markdown .markdown-file-reference:hover,
 .safe-markdown .markdown-web-reference:hover,
-.message-file-reference:hover { color: var(--resource-link-hover); text-decoration-color: currentColor; }
+.message-file-reference:hover,
+.safe-markdown .markdown-file-reference:active,
+.safe-markdown .markdown-web-reference:active,
+.message-file-reference:active { color: var(--resource-link-hover); text-decoration: none; }
 .safe-markdown .markdown-file-reference:focus-visible,
 .safe-markdown .markdown-web-reference:focus-visible,
-.message-file-reference:focus-visible { border-radius: 2px; outline: 2px solid var(--focus); outline-offset: 2px; }
+.message-file-reference:focus-visible { border-radius: 2px; outline: 2px solid var(--focus); outline-offset: 2px; text-decoration: none; }
 .safe-markdown .markdown-file-reference.inline-code-file-reference,
 .message-file-reference.inline-code-file-reference {
   text-decoration: none;
@@ -1941,7 +1941,7 @@ html.file-preview-resizing .file-preview-pane { pointer-events: none; }
   stroke: currentColor;
   stroke-linecap: round;
   stroke-linejoin: round;
-  stroke-width: 1.5;
+  stroke-width: 1.7;
   transform: translateY(2px);
   opacity: .84;
 }
@@ -1949,13 +1949,8 @@ html.file-preview-resizing .file-preview-pane { pointer-events: none; }
 .resource-reference-label { min-width: 0; overflow-wrap: anywhere; }
 .file-reference-label.is-code { font: .9em/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
 .inline-code-file-reference:hover,
-.inline-code-file-reference:active { color: var(--resource-link-hover); }
-.inline-code-file-reference:hover .file-reference-label {
-  text-decoration-line: underline;
-  text-decoration-style: dotted;
-  text-decoration-thickness: 1px;
-  text-underline-offset: 3px;
-}
+.inline-code-file-reference:active { color: var(--resource-link-hover); text-decoration: none; }
+.inline-code-file-reference:hover .file-reference-label,
 .inline-code-file-reference:active .file-reference-label,
 .inline-code-file-reference:focus-visible .file-reference-label { text-decoration: none; }
 .file-preview-inline-error { max-width: 780px; margin: 0 auto 12px; color: var(--danger); font-size: 10px; }

--- a/apps/desktop/src/renderer/src/theme-tokens.test.ts
+++ b/apps/desktop/src/renderer/src/theme-tokens.test.ts
@@ -283,6 +283,15 @@ describe('Porcelain Day + Steel Night theme tokens', () => {
     expect(css).toMatch(/\.agent-output-file-grid\s*\{[^}]*grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/)
   })
 
+  it('keeps file references underline-free and shared resource glyphs at one stroke weight', () => {
+    expect(css).toMatch(/\.safe-markdown \.markdown-file-reference,[\s\S]*?\.message-file-reference\s*\{[^}]*text-decoration: none/)
+    expect(css).toMatch(/\.safe-markdown \.markdown-file-reference:hover,[\s\S]*?\.message-file-reference:active\s*\{[^}]*text-decoration: none/)
+    expect(css).toMatch(/\.safe-markdown \.markdown-file-reference:focus-visible,[\s\S]*?\.message-file-reference:focus-visible\s*\{[^}]*text-decoration: none/)
+    expect(css).not.toMatch(/\.inline-code-file-reference:hover \.file-reference-label\s*\{[^}]*text-decoration-(?:line|style): underline/)
+    expect(css).toMatch(/\.file-preview-tab-icon\s*\{[^}]*stroke-width: 1\.7[^}]*opacity: \.9/)
+    expect(css).toMatch(/\.resource-reference-icon\s*\{[^}]*stroke-width: 1\.7/)
+  })
+
   it('uses quiet selected backgrounds for the active Camp and current Project', () => {
     expect(css).toMatch(/\.camp-nav-row\.selected\s*\{[^}]*background: var\(--surface-selected\)/)
     expect(css).toMatch(/\.project-heading-row\.current-project\s*\{[^}]*background: var\(--surface-selected\)/)

--- a/docs/ui/components/file-preview.md
+++ b/docs/ui/components/file-preview.md
@@ -2,7 +2,7 @@
 document_type: ui-component-contract
 authority: renderer-file-preview
 status: accepted
-last_updated: 2026-09-03
+last_updated: 2026-09-04
 ---
 
 # Camp 文件预览区
@@ -10,15 +10,15 @@ last_updated: 2026-09-03
 ## 会话内的文件链接
 
 文件与 Web 链接统一使用独立的 `--resource-link`，Hover 使用 `--resource-link-hover`；色值由两套主题分别定义，
-不复用品牌或信息状态颜色。文件链接保持正文阅读感与原生链接语义，不呈现为按钮或 Badge。普通文件链接保留
-轻下划线，Hover 加强下划线；键盘焦点使用既有 focus token，长路径可自然换行，不让正文横向溢出。
+不复用品牌或信息状态颜色。文件链接保持正文阅读感与原生链接语义，不呈现为按钮或 Badge。文件与 Web 资源链接
+在默认、Hover、Active 与 Focus 状态均不显示下划线；Hover/Active 只加强链接色，键盘焦点使用既有 focus token，
+长路径可自然换行，不让正文横向溢出。
 
 - Markdown 文件链接 `[label](target)` 只显示可点击的 label；target 仅用于解析/打开，不在正文中重复常驻展示。
 - 整体为文件引用的 inline-code（如 `` `src/App.tsx:20` ``）只有在当前消息来源工作目录可解析为现存普通文件时
   才成为文件入口。相对路径使用来源 AgentRun 的工作目录、无来源 Run 时使用 directory Camp 项目目录；绝对路径
   直接解析。不存在、目录或解析失败时保持原生 `<code>`，不显示图标、链接或错误。成功入口的等宽文字移除灰底和嵌套
-  `<code>`，默认无下划线；Hover 加强链接色并只为文字显示 1px 点状下划线，按下或键盘焦点时不显示下划线。
-  普通 inline-code、代码块和混合正文保持原样。
+  `<code>`，所有交互状态都不显示下划线；Hover/Active 只加强链接色。普通 inline-code、代码块和混合正文保持原样。
 - 普通正文不扫描、不猜测本地路径。`src/App.tsx:20`、`/compact` 与 `docs/prototypes/demo/` 只有在显式
   Markdown 文件链接或整体 inline-code 中才可能成为文件入口；消息存储、整条消息复制与模型输入保持原文。
 - 每个文件入口在 label 前显示真实资源类型的 14px 单色线性 SVG，不再由 label 是否为 inline-code 决定是否显示。
@@ -90,9 +90,9 @@ last_updated: 2026-09-03
 ## 文件 Tabs
 
 Tabs 使用 Codex toolbar 语法：小间距、无逐项边框、当前项用次级 surface 和文字对比表达，不使用品牌下划线。
-普通文件 Tab 与会话文件链接按文件名共用相同资源视觉类型，不直接用 `FilePreviewKind` 选图标；左侧用统一 14px
-细线 SVG 区分 Markdown（书页）、代码（尖括号）、HTML（网页）、图片/SVG（图片）、
-文本/分页原文（文档）和 Diff/Patch/File Change（加减差异）。图标使用继承的中性色，作为装饰隐藏于辅助技术，
+普通文件 Tab 与会话文件链接按文件名共用相同资源视觉类型，不直接用 `FilePreviewKind` 选图标；左侧复用文件引用的
+同一套 14px、1.7px 描边单色 SVG Glyph，覆盖共享资源类型矩阵；File Change 固定复用 Diff/Patch Glyph。
+图标使用继承的中性色，作为装饰隐藏于辅助技术，
 文件名和 File Change 前缀继续提供可访问名称，不用颜色代替类型语义。
 文件名使用 UI 字体；同类 Tab 重名且存在安全父目录时显示 `父目录/文件名`；只有安全文件名的项目外文件、
 Attachment 或项目根目录文件使用当前同名组内的 `文件名 · 1/2` 序号区分，不回推或暴露绝对路径。


### PR DESCRIPTION
## Summary
- replace all 21 shared resource glyphs with the approved 24x24 geometry
- remove underlines from file and web resource links in every interaction state
- keep preview classification and opening behavior unchanged
- update the file-preview UI contract and add glyph/style regression coverage

## Validation
- pnpm typecheck
- pnpm exec vitest run (145 files, 1532 tests)
- pnpm docs:test
- pnpm docs:check
- pnpm build:desktop
- pnpm test:file-reference-navigation
- pnpm test:file-preview-layout
- visual review: Porcelain Day, Steel Night, 200% zoom, reduced motion