### PR TITLE
style(desktop): share markdown code layers across camp surfaces

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -154,9 +154,10 @@ only boundary of an input or control.
 - **Evidence:** uses the dedicated evidence and diff tokens, monospaced type where appropriate, and
   structural `+`/`-`, line numbers or labels in addition to color.
 - **Code:** shared SafeMarkdown surfaces use a quiet inline canvas with `0 2px` padding and a `3px`
-  radius; fenced code uses the matching block canvas with an evidence border. Camp message prose
-  applies its component-owned Mist Gray treatment without changing file previews, release notes or
-  Runtime process copy. Other bounded evidence surfaces keep the stronger evidence canvas.
+  radius; fenced code uses the matching block canvas with an evidence border. Camp message prose,
+  Runtime process copy in both execution placements and Markdown file previews share the
+  component-owned Mist Gray treatment. Release notes and other SafeMarkdown surfaces retain the
+  quiet shared defaults; other bounded evidence surfaces keep the stronger evidence canvas.
 - **Identity:** portraits and eight stable identity tokens are a narrow exception to the neutral
   workspace. Identity treatments do not spread into background decoration.
 

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -3180,9 +3180,15 @@ button.camp-world-map-live-caption { cursor: pointer; font: inherit; }
 .safe-markdown code { padding: 0 2px; border-radius: 3px; color: var(--evidence-ink); background: var(--inline-code-canvas); font: .9em/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
 .safe-markdown .markdown-file-reference code { color: inherit; }
 .safe-markdown pre code { padding: 0; background: transparent; font-size: inherit; }
-.conversation-bubble :is(.final-copy, .message-bubble) .safe-markdown code { padding: 1px 4px; border-radius: 6px; background: var(--conversation-inline-code-canvas); box-decoration-break: clone; -webkit-box-decoration-break: clone; }
-.conversation-bubble :is(.final-copy, .message-bubble) .safe-markdown pre { padding: 11px 12px; border-color: var(--conversation-code-line); border-radius: 8px; background: var(--conversation-code-block-canvas); }
-.conversation-bubble :is(.final-copy, .message-bubble) .safe-markdown pre code { padding: 0; border-radius: 0; background: transparent; }
+.conversation-bubble :is(.final-copy, .message-bubble) .safe-markdown code,
+.execution-drawer .safe-markdown code,
+.file-preview-markdown .safe-markdown code { padding: 1px 4px; border-radius: 6px; background: var(--conversation-inline-code-canvas); box-decoration-break: clone; -webkit-box-decoration-break: clone; }
+.conversation-bubble :is(.final-copy, .message-bubble) .safe-markdown pre,
+.execution-drawer .safe-markdown pre,
+.file-preview-markdown .safe-markdown pre { padding: 11px 12px; border-color: var(--conversation-code-line); border-radius: 8px; background: var(--conversation-code-block-canvas); }
+.conversation-bubble :is(.final-copy, .message-bubble) .safe-markdown pre code,
+.execution-drawer .safe-markdown pre code,
+.file-preview-markdown .safe-markdown pre code { padding: 0; border-radius: 0; background: transparent; }
 .safe-markdown table { display: block; width: 100%; margin: 9px 0; overflow-x: auto; border-spacing: 0; border-collapse: collapse; font-size: 11px; }
 .safe-markdown th, .safe-markdown td { padding: 6px 8px; border: 1px solid var(--line); text-align: left; vertical-align: top; }
 .safe-markdown th { background: var(--surface-muted); font-weight: 700; }

--- a/apps/desktop/src/renderer/src/theme-tokens.test.ts
+++ b/apps/desktop/src/renderer/src/theme-tokens.test.ts
@@ -386,9 +386,6 @@ describe('Porcelain Day + Steel Night theme tokens', () => {
     expect(css).not.toMatch(/\.safe-markdown code\s*\{[^}]*\bborder\s*:/)
     expect(css).toMatch(/\.safe-markdown pre\s*\{[^}]*background:\s*var\(--code-block-canvas\)/)
     expect(css).toMatch(/\.safe-markdown pre code\s*\{[^}]*padding:\s*0[^}]*background:\s*transparent/)
-    expect(css).toMatch(/\.conversation-bubble :is\(\.final-copy, \.message-bubble\) \.safe-markdown code\s*\{[^}]*padding:\s*1px 4px[^}]*border-radius:\s*6px[^}]*background:\s*var\(--conversation-inline-code-canvas\)[^}]*box-decoration-break:\s*clone/)
-    expect(css).toMatch(/\.conversation-bubble :is\(\.final-copy, \.message-bubble\) \.safe-markdown pre\s*\{[^}]*padding:\s*11px 12px[^}]*border-color:\s*var\(--conversation-code-line\)[^}]*border-radius:\s*8px[^}]*background:\s*var\(--conversation-code-block-canvas\)/)
-    expect(css).toMatch(/\.conversation-bubble :is\(\.final-copy, \.message-bubble\) \.safe-markdown pre code\s*\{[^}]*padding:\s*0[^}]*border-radius:\s*0[^}]*background:\s*transparent/)
     expect(css).toContain('.conversation-bubble:hover .message-actions')
     expect(css).toMatch(/\.message-actions\s*\{[^}]*align-self: flex-end[^}]*margin-top: 3px/)
     expect(css).toMatch(/\.conversation-bubble\.agent \.message-actions\s*\{[^}]*width: fit-content[^}]*align-self: flex-start[^}]*justify-content: flex-start/)
@@ -433,6 +430,12 @@ describe('Porcelain Day + Steel Night theme tokens', () => {
     expect(css).toMatch(
       /@media\s*\(min-width:\s*1800px\)[\s\S]*?\.runtime-recovery-dock\s*\{[^}]*width:\s*min\(var\(--conversation-wide-width\), calc\(100% - 54px\)\)/
     )
+  })
+
+  it('shares Mist Gray Markdown code layers across Camp reading surfaces', () => {
+    expect(css).toMatch(/\.conversation-bubble :is\(\.final-copy, \.message-bubble\) \.safe-markdown code,\s*\.execution-drawer \.safe-markdown code,\s*\.file-preview-markdown \.safe-markdown code\s*\{[^}]*padding:\s*1px 4px[^}]*border-radius:\s*6px[^}]*background:\s*var\(--conversation-inline-code-canvas\)[^}]*box-decoration-break:\s*clone/)
+    expect(css).toMatch(/\.conversation-bubble :is\(\.final-copy, \.message-bubble\) \.safe-markdown pre,\s*\.execution-drawer \.safe-markdown pre,\s*\.file-preview-markdown \.safe-markdown pre\s*\{[^}]*padding:\s*11px 12px[^}]*border-color:\s*var\(--conversation-code-line\)[^}]*border-radius:\s*8px[^}]*background:\s*var\(--conversation-code-block-canvas\)/)
+    expect(css).toMatch(/\.conversation-bubble :is\(\.final-copy, \.message-bubble\) \.safe-markdown pre code,\s*\.execution-drawer \.safe-markdown pre code,\s*\.file-preview-markdown \.safe-markdown pre code\s*\{[^}]*padding:\s*0[^}]*border-radius:\s*0[^}]*background:\s*transparent/)
   })
 
   it('keeps AgentRun disclosure in a fixed trailing SVG track', () => {

--- a/docs/ui/components/conversation-workspace.md
+++ b/docs/ui/components/conversation-workspace.md
@@ -196,11 +196,11 @@ Agent 消息继续左对齐并保持透明开放阅读面，不添加身份色�
 使用完整正文，不得复制截断投影；当前会话查找命中这类消息时临时挂载全文，使首尾 occurrence 都能被
 定位，关闭或切换查找后恢复静态截断。
 
-会话消息正文的 SafeMarkdown 使用 Mist Gray 分层：行内 code 以
+会话消息正文、底部与浮层执行台中的 Runtime 过程正文，以及 Markdown 文件预览共享 Mist Gray 分层：行内 code 以
 `--conversation-inline-code-canvas` 为底色，保留 `1px 4px` 留白、`6px` 圆角和跨行连续底色；围栏代码块使用
 `--conversation-code-block-canvas`、`--conversation-code-line`、`11px 12px` 留白与 `8px` 圆角。块内
-`pre code` 必须继续透明且不保留行内留白或圆角。该覆盖只属于用户/Agent 消息正文，不改变文件预览、更新说明、
-Runtime 过程正文、附件卡片或其他 SafeMarkdown 表面；Day 与 Night 分别使用主题文档给出的独立 token 值。
+`pre code` 必须继续透明且不保留行内留白或圆角。该覆盖不改变更新说明、附件卡片、Tool 结果、其他 Evidence
+或其他 SafeMarkdown 表面；Day 与 Night 分别使用主题文档给出的独立 token 值。
 
 当前可操作的队员头像、显示名和 Mention 可打开同一个锚定人物信息卡，不导航。已离开、移除或
 不可解析身份保持静态。精确 token 行为见[结构化 Mention](structured-mentions.md)。
@@ -280,6 +280,8 @@ Mention，本 Draft 也只回到默认 Lead，不能让路由控件反复出现�
 “会话 / 地图”视图按钮仍使用原有 `--brand-soft`。运行底色不随历史 Run 焦点切换而消失。选中态、状态形状、
 边框、焦点及工具结果的专用 Evidence 底色保持各自语义，不用背景分层改变执行状态或交互。
 两块着色区域将弱提示文字局部提升到 `--muted`，保证日夜主题的文字对比度，不改变历史 Run 与会话区文字层级。
+Runtime narration 与 plan explanation 的 SafeMarkdown 在底部和浮层复用上文的 Mist Gray 代码分层；Tool 行、
+Shell 结果、Diff 与其他结构化 Evidence 继续使用各自专用样式，不因承载位置改变。
 
 同一 Camp 中每个曾有 AgentRun 的队员只保留一个 Agent 过程入口。按需详情 surface 以时间顺序展示
 该 Agent 的独立 Run stage、状态、收件人与证据；这只是 Renderer grouping，不创建 Process

--- a/docs/ui/components/file-preview.md
+++ b/docs/ui/components/file-preview.md
@@ -147,7 +147,7 @@ Renderer 不自行猜测。
 
 Viewer 不显示预览/源码切换、右上角复制按钮、整行工具栏或 `Ready` 状态。每个类型只有一个规范阅读视图：
 
-- Markdown 渲染安全 GFM；超出 4 MiB 显示分页原文；
+- Markdown 渲染安全 GFM；行内 code 与围栏代码块复用 Camp 工作区的 Mist Gray 分层，超出 4 MiB 显示分页原文；
 - HTML 在 sandbox iframe 中执行；超限或初始化失败回退只读原文；
 - 代码/文本只读显示行号、搜索、定位、选择与系统复制，大文件分页；
 - 图片/SVG 提供适应、原始尺寸、缩放和重置，不把 SVG 注入宿主 DOM；

--- a/docs/ui/themes/porcelain-day.md
+++ b/docs/ui/themes/porcelain-day.md
@@ -194,9 +194,10 @@ Agent 交付文件的图形色只表达格式家族，不表达状态、身份�
 - Narrative inline code uses the borderless `--inline-code-canvas`; Shell command results use
   `--shell-result-canvas`; fenced code uses the bounded `--code-block-canvas` with its evidence
   border, while other evidence surfaces continue to use `--evidence-canvas`.
-- Camp message prose uses the dedicated `--conversation-inline-code-canvas`,
-  `--conversation-code-block-canvas` and `--conversation-code-line` Mist Gray layer. These tokens do
-  not alter file previews, release notes or Runtime process copy.
+- Camp message prose, Runtime process copy in the bottom and Inspector execution surfaces, and
+  Markdown file previews use the dedicated `--conversation-inline-code-canvas`,
+  `--conversation-code-block-canvas` and `--conversation-code-line` Mist Gray layer. Release notes,
+  Tool results and other SafeMarkdown surfaces keep the shared defaults.
 - Current-user message bubbles use the dedicated porcelain-gray
   `--conversation-user-message-surface` and `--conversation-user-message-line`; Agent narrative
   remains on the transparent conversation surface.

--- a/docs/ui/themes/steel-night.md
+++ b/docs/ui/themes/steel-night.md
@@ -195,9 +195,10 @@ they do not become statuses. Evidence and diffs remain neutral and structurally 
 inline code uses the borderless `--inline-code-canvas`; Shell command results use
 `--shell-result-canvas`; fenced code uses the bounded `--code-block-canvas` with its evidence border,
 while other evidence surfaces continue to use `--evidence-canvas`.
-Camp message prose uses the dedicated `--conversation-inline-code-canvas`,
-`--conversation-code-block-canvas` and `--conversation-code-line` Mist Gray layer; file previews,
-release notes and Runtime process copy keep the shared defaults.
+Camp message prose, Runtime process copy in the bottom and Inspector execution surfaces, and
+Markdown file previews use the dedicated `--conversation-inline-code-canvas`,
+`--conversation-code-block-canvas` and `--conversation-code-line` Mist Gray layer; release notes,
+Tool results and other SafeMarkdown surfaces keep the shared defaults.
 Current-user message bubbles use the dedicated neutral Steel pair
 `--conversation-user-message-surface` / `--conversation-user-message-line`; Agent narrative remains
 transparent.


### PR DESCRIPTION
## Summary

- extend the approved Mist Gray inline-code and fenced-code treatment to Runtime narration/plan content in both execution placements
- apply the same treatment to Markdown file previews while leaving Tool results, structured Evidence, release notes, and other SafeMarkdown surfaces unchanged
- update the UI/theme contracts and selector regression coverage

## Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm build:desktop`
- `pnpm vitest run apps/desktop/src/renderer/src/theme-tokens.test.ts apps/desktop/src/renderer/src/execution-console-layout.test.ts apps/desktop/src/renderer/src/file-preview-layout.test.ts`
- `DOCS_BASE_REF=93a7aa383464e09a0f84a92542c511e579c5bd05 pnpm docs:check:ci`
- Day/Night computed-style and visual inspection for execution drawer and Markdown preview