### PR TITLE
fix(pi): hide fixed approval mode in member settings

### DIFF
--- a/apps/desktop/.impeccable/surfaces/member-workspace.md
+++ b/apps/desktop/.impeccable/surfaces/member-workspace.md
@@ -1,5 +1,5 @@
 ---
-version: 5
+version: 6
 slug: "member-workspace"
 primary_target: "apps/desktop/src/renderer/src/MemberManagement.tsx"
 related_targets:
@@ -100,6 +100,8 @@ Pi Coding Agent is a Product Runtime with `preview` admission on macOS arm64, ma
 selectable and editable on all three platforms, append `（实验性）` to the selector label, and show the real machine
 availability independently. Preview permits normal checks and AgentRun but retains missing qualification evidence;
 do not describe it as First-Class or qualified, and do not weaken installation, model, permission or Dispatch checks.
+Pi's fixed `partial_managed` value is an internal execution contract rather than a user-selectable native approval
+mode. Its member Runtime parameters show model fields only and do not expose that value as an approval control.
 
 ## Removal
 

--- a/apps/desktop/src/renderer/src/MemberRuntimeParameters.test.ts
+++ b/apps/desktop/src/renderer/src/MemberRuntimeParameters.test.ts
@@ -206,7 +206,6 @@ describe('member runtime parameters', () => {
   })
 
   it.each([
-    ['pi', '审批模式', 'partial_managed'],
     ['opencode-cli', '工具权限', 'allow'],
     ['claude-code-cli', '权限模式', 'bypassPermissions'],
     ['qoder-cli', '权限模式', 'bypass_permissions'],
@@ -227,6 +226,22 @@ describe('member runtime parameters', () => {
 
     expect(markup).toContain(label)
     expect(markup).toContain(`value="${value}" selected`)
+  })
+
+  it('does not present Pi fixed managed approval as a configurable Runtime mode', () => {
+    const installation = runtimeInstallation('pi')
+    const markup = renderToStaticMarkup(createElement(MemberRuntimeParameters, {
+      adapterKind: 'pi',
+      installation,
+      draft: draftFromDefaults(installation.memberRuntimeDefaults!),
+      disabled: false,
+      onChange: () => undefined
+    }))
+
+    expect(markup).toContain('模型、模型参数与 Agent 运行时原生权限。')
+    expect(markup).toContain('模型策略')
+    expect(markup).not.toContain('审批模式')
+    expect(markup).not.toContain('partial_managed')
   })
 
   it('uses switches for Copilot, Kiro, and Antigravity on/off fields', () => {

--- a/apps/desktop/src/renderer/src/MemberRuntimeParameters.tsx
+++ b/apps/desktop/src/renderer/src/MemberRuntimeParameters.tsx
@@ -236,7 +236,6 @@ function PiRuntimeParameters(props: RuntimeParameterProps): React.JSX.Element {
   return (
     <div className="runtime-parameter-form">
       {modelFieldsFor('pi', props)}
-      <PermissionSelect {...props} fieldKey="approval_mode" label="审批模式" />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- hide Pi's fixed `partial_managed` approval value from member Runtime settings
- keep the shared Runtime parameters heading and supporting copy unchanged
- document that Pi managed approval is an internal execution contract, not a user-selectable native mode

## Validation
- `pnpm exec vitest run apps/desktop/src/renderer/src/MemberRuntimeParameters.test.ts`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build:desktop`
- Impeccable detector: no findings