### PR TITLE
style(desktop): round user message corner

### DIFF
--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -2835,7 +2835,7 @@ button.camp-world-map-live-caption { cursor: pointer; font: inherit; }
   max-width: 100%;
   padding: 9px 12px 10px;
   border: 1px solid var(--conversation-user-message-line);
-  border-radius: 12px 12px 4px 12px;
+  border-radius: 12px;
   background: var(--conversation-user-message-surface);
   text-align: left;
 }

--- a/apps/desktop/src/renderer/src/theme-tokens.test.ts
+++ b/apps/desktop/src/renderer/src/theme-tokens.test.ts
@@ -366,7 +366,7 @@ describe('Porcelain Day + Steel Night theme tokens', () => {
     expect(css).toMatch(/\.settings-content \.settings-panel\s*\{[^}]*background: var\(--home-surface\)/)
   })
 
-  it('keeps Agent narrative open while giving right-aligned user messages a bounded Porcelain surface', () => {
+  it('keeps Agent narrative open while giving right-aligned user messages a fully rounded Porcelain surface', () => {
     expect(css).toMatch(/\.conversation-bubble\.agent\s*\{[^}]*--agent-accent: var\(--identity-1\)/)
     expect(css).not.toMatch(/\.conversation-bubble\.agent\s*\{[^}]*background:/)
     expect(css).not.toMatch(/\.conversation-bubble\.agent\s+\.final-copy\s*\{[^}]*background:/)
@@ -376,7 +376,7 @@ describe('Porcelain Day + Steel Night theme tokens', () => {
     expect(css).not.toContain('.conversation-bubble:is(.user, .agent):hover::before')
     expect(css).toMatch(/\.conversation-bubble:is\(\.user, \.external_principal\)\s*\{[^}]*margin-left: auto[^}]*grid-template-columns: minmax\(0, 1fr\) 32px/)
     expect(css).toMatch(/\.conversation-bubble:is\(\.user, \.external_principal\) \.local-message-avatar\s*\{[^}]*grid-column: 2/)
-    expect(css).toMatch(/\.conversation-bubble:is\(\.user, \.external_principal\) \.message-bubble\s*\{[^}]*border-radius: 12px 12px 4px 12px[^}]*background: var\(--conversation-user-message-surface\)/)
+    expect(css).toMatch(/\.conversation-bubble:is\(\.user, \.external_principal\) \.message-bubble\s*\{[^}]*border-radius: 12px;[^}]*background: var\(--conversation-user-message-surface\)/)
     expect(css).toMatch(/\.conversation-bubble:is\(\.user, \.external_principal\) \.message-surface\s*\{[^}]*width: fit-content[^}]*max-width: min\([^}]*var\(--conversation-user-message-max-width\)[^}]*66\.667cqw[^}]*align-items: flex-end/)
     expect(css).toMatch(/\.conversation-bubble:is\(\.user, \.external_principal\) \.message-bubble\s*\{[^}]*width: fit-content[^}]*max-width: 100%/)
     expect(css).toMatch(/\.message-body\s*\{[^}]*position: relative[^}]*display: flex/)


### PR DESCRIPTION
## Summary

- change the current-user and verified external-principal message surface from a 4px bottom-right corner to the same 12px radius as the other corners
- tighten the existing theme contract so the fully rounded shape cannot regress
- leave Agent messages, attachment tracks, colors, spacing, and interaction behavior unchanged

## Verification

- `pnpm exec vitest run apps/desktop/src/renderer/src/theme-tokens.test.ts`: 31/31
- `pnpm typecheck`
- `pnpm build:desktop`
- `pnpm test`: 145 Vitest files / 1531 tests; remaining Node tests 220 passed + 1 existing Windows skip
- `git diff --check`
- Impeccable detector run once; findings were pre-existing unrelated side-accent/width-transition warnings, with no finding on this change

`pnpm test:camp-open-projection` is explicitly `BLOCKED` in the current nested macOS sandbox before Chromium starts, so this PR does not claim that real Electron visual assertion passed locally.