### PR TITLE
feat(composer): converge draft authority and inline atoms

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1627,16 +1627,28 @@ A legacy Draft-private reference to one Authority Attachment inside a Camp Compo
 _Avoid_: Local Attachment Source Ref, new user attachment, Published Attachment, Runtime-readable file, mixed Draft
 
 **Camp Composer Draft**:
-The private, durable user preparation for one future CampMessage, containing Structured Camp Message Content and ordered Local Attachment Source Refs, or mutually exclusive legacy Prepared Attachments. It may survive Camp navigation or application restart, is invisible to Agents and public history, and is consumed only by an accepted direct send or complete-intent transfer to Pending.
+The private, durable user preparation for one future CampMessage, containing a ComposerDocument V2 and ordered Local Attachment Source Refs, or mutually exclusive legacy Prepared Attachments, plus Reply/Continuation intent and one exact Revision. It may survive Camp navigation or application restart, is invisible to Agents and public history, and is consumed only by an accepted direct send or complete-intent transfer to Pending.
 _Avoid_: CampMessage, New Conversation Draft, Agent context, public draft
 
 **Camp Composer Draft Revision**:
 The opaque, monotonically advancing identity of one exact Camp Composer Draft state. A send can consume only the referenced current Revision, so a newer Draft remains a distinct unsent preparation.
 _Avoid_: updated timestamp, Renderer counter, CampMessage version, best-effort autosave marker
 
+**ComposerDocument**:
+The closed version-2 Draft/Pending domain protocol containing only adjacent-normalized `Text(text)` and typed `Atom(member | all_members | skill)` segments. Newlines are characters inside Text; Lexical Paragraph/LineBreak nodes, selection, history, node keys, DOM and presentation never enter it. Core derives plain `body` from this document and maps it to public Structured Camp Message Content only at publication.
+_Avoid_: Lexical JSON, rich-text document, public Message Content, independent body state, presentation label
+
+**Draft Mutation Coordinator**:
+The single Renderer owner of the complete current `CampComposerDraftView`. It serializes content, source attachment, Reply, Continuation and recipient mutations against the latest Core Revision, replaces authority only with a complete Core response, and fences late responses by editing epoch. React and Composer Draft Sync may observe or project it but must not cache a competing complete View.
+_Avoid_: latest autosave result cache, React Draft state, per-feature revision ref, parallel attachment/content mutation
+
+**Composer Local Sync**:
+The Renderer-local Lexical persistence state for one editing epoch: latest EditorState, local/saved version, dirty flag, debounce/single-flight work and saved/dirty/saving/error status. It serializes only at save/flush boundaries and obtains complete Draft authority from Draft Mutation Coordinator; it never owns a Core Revision or complete Draft View.
+_Avoid_: controlled Composer value, Core Draft authority, per-keystroke serialization, swallowed explicit flush error
+
 **Structured Camp Message Content**:
-The authoritative ordered content of one CampMessage and, for user-authored input, its Camp Composer Draft, using the closed `Text`, `MemberMention(agentId)`, `AllMembersMention`, and Core-generated `CurrentUserMention(local_user)` segments. Plain-text display, search, Context, Clipboard, accessibility and mention projections derive from it; submitted or stored plain body must not become a parallel content truth.
-_Avoid_: generic rich-text document, HTML, Markdown AST, mention character offsets, parsed user lookalike, parallel body and routing truth
+The authoritative ordered public content of one CampMessage, using the closed `Text`, `MemberMention(agentId)`, `AllMembersMention`, `SkillMention(skillId, nameAtSend)` and Core-generated `CurrentUserMention(local_user)` segments. Core maps user ComposerDocument into it only during accepted publication. Plain-text display, search, Context and historical accessibility projections derive from it; Draft/Pending persistence uses ComposerDocument instead.
+_Avoid_: ComposerDocument, generic rich-text document, HTML, Markdown AST, mention character offsets, parsed user lookalike, Draft authority
 
 **Published Attachment**:
 An immutable Authority or Managed Attachment adopted by one accepted public CampMessage from a legacy Prepared Attachment or admitted Agent file ingress. New Desktop user attachments remain Local Attachment Source Refs on the Message and are not Published Attachments in this storage sense. For legacy/Agent data, the message commit makes it shared with the whole Camp regardless of addressing or whether it appears in a particular AgentRun's Context; it may accompany a body or constitute the complete attachment-only payload, and every eligible Camp Agent may enumerate and read its Published Attachment Path while it is currently available.

--- a/apps/desktop/src/renderer/src/CampWorkspace.tsx
+++ b/apps/desktop/src/renderer/src/CampWorkspace.tsx
@@ -49,10 +49,14 @@ import {
 } from './StructuredMentionComposer'
 import {
   composerDocumentFromText,
-  composerDocumentsEqual,
   emptyComposerDocument,
   type ComposerLocalStatus
 } from './composer-document'
+import {
+  DraftMutationCoordinator,
+  type DraftMutation
+} from './draft-mutation-coordinator'
+import type { ComposerDraftPersistenceStatus } from './composer-draft-sync'
 import { PendingCampInputs } from './PendingCampInputs'
 import {
   activityStatusForAgentRun,
@@ -387,6 +391,54 @@ export function composerDraftNeedsContinuationRepair(
   const member = members.find(({ agentId }) => agentId === intent.recipient.agentId)
   const available = member?.membershipStatus === 'active' && member.profilePresence === 'present'
   return intent.recipientSelectionRequired || !available
+}
+
+async function mutateComposerDraft(
+  draft: CampComposerDraftView,
+  mutation: DraftMutation
+): Promise<CampComposerDraftView> {
+  const common = { campId: draft.campId, expectedRevision: draft.revision }
+  switch (mutation.kind) {
+    case 'save_content':
+      return window.rovai.request<CampComposerDraftView>('camp.composerDraft.save', {
+        ...common,
+        content: mutation.content,
+        continuationSourceMessageId: draft.continuationIntent?.sourceCampMessageId ?? null
+      })
+    case 'add_source_attachment':
+      return window.rovai.composerAttachments.prepare(
+        draft.campId,
+        draft.revision,
+        mutation.file
+      )
+    case 'remove_source_attachment':
+      return window.rovai.request<CampComposerDraftView>('camp.composerDraft.removeAttachment', {
+        ...common,
+        attachmentId: mutation.attachmentId
+      })
+    case 'start_reply':
+      return window.rovai.request<CampComposerDraftView>('camp.composerDraft.startReply', {
+        ...common,
+        replyToCampMessageId: mutation.replyToCampMessageId
+      })
+    case 'cancel_reply':
+      return window.rovai.request<CampComposerDraftView>('camp.composerDraft.cancelReply', common)
+    case 'resolve_reply_recipient':
+      return window.rovai.request<CampComposerDraftView>(
+        'camp.composerDraft.resolveReplyRecipient',
+        { ...common, recipient: mutation.recipient }
+      )
+    case 'dismiss_continuation':
+      return window.rovai.request<CampComposerDraftView>(
+        'camp.composerDraft.dismissContinuation',
+        { ...common, sourceCampMessageId: mutation.sourceCampMessageId }
+      )
+    case 'resolve_continuation_recipient':
+      return window.rovai.request<CampComposerDraftView>(
+        'camp.composerDraft.resolveContinuationRecipient',
+        { ...common, agentId: mutation.agentId }
+      )
+  }
 }
 
 export function composerRecipientSummary(
@@ -1388,7 +1440,9 @@ export function CampWorkspace({
   onNotify?(message: string): void
 }): JSX.Element {
   const filePreview = useOptionalFilePreview()
-  const [composerDraft, setComposerDraft] = useState<CampComposerDraftView | null>(null)
+  const [, setComposerDraftProjectionVersion] = useState(0)
+  const [composerPersistenceStatus, setComposerPersistenceStatus] =
+    useState<ComposerDraftPersistenceStatus>({ state: 'saved' })
   const [composerLocalStatus, setComposerLocalStatus] = useState<ComposerLocalStatus>({
     hasContent: false,
     hasExplicitRecipient: false,
@@ -1417,12 +1471,37 @@ export function CampWorkspace({
   const composerFileInputRef = useRef<HTMLInputElement>(null)
   const campLeaveTimer = useRef<{ campId: string; timer: number } | null>(null)
   const draftCampId = useRef<string | null>(null)
-  const composerDraftRef = useRef<CampComposerDraftView | null>(null)
   const initializedComposerRoute = useRef<{
-    draft: CampComposerDraftView
+    revision: number
     publishedMessageSequence: number
   } | null>(null)
-  const draftMutationQueues = useRef(new Map<string, Promise<CampComposerDraftView>>())
+  const activeCampIdRef = useRef(snapshot.camp.id)
+  const activationStateRef = useRef(snapshot.camp.activationState)
+  const pendingDraftPersistedRef = useRef(onPendingDraftPersisted)
+  activeCampIdRef.current = snapshot.camp.id
+  activationStateRef.current = snapshot.camp.activationState
+  pendingDraftPersistedRef.current = onPendingDraftPersisted
+  const draftCoordinatorRef = useRef<DraftMutationCoordinator | null>(null)
+  if (!draftCoordinatorRef.current) {
+    draftCoordinatorRef.current = new DraftMutationCoordinator({
+      load: (campId) => window.rovai.request<CampComposerDraftView>(
+        'camp.composerDraft.get',
+        { campId }
+      ),
+      mutate: async (draft, mutation) => {
+        const next = await mutateComposerDraft(draft, mutation)
+        if (
+          activeCampIdRef.current === draft.campId
+          && activationStateRef.current === 'pending'
+        ) pendingDraftPersistedRef.current?.()
+        return next
+      },
+      onChange: () => setComposerDraftProjectionVersion((version) => version + 1)
+    })
+  }
+  const draftCoordinator = draftCoordinatorRef.current
+  const coordinatorDraft = draftCoordinator.getCurrentDraft()
+  const composerDraft = coordinatorDraft?.campId === snapshot.camp.id ? coordinatorDraft : null
   const dragLeaveTimer = useRef<number | null>(null)
   const dragActivityTimer = useRef<number | null>(null)
   const attachmentPreparationQueue = useRef<Promise<void>>(Promise.resolve())
@@ -1953,61 +2032,15 @@ export function CampWorkspace({
     return counts
   }, [snapshot.executionEvidence])
 
-  const applyComposerDraft = (campId: string, draft: CampComposerDraftView): void => {
-    if (draftCampId.current !== campId) return
-    composerDraftRef.current = draft
-    setComposerDraft(draft)
-  }
-
-  const queueDraftMutation = (
-    campId: string,
-    mutate: (draft: CampComposerDraftView) => Promise<CampComposerDraftView>
-  ): Promise<CampComposerDraftView> => {
-    const current = composerDraftRef.current
-    const initial = current?.campId === campId
-      ? Promise.resolve(current)
-      : window.rovai.request<CampComposerDraftView>('camp.composerDraft.get', { campId })
-    const previous = draftMutationQueues.current.get(campId) ?? initial
-    const mutation = previous
-      .catch(() => window.rovai.request<CampComposerDraftView>('camp.composerDraft.get', { campId }))
-      .then(mutate)
-    const next = mutation.catch(async (error: unknown) => {
-      const refreshed = await window.rovai.request<CampComposerDraftView>(
-        'camp.composerDraft.get',
-        { campId }
-      )
-      applyComposerDraft(campId, refreshed)
-      throw error
-    })
-    draftMutationQueues.current.set(campId, next)
-    void next.then((draft) => {
-      if (draftMutationQueues.current.get(campId) === next) {
-        draftMutationQueues.current.delete(campId)
-      }
-      applyComposerDraft(campId, draft)
-      if (snapshot.camp.activationState === 'pending') onPendingDraftPersisted?.()
-    }, () => {
-      if (draftMutationQueues.current.get(campId) === next) {
-        draftMutationQueues.current.delete(campId)
-      }
-    })
-    return next
-  }
-
-  const saveStructuredDraft = (
+  const saveStructuredDraft = async (
     campId: string,
     content: ComposerDocument
-  ): Promise<CampComposerDraftView> => queueDraftMutation(
-    campId,
-    (draft) => composerDocumentsEqual(draft.content, content)
-      ? Promise.resolve(draft)
-      : window.rovai.request<CampComposerDraftView>('camp.composerDraft.save', {
-        campId,
-        expectedRevision: draft.revision,
-        content,
-        continuationSourceMessageId: draft.continuationIntent?.sourceCampMessageId ?? null
-      })
-  )
+  ): Promise<void> => {
+    if (draftCoordinator.getCurrentDraft()?.campId !== campId) {
+      throw new Error('Composer Draft context changed before content persistence.')
+    }
+    await draftCoordinator.saveContent(content)
+  }
 
   const loadReplyAnchorWindow = useCallback((messageId: string): Promise<CampMessageView[] | null> => {
     const existing = replyAnchorLoads.current.get(messageId)
@@ -2043,25 +2076,23 @@ export function CampWorkspace({
   useEffect(() => {
     if (!composerDraft || hasLocalDraftPayload || composerSubmitting || routingMutating) return
     const initializedRoute = initializedComposerRoute.current
-    if (initializedRoute && initializedRoute.draft === composerDraftRef.current
+    if (initializedRoute && initializedRoute.revision === composerDraft.revision
       && initializedRoute.publishedMessageSequence >= publishedMessageSequence) return
     const campId = snapshot.camp.id
     let cancelled = false
     // Pending publication bypasses submitMessage. Refresh Core's route projection
     // when a message enters the conversation, without replacing the local editor.
     void (async () => {
-      await draftMutationQueues.current.get(campId)
-      if (cancelled) return
-      const current = composerDraftRef.current
+      const epoch = draftCoordinator.getEpoch()
+      await draftCoordinator.waitForIdle()
+      if (cancelled || epoch !== draftCoordinator.getEpoch()) return
       const localVersion = composerHandleRef.current?.getLocalVersion() ?? 0
-      const refreshed = await window.rovai.request<CampComposerDraftView>('camp.composerDraft.get', { campId })
+      const refreshed = await draftCoordinator.load()
       if (cancelled || draftCampId.current !== campId
-        || composerDraftRef.current !== current
+        || epoch !== draftCoordinator.getEpoch()
         || composerHandleRef.current?.getLocalVersion() !== localVersion
-        || composerHandleRef.current?.isDirty()
-        || draftMutationQueues.current.has(campId)) return
-      initializedComposerRoute.current = { draft: refreshed, publishedMessageSequence }
-      applyComposerDraft(campId, refreshed)
+        || composerHandleRef.current?.isDirty()) return
+      initializedComposerRoute.current = { revision: refreshed.revision, publishedMessageSequence }
     })().catch(() => { /* Keep the current Draft; the next publication or Draft mutation refreshes it. */ })
     return () => { cancelled = true }
   }, [snapshot.camp.id, publishedMessageSequence, composerDraft !== null, hasLocalDraftPayload, composerSubmitting, routingMutating])
@@ -2422,12 +2453,6 @@ export function CampWorkspace({
     visibleCampMessages
   ])
 
-  const syncReplyDraft = (draft: CampComposerDraftView): CampComposerDraftView => {
-    applyComposerDraft(draft.campId, draft)
-    composerHandleRef.current?.replaceDocument(draft.content, draft)
-    return draft
-  }
-
   const mutateRoutingDraft = (
     method:
       | 'camp.composerDraft.startReply'
@@ -2436,17 +2461,16 @@ export function CampWorkspace({
       | 'camp.composerDraft.resolveContinuationRecipient',
     params: Record<string, unknown>
   ): Promise<CampComposerDraftView> => {
-    const campId = snapshot.camp.id
     return (async () => {
-      const flushed = await composerHandleRef.current?.flush()
-      if (flushed?.result) applyComposerDraft(campId, flushed.result)
-      return queueDraftMutation(campId, (draft) =>
-        window.rovai.request<CampComposerDraftView>(method, {
-        campId,
-        expectedRevision: draft.revision,
-        ...params
-        })
-      ).then(syncReplyDraft)
+      await composerHandleRef.current?.flush()
+      if (method === 'camp.composerDraft.startReply') {
+        return draftCoordinator.startReply(String(params.replyToCampMessageId))
+      }
+      if (method === 'camp.composerDraft.cancelReply') return draftCoordinator.cancelReply()
+      if (method === 'camp.composerDraft.resolveReplyRecipient') {
+        return draftCoordinator.resolveReplyRecipient(params.recipient as CampComposerReplyRecipient)
+      }
+      return draftCoordinator.resolveContinuationRecipient(String(params.agentId))
     })()
   }
 
@@ -2519,25 +2543,13 @@ export function CampWorkspace({
   }
 
   const dismissContinuation = async (restoreFocus = true): Promise<void> => {
-    const intent = composerDraftRef.current?.continuationIntent
+    const intent = draftCoordinator.getCurrentDraft()?.continuationIntent
     if (!intent || routingMutating) return
     setRoutingMutating(true)
     setReplyInteractionError(null)
     try {
-      const campId = snapshot.camp.id
-      const flushed = await composerHandleRef.current?.flush()
-      if (flushed?.result) applyComposerDraft(campId, flushed.result)
-      await queueDraftMutation(
-        campId,
-        (draft) => window.rovai.request<CampComposerDraftView>(
-          'camp.composerDraft.dismissContinuation',
-          {
-            campId,
-            expectedRevision: draft.revision,
-            sourceCampMessageId: intent.sourceCampMessageId
-          }
-        )
-      )
+      await composerHandleRef.current?.flush()
+      await draftCoordinator.dismissContinuation(intent.sourceCampMessageId)
       if (restoreFocus) focusComposerAtBoundary('keyboard', 'end')
     } catch (error) {
       setReplyInteractionError(replyDraftErrorMessage(error))
@@ -2641,8 +2653,8 @@ export function CampWorkspace({
       window.clearTimeout(campLeaveTimer.current.timer)
       campLeaveTimer.current = null
     }
-    setComposerDraft(null)
-    composerDraftRef.current = null
+    draftCoordinator.beginEpoch(campId)
+    setComposerPersistenceStatus({ state: 'saved' })
     setComposerLocalStatus({
       hasContent: false,
       hasExplicitRecipient: false,
@@ -2659,14 +2671,9 @@ export function CampWorkspace({
     setSuppressPointerFocusRing(false)
     autoSuppressedContinuationSourceRef.current = null
     draftCampId.current = campId
-    const pendingDraft = draftMutationQueues.current.get(campId)
-    void (pendingDraft ?? window.rovai.request<CampComposerDraftView>(
-      'camp.composerDraft.get',
-      { campId }
-    ))
-      .then((draft) => {
+    void draftCoordinator.load()
+      .then(() => {
         if (cancelled || draftCampId.current !== campId) return
-        applyComposerDraft(campId, draft)
       })
       .catch(() => {
         if (!cancelled && draftCampId.current === campId) {
@@ -2681,16 +2688,19 @@ export function CampWorkspace({
             updatedAt: null,
             expiresAt: null
           }
-          composerDraftRef.current = emptyDraft
-          setComposerDraft(emptyDraft)
+          draftCoordinator.acceptAuthoritativeDraft(emptyDraft)
         }
       })
     return () => {
       cancelled = true
       if (draftCampId.current === campId) {
         const persistedDraft = composerHandleRef.current?.flush()
-          .then(({ result, document }) => result ?? saveStructuredDraft(campId, document))
-          ?? Promise.resolve(composerDraftRef.current)
+          .then(async ({ draft, document }) => {
+            if (draft) return draft
+            await saveStructuredDraft(campId, document)
+            return draftCoordinator.getCurrentDraft()
+          })
+          ?? draftCoordinator.waitForIdle().catch(() => draftCoordinator.getCurrentDraft())
         const timer = window.setTimeout(() => {
           if (campLeaveTimer.current?.timer === timer) campLeaveTimer.current = null
           if (snapshot.camp.activationState === 'pending' && onPendingCampLeave) {
@@ -3158,9 +3168,8 @@ export function CampWorkspace({
       persistenceHeld = composerHandle !== null
       const flushed = await composerHandle?.flush({ holdPersistence: true })
       sentLocalVersion = flushed?.localVersion ?? null
-      const frozenDraft = flushed?.result ?? composerDraftRef.current
+      const frozenDraft = flushed?.draft ?? draftCoordinator.getCurrentDraft()
       if (!frozenDraft) throw new Error('Composer Draft 尚未就绪。')
-      applyComposerDraft(campId, frozenDraft)
       sendAttempted = true
       const sendReceipt = await onSend(frozenDraft)
       if (sendReceipt?.agentRunIds.length || sendReceipt?.campTurnId) {
@@ -3172,20 +3181,20 @@ export function CampWorkspace({
         'camp.composerDraft.get', { campId }
       )
       if (draftCampId.current === campId) {
+        draftCoordinator.acceptAuthoritativeDraft(nextDraft, true)
         initializedComposerRoute.current = {
-          draft: nextDraft,
+          revision: nextDraft.revision,
           publishedMessageSequence: Math.max(publishedMessageSequence, sendReceipt?.publishedMessageSequence ?? 0)
         }
-        applyComposerDraft(campId, nextDraft)
         const cleared = sentLocalVersion !== null
           && composerHandleRef.current?.clearIfVersion(
             sentLocalVersion,
-            nextDraft.content,
-            nextDraft
+            nextDraft.content
           ) === true
         if (cleared) {
           persistenceHeld = false
         } else {
+          composerHandleRef.current?.advancePersistenceEpoch(sentLocalVersion ?? undefined)
           composerHandleRef.current?.resumePersistence()
           persistenceHeld = false
           await composerHandleRef.current?.flush()
@@ -3199,16 +3208,16 @@ export function CampWorkspace({
             { campId }
           )
           if (draftCampId.current === campId) {
-            applyComposerDraft(campId, draft)
+            draftCoordinator.acceptAuthoritativeDraft(draft, true)
             const replaced = sentLocalVersion !== null
               && composerHandleRef.current?.clearIfVersion(
                 sentLocalVersion,
-                draft.content,
-                draft
+                draft.content
               ) === true
             if (replaced) {
               persistenceHeld = false
             } else {
+              composerHandleRef.current?.advancePersistenceEpoch(sentLocalVersion ?? undefined)
               composerHandleRef.current?.resumePersistence()
               persistenceHeld = false
               await composerHandleRef.current?.flush().catch(() => undefined)
@@ -3263,16 +3272,8 @@ export function CampWorkspace({
     const preparePending = async (): Promise<void> => {
       for (const item of pending) {
         try {
-          const flushed = await composerHandleRef.current?.flush()
-          if (flushed?.result) applyComposerDraft(campId, flushed.result)
-          await queueDraftMutation(
-            campId,
-            (draft) => window.rovai.composerAttachments.prepare(
-              campId,
-              draft.revision,
-              item.file
-            )
-          )
+          await composerHandleRef.current?.flush()
+          await draftCoordinator.addSourceAttachment(item.file)
         } catch (error) {
           if (draftCampId.current === campId) {
             setFailedAttachments((current) => [
@@ -3389,16 +3390,8 @@ export function CampWorkspace({
   }, [])
 
   const removePreparedAttachment = async (attachmentId: string): Promise<void> => {
-    const campId = snapshot.camp.id
-    const flushed = await composerHandleRef.current?.flush()
-    if (flushed?.result) applyComposerDraft(campId, flushed.result)
-    await queueDraftMutation(
-      campId,
-      (draft) => window.rovai.request<CampComposerDraftView>(
-        'camp.composerDraft.removeAttachment',
-        { campId, expectedRevision: draft.revision, attachmentId }
-      )
-    )
+    await composerHandleRef.current?.flush()
+    await draftCoordinator.removeSourceAttachment(attachmentId)
   }
 
   const copyMessage = (
@@ -4674,10 +4667,11 @@ export function CampWorkspace({
                 ? composerDraft.content
                 : emptyComposerDocument()}
               ready={composerDraft?.campId === snapshot.camp.id}
-              authoritativeResult={composerDraft}
+              getAuthoritativeDraft={() => draftCoordinator.getCurrentDraft()}
               persistDocument={(content) => saveStructuredDraft(snapshot.camp.id, content)}
-              onDraftSaved={(draft) => applyComposerDraft(snapshot.camp.id, draft)}
+              waitForDraftAuthority={() => draftCoordinator.waitForIdle().then(() => undefined)}
               onLocalStatusChange={setComposerLocalStatus}
+              onPersistenceStatusChange={setComposerPersistenceStatus}
               onBackspaceAtStart={composerDraft?.replyIntent
                 ? () => cancelReply('start')
                 : undefined}
@@ -4709,6 +4703,11 @@ export function CampWorkspace({
             {!composerDraft?.replyIntent && replyInteractionError && (
               <span className="composer-reply-status" role="status" aria-live="polite">
                 {replyInteractionError}
+              </span>
+            )}
+            {composerPersistenceStatus.state === 'error' && (
+              <span className="composer-reply-status" role="status" aria-live="polite">
+                草稿尚未保存；发送时会重试。{composerPersistenceStatus.error.message}
               </span>
             )}
           </div>

--- a/apps/desktop/src/renderer/src/ComposerAtomNode.ts
+++ b/apps/desktop/src/renderer/src/ComposerAtomNode.ts
@@ -4,13 +4,13 @@ import {
   $getState,
   $setState,
   createState,
-  TextNode,
+  DecoratorNode,
   type EditorConfig,
   type LexicalEditor,
   type LexicalNode,
   type LexicalUpdateJSON,
   type NodeKey,
-  type SerializedTextNode
+  type SerializedLexicalNode
 } from 'lexical'
 
 export type ComposerAtomType = ComposerAtom['type']
@@ -23,7 +23,7 @@ export interface ComposerAtomPresentation {
   ariaLabel: string
 }
 
-export type SerializedComposerAtomNode = SerializedTextNode & {
+export type SerializedComposerAtomNode = SerializedLexicalNode & {
   atomType?: ComposerAtomType
   referenceId?: string | null
   nameAtSend?: string | null
@@ -56,22 +56,22 @@ export function setComposerAtomPresentationResolver(
   else presentationResolvers.delete(editor)
 }
 
-export class ComposerAtomNode extends TextNode {
+export class ComposerAtomNode extends DecoratorNode<null> {
   static getType(): string {
     return 'composer-atom'
   }
 
   static clone(node: ComposerAtomNode): ComposerAtomNode {
-    return new ComposerAtomNode(node.__text, node.__key)
+    return new ComposerAtomNode(node.__key)
   }
 
   static importJSON(serializedNode: SerializedComposerAtomNode): ComposerAtomNode {
     return new ComposerAtomNode().updateFromJSON(serializedNode)
   }
 
-  $config(): ReturnType<TextNode['$config']> {
+  $config(): ReturnType<DecoratorNode<null>['$config']> {
     return this.config('composer-atom', {
-      extends: TextNode,
+      extends: DecoratorNode,
       stateConfigs: [
         { stateConfig: atomTypeState, flat: true },
         { stateConfig: referenceIdState, flat: true },
@@ -81,8 +81,8 @@ export class ComposerAtomNode extends TextNode {
     })
   }
 
-  constructor(text = '', key?: NodeKey) {
-    super(text, key)
+  constructor(key?: NodeKey) {
+    super(key)
   }
 
   updateFromJSON(serializedNode: LexicalUpdateJSON<SerializedComposerAtomNode>): this {
@@ -92,38 +92,39 @@ export class ComposerAtomNode extends TextNode {
       .setReferenceId(serializedNode.referenceId ?? null)
       .setNameAtSend(serializedNode.nameAtSend ?? null)
       .setFallbackLabel(serializedNode.fallbackLabel ?? '')
-      .setMode('token')
-      .setUnmergeable(true)
   }
 
   exportJSON(): SerializedComposerAtomNode {
     return super.exportJSON() as SerializedComposerAtomNode
   }
 
-  createDOM(config: EditorConfig, editor: LexicalEditor): HTMLElement {
-    const dom = super.createDOM(config, editor)
+  createDOM(_config: EditorConfig, editor: LexicalEditor): HTMLElement {
+    const dom = document.createElement('span')
     domEditors.set(dom, editor)
     updateComposerAtomDOM(dom, this, editor)
     return dom
   }
 
-  updateDOM(prevNode: this, dom: HTMLElement, config: EditorConfig): boolean {
-    super.updateDOM(prevNode, dom, config)
+  updateDOM(_prevNode: this, dom: HTMLElement, _config: EditorConfig): boolean {
     const editor = domEditors.get(dom)
     if (editor) updateComposerAtomDOM(dom, this, editor)
     return false
   }
 
-  canInsertTextBefore(): false {
-    return false
+  decorate(): null {
+    return null
   }
 
-  canInsertTextAfter(): false {
-    return false
-  }
-
-  isTextEntity(): true {
+  isInline(): true {
     return true
+  }
+
+  isKeyboardSelectable(): true {
+    return true
+  }
+
+  isIsolated(): false {
+    return false
   }
 
   getAtomType(): ComposerAtomType {
@@ -156,11 +157,6 @@ export class ComposerAtomNode extends TextNode {
 
   setFallbackLabel(value: string): this {
     return $setState(this, fallbackLabelState, value)
-  }
-
-  setUnmergeable(unmergeable: boolean): this {
-    if (this.isUnmergeable() !== unmergeable) this.toggleUnmergeable()
-    return this
   }
 
   getAtom(): ComposerAtom {
@@ -235,21 +231,12 @@ function updateComposerAtomDOM(
   }
 }
 
-export function $createComposerAtomNode(atom: ComposerAtom, fallbackLabel?: string): ComposerAtomNode {
-  const visibleFallback = atom.type === 'member'
-    ? fallbackLabel ?? atom.labelFallback ?? '不可用队员'
-    : atom.type === 'all_members'
-      ? '所有队员'
-      : atom.nameAtSend
-  const node = $applyNodeReplacement(new ComposerAtomNode(
-    atom.type === 'skill' ? `/${visibleFallback}` : `@${visibleFallback}`
-  ))
+export function $createComposerAtomNode(atom: ComposerAtom): ComposerAtomNode {
+  const node = $applyNodeReplacement(new ComposerAtomNode())
     .setAtomType(atom.type)
     .setReferenceId(atom.type === 'member' ? atom.agentId : atom.type === 'skill' ? atom.skillId : null)
     .setNameAtSend(atom.type === 'skill' ? atom.nameAtSend : null)
     .setFallbackLabel(atom.type === 'member' ? atom.labelFallback ?? '' : atom.type === 'skill' ? atom.nameAtSend : '所有队员')
-    .setMode('token')
-    .setUnmergeable(true)
   return node
 }
 

--- a/apps/desktop/src/renderer/src/ComposerTypeaheadPlugin.tsx
+++ b/apps/desktop/src/renderer/src/ComposerTypeaheadPlugin.tsx
@@ -1,0 +1,149 @@
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import {
+  COMMAND_PRIORITY_LOW,
+  KEY_ARROW_DOWN_COMMAND,
+  KEY_ARROW_UP_COMMAND,
+  KEY_ENTER_COMMAND,
+  KEY_ESCAPE_COMMAND,
+  KEY_TAB_COMMAND
+} from 'lexical'
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type JSX,
+  type ReactNode
+} from 'react'
+import { createPortal } from 'react-dom'
+import { $findComposerTriggerMatch, type ComposerTriggerMatch } from './composer-trigger'
+
+interface ComposerTypeaheadRenderState {
+  selectedIndex: number
+  setHighlightedIndex(index: number): void
+  selectIndex(index: number): void
+}
+
+export interface ComposerTypeaheadPluginProps {
+  match: ComposerTriggerMatch | null
+  optionCount: number
+  onMatchChange(match: ComposerTriggerMatch | null): void
+  onSelect(index: number, match: ComposerTriggerMatch): void
+  renderMenu(state: ComposerTypeaheadRenderState): ReactNode
+}
+
+/** One bounded selection listener and one keyboard owner for both @ and /. */
+export function ComposerTypeaheadPlugin({
+  match,
+  optionCount,
+  onMatchChange,
+  onSelect,
+  renderMenu
+}: ComposerTypeaheadPluginProps): JSX.Element | null {
+  const [editor] = useLexicalComposerContext()
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const [portalHost, setPortalHost] = useState<HTMLElement | null>(null)
+  const current = useRef({ match, optionCount, onMatchChange, onSelect })
+  current.current = { match, optionCount, onMatchChange, onSelect }
+
+  const close = useCallback(() => current.current.onMatchChange(null), [])
+  const selectIndex = useCallback((index: number) => {
+    const state = current.current
+    if (editor.isComposing() || !state.match || state.optionCount === 0) return
+    const boundedIndex = Math.max(0, Math.min(index, state.optionCount - 1))
+    state.onSelect(boundedIndex, state.match)
+  }, [editor])
+
+  useEffect(() => editor.registerRootListener((root) => {
+    setPortalHost(root?.parentElement ?? null)
+  }), [editor])
+
+  useEffect(() => editor.registerEditableListener((editable) => {
+    if (!editable) close()
+  }), [close, editor])
+
+  useEffect(() => editor.registerUpdateListener(({ editorState }) => {
+    if (editor.isComposing()) return
+    const next = editorState.read(() => $findComposerTriggerMatch(editor))
+    const previous = current.current.match
+    if (composerTriggerMatchesEqual(previous, next)) return
+    current.current.onMatchChange(next)
+  }), [editor])
+
+  useEffect(() => {
+    const unregister = [
+      editor.registerCommand(KEY_ARROW_DOWN_COMMAND, (event) => {
+        const state = current.current
+        if (!state.match || editor.isComposing()) return false
+        event?.preventDefault()
+        if (state.optionCount > 0) {
+          setSelectedIndex((index) => (index + 1) % state.optionCount)
+        }
+        return true
+      }, COMMAND_PRIORITY_LOW),
+      editor.registerCommand(KEY_ARROW_UP_COMMAND, (event) => {
+        const state = current.current
+        if (!state.match || editor.isComposing()) return false
+        event?.preventDefault()
+        if (state.optionCount > 0) {
+          setSelectedIndex((index) => (index - 1 + state.optionCount) % state.optionCount)
+        }
+        return true
+      }, COMMAND_PRIORITY_LOW),
+      editor.registerCommand(KEY_ENTER_COMMAND, (event) => {
+        const state = current.current
+        if (!state.match || state.optionCount === 0 || editor.isComposing() || event?.isComposing) {
+          return false
+        }
+        event?.preventDefault()
+        selectIndex(selectedIndex)
+        return true
+      }, COMMAND_PRIORITY_LOW),
+      editor.registerCommand(KEY_TAB_COMMAND, (event) => {
+        const state = current.current
+        if (!state.match || state.optionCount === 0 || editor.isComposing()) return false
+        event?.preventDefault()
+        selectIndex(selectedIndex)
+        return true
+      }, COMMAND_PRIORITY_LOW),
+      editor.registerCommand(KEY_ESCAPE_COMMAND, (event) => {
+        if (!current.current.match) return false
+        event?.preventDefault()
+        close()
+        return true
+      }, COMMAND_PRIORITY_LOW)
+    ]
+    return () => unregister.forEach((cleanup) => cleanup())
+  }, [close, editor, selectIndex, selectedIndex])
+
+  useEffect(() => {
+    setSelectedIndex((index) => optionCount === 0 ? 0 : Math.min(index, optionCount - 1))
+  }, [optionCount])
+
+  useEffect(() => { setSelectedIndex(0) }, [match?.kind, match?.nodeKey, match?.fromOffset])
+
+  useEffect(() => {
+    const selected = portalHost?.querySelector<HTMLElement>(
+      '.structured-mention-menu [aria-selected="true"]'
+    )
+    selected?.scrollIntoView({ block: 'nearest' })
+  }, [portalHost, selectedIndex])
+
+  if (!match || !portalHost) return null
+  return createPortal(renderMenu({ selectedIndex, setHighlightedIndex: setSelectedIndex, selectIndex }), portalHost)
+}
+
+function composerTriggerMatchesEqual(
+  left: ComposerTriggerMatch | null,
+  right: ComposerTriggerMatch | null
+): boolean {
+  return left === right || Boolean(
+    left
+      && right
+      && left.kind === right.kind
+      && left.query === right.query
+      && left.nodeKey === right.nodeKey
+      && left.fromOffset === right.fromOffset
+      && left.toOffset === right.toOffset
+  )
+}

--- a/apps/desktop/src/renderer/src/RovaiComposerExtension.ts
+++ b/apps/desktop/src/renderer/src/RovaiComposerExtension.ts
@@ -6,6 +6,7 @@ import {
   $createLineBreakNode,
   $getNearestNodeFromDOMNode,
   $getSelection,
+  $isNodeSelection,
   $isParagraphNode,
   $isRangeSelection,
   CLICK_COMMAND,
@@ -154,6 +155,7 @@ export const ComposerClipboardExtension = defineExtension({
         $addUpdateTag(CUT_TAG)
         const selection = $getSelection()
         if ($isRangeSelection(selection)) selection.removeText()
+        else if ($isNodeSelection(selection)) selection.deleteNodes()
       }
       return true
     }

--- a/apps/desktop/src/renderer/src/StructuredMentionComposer.tsx
+++ b/apps/desktop/src/renderer/src/StructuredMentionComposer.tsx
@@ -1,23 +1,12 @@
 import type { CampComposerDraftView, ComposerAtom, ComposerDocument } from '@contracts'
 import { LexicalExtensionComposer } from '@lexical/react/LexicalExtensionComposer'
 import { ContentEditable } from '@lexical/react/LexicalContentEditable'
-import {
-  LexicalTypeaheadMenuPlugin,
-  MenuOption,
-  type MenuRenderFn,
-  type MenuTextMatch,
-  type TriggerFn
-} from '@lexical/react/LexicalTypeaheadMenuPlugin'
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
 import {
   $getRoot,
-  $getSelection,
-  $isLineBreakNode,
-  $isRangeSelection,
   $nodesOfType,
   CLEAR_HISTORY_COMMAND,
-  HISTORY_PUSH_TAG,
-  type LexicalEditor
+  HISTORY_PUSH_TAG
 } from 'lexical'
 import {
   forwardRef,
@@ -33,12 +22,12 @@ import {
   type JSX,
   type RefObject
 } from 'react'
-import { createPortal } from 'react-dom'
 import {
   ComposerAtomNode,
   setComposerAtomPresentationResolver,
   type ComposerAtomPresentation
 } from './ComposerAtomNode'
+import { ComposerTypeaheadPlugin } from './ComposerTypeaheadPlugin'
 import { MemberAvatar } from './MemberAvatar'
 import {
   RovaiComposerExtension,
@@ -47,10 +36,11 @@ import {
 } from './RovaiComposerExtension'
 import { SkillIdentityMark } from './SkillIdentityMark'
 import type { ComposerSkillOption } from './composer-skill-picker'
+import { $replaceEditorWithComposerDocument } from './composer-editor-state'
 import {
-  $insertComposerAtomWithTrailingSpace,
-  $replaceEditorWithComposerDocument
-} from './composer-editor-state'
+  $replaceComposerTriggerWithAtom,
+  type ComposerTriggerMatch
+} from './composer-trigger'
 import {
   ComposerDraftSync,
   ROVAI_ATOM_PRESENTATION_TAG,
@@ -58,10 +48,10 @@ import {
   ROVAI_COMPOSER_REPLACE_TAG,
   type ComposerFlushResult,
   type ComposerFlushOptions,
-  type ComposerPersistContext
+  type ComposerPersistContext,
+  type ComposerDraftPersistenceStatus
 } from './composer-draft-sync'
 import {
-  MAX_TYPEAHEAD_QUERY_LENGTH,
   composerDocumentToPlainText,
   emptyComposerDocument,
   parseComposerClipboardDocument,
@@ -83,16 +73,15 @@ export type StructuredMentionOption =
 export interface StructuredMentionComposerHandle {
   flush(options?: ComposerFlushOptions): Promise<ComposerFlushResult<CampComposerDraftView>>
   resumePersistence(): void
+  advancePersistenceEpoch(savedLocalVersion?: number): void
   replaceDocument(
     document: ComposerDocument,
-    result?: CampComposerDraftView | null,
     boundary?: 'start' | 'end'
   ): void
   setDocument(document: ComposerDocument, boundary?: 'start' | 'end'): void
   clearIfVersion(
     localVersion: number,
-    document: ComposerDocument,
-    result?: CampComposerDraftView | null
+    document: ComposerDocument
   ): boolean
   focus(boundary?: 'start' | 'end'): void
   getLocalVersion(): number
@@ -104,7 +93,7 @@ export interface StructuredMentionComposerProps {
   draftIdentity: string
   document: ComposerDocument
   ready?: boolean
-  authoritativeResult?: CampComposerDraftView | null
+  getAuthoritativeDraft?(): CampComposerDraftView | null
   members: readonly StructuredMentionMember[]
   skills?: readonly ComposerSkillOption[] | null
   skillCatalogStatus?: 'loading' | 'ready' | 'error'
@@ -116,10 +105,11 @@ export interface StructuredMentionComposerProps {
   persistDocument?(
     document: ComposerDocument,
     context: ComposerPersistContext
-  ): Promise<CampComposerDraftView>
-  onDraftSaved?(draft: CampComposerDraftView, localVersion: number): void
+  ): Promise<void>
+  waitForDraftAuthority?(): Promise<void>
   onLocalStatusChange?(status: ComposerLocalStatus): void
   onDirtyChange?(dirty: boolean): void
+  onPersistenceStatusChange?(status: ComposerDraftPersistenceStatus): void
   onSubmit(): void | Promise<void>
   onBackspaceAtStart?(): void | Promise<void>
   onPasteFiles?(files: File[]): void
@@ -210,7 +200,7 @@ function ComposerBridge({
   id,
   document,
   ready = true,
-  authoritativeResult = null,
+  getAuthoritativeDraft,
   members,
   skills = [],
   skillCatalogStatus = 'ready',
@@ -220,9 +210,10 @@ function ComposerBridge({
   className = '',
   editorRef,
   persistDocument,
-  onDraftSaved,
+  waitForDraftAuthority,
   onLocalStatusChange,
   onDirtyChange,
+  onPersistenceStatusChange,
   onSubmit,
   onBackspaceAtStart,
   onPasteFiles,
@@ -239,13 +230,14 @@ function ComposerBridge({
   const initializedRef = useRef(false)
   const readyRef = useRef(ready)
   const callbacks = useRef({
-    authoritativeResult,
+    getAuthoritativeDraft,
     members,
     skills: skills ?? [],
     persistDocument,
-    onDraftSaved,
+    waitForDraftAuthority,
     onLocalStatusChange,
     onDirtyChange,
+    onPersistenceStatusChange,
     onSubmit,
     onBackspaceAtStart,
     onPasteFiles,
@@ -254,13 +246,14 @@ function ComposerBridge({
     onActivateSkillMention
   })
   callbacks.current = {
-    authoritativeResult,
+    getAuthoritativeDraft,
     members,
     skills: skills ?? [],
     persistDocument,
-    onDraftSaved,
+    waitForDraftAuthority,
     onLocalStatusChange,
     onDirtyChange,
+    onPersistenceStatusChange,
     onSubmit,
     onBackspaceAtStart,
     onPasteFiles,
@@ -269,20 +262,14 @@ function ComposerBridge({
     onActivateSkillMention
   }
 
-  const [mentionQuery, setMentionQuery] = useState<string | null>(null)
-  const [skillQuery, setSkillQuery] = useState<string | null>(null)
-  const updateMentionQuery = useCallback((query: string | null) => {
-    if (!editor.isComposing()) setMentionQuery(query)
-  }, [editor])
-  const updateSkillQuery = useCallback((query: string | null) => {
-    if (!editor.isComposing()) setSkillQuery(query)
-  }, [editor])
+  const [triggerMatch, setTriggerMatch] = useState<ComposerTriggerMatch | null>(null)
   const closeTypeaheads = useCallback(() => {
-    setMentionQuery(null)
-    setSkillQuery(null)
+    setTriggerMatch(null)
   }, [])
-  const mentionOpen = mentionQuery !== null
-  const skillOpen = skillQuery !== null
+  const mentionQuery = triggerMatch?.kind === 'member' ? triggerMatch.query : null
+  const skillQuery = triggerMatch?.kind === 'skill' ? triggerMatch.query : null
+  const mentionOpen = triggerMatch?.kind === 'member'
+  const skillOpen = triggerMatch?.kind === 'skill'
   const mentionOptions = useMemo(
     () => mentionQuery === null ? [] : structuredMentionOptions(members, mentionQuery),
     [members, mentionQuery]
@@ -296,34 +283,31 @@ function ComposerBridge({
 
   const bindings = useCallback(() => ({
     persist: callbacks.current.persistDocument,
-    currentResult: () => callbacks.current.authoritativeResult,
+    waitForAuthority: callbacks.current.waitForDraftAuthority,
+    currentDraft: () => callbacks.current.getAuthoritativeDraft?.() ?? null,
     atomIsAvailable: (node: ComposerAtomNode) =>
       atomPresentation(node, callbacks.current).availability === 'available',
-    onSaved: (draft: CampComposerDraftView, localVersion: number) =>
-      callbacks.current.onDraftSaved?.(draft, localVersion),
     onStatusChange: (status: ComposerLocalStatus) =>
       callbacks.current.onLocalStatusChange?.(status),
-    onDirtyChange: (dirty: boolean) => callbacks.current.onDirtyChange?.(dirty)
+    onDirtyChange: (dirty: boolean) => callbacks.current.onDirtyChange?.(dirty),
+    onPersistenceStatusChange: (status: ComposerDraftPersistenceStatus) =>
+      callbacks.current.onPersistenceStatusChange?.(status)
   }), [])
 
   const replaceAuthoritativeDocument = useCallback((
     nextDocument: ComposerDocument,
-    result: CampComposerDraftView | null = null,
     boundary: 'start' | 'end' = 'end'
   ): void => {
     closeTypeaheads()
     editor.update(() => {
-      $replaceEditorWithComposerDocument(
-        nextDocument,
-        (atom) => fallbackForAtom(atom, callbacks.current)
-      )
+      $replaceEditorWithComposerDocument(nextDocument)
       if (boundary === 'start') $getRoot().selectStart()
       else $getRoot().selectEnd()
     }, {
       discrete: true,
       tag: ROVAI_COMPOSER_REPLACE_TAG,
       onUpdate: () => {
-        syncRef.current?.acceptAuthoritativeState(editor.getEditorState(), result)
+        syncRef.current?.acceptAuthoritativeState(editor.getEditorState())
         editor.dispatchCommand(CLEAR_HISTORY_COMMAND, undefined)
       }
     })
@@ -336,10 +320,7 @@ function ComposerBridge({
     )
     const initialDocument = ready ? document : emptyComposerDocument()
     editor.update(() => {
-      $replaceEditorWithComposerDocument(
-        initialDocument,
-        (atom) => fallbackForAtom(atom, callbacks.current)
-      )
+      $replaceEditorWithComposerDocument(initialDocument)
     }, { discrete: true, tag: ROVAI_COMPOSER_INITIALIZE_TAG })
     const sync = new ComposerDraftSync(editor, editor.getEditorState(), bindings())
     const runtime: ComposerExtensionRuntime<CampComposerDraftView> = {
@@ -405,8 +386,8 @@ function ComposerBridge({
       return
     }
     readyRef.current = true
-    replaceAuthoritativeDocument(document, authoritativeResult)
-  }, [authoritativeResult, document, ready, replaceAuthoritativeDocument])
+    replaceAuthoritativeDocument(document)
+  }, [document, ready, replaceAuthoritativeDocument])
 
   useEffect(() => { editor.setEditable(ready && !disabled) }, [disabled, editor, ready])
 
@@ -418,29 +399,28 @@ function ComposerBridge({
           document,
           localVersion: 0,
           savedVersion: 0,
-          result: authoritativeResult
+          draft: getAuthoritativeDraft?.() ?? null
         }
       }
       return sync.flush(options)
     },
     resumePersistence: () => syncRef.current?.resumePersistence(),
+    advancePersistenceEpoch: (savedLocalVersion) =>
+      syncRef.current?.advancePersistenceEpoch(savedLocalVersion),
     replaceDocument: replaceAuthoritativeDocument,
     setDocument(nextDocument, boundary = 'end') {
       closeTypeaheads()
       editor.update(() => {
-        $replaceEditorWithComposerDocument(
-          nextDocument,
-          (atom) => fallbackForAtom(atom, callbacks.current)
-        )
+        $replaceEditorWithComposerDocument(nextDocument)
         if (boundary === 'start') $getRoot().selectStart()
         else $getRoot().selectEnd()
       }, { discrete: true, tag: HISTORY_PUSH_TAG })
       editor.focus(undefined, { defaultSelection: boundary === 'start' ? 'rootStart' : 'rootEnd' })
     },
-    clearIfVersion(localVersion, nextDocument, result = null) {
+    clearIfVersion(localVersion, nextDocument) {
       const sync = syncRef.current
       if (!sync || sync.getLocalVersion() !== localVersion) return false
-      replaceAuthoritativeDocument(nextDocument, result)
+      replaceAuthoritativeDocument(nextDocument)
       return true
     },
     focus(boundary = 'end') {
@@ -452,22 +432,14 @@ function ComposerBridge({
     },
     getLocalVersion: () => syncRef.current?.getLocalVersion() ?? 0,
     isDirty: () => syncRef.current?.isDirty() ?? false
-  }), [authoritativeResult, closeTypeaheads, document, editor, replaceAuthoritativeDocument])
+  }), [closeTypeaheads, document, editor, getAuthoritativeDraft, replaceAuthoritativeDocument])
 
   const setEditorElement = useCallback((element: HTMLDivElement | null) => {
     if (editorRef) editorRef.current = element
   }, [editorRef])
 
-  const mentionTrigger = useMemo(() => createTypeaheadTrigger('@', 'member'), [])
-  const skillTrigger = useMemo(() => createTypeaheadTrigger('/', 'skill'), [])
-  const mentionMenuOptions = useMemo(
-    () => mentionOptions.slice(0, 50).map((option) => new MemberTypeaheadOption(option)),
-    [mentionOptions]
-  )
-  const skillMenuOptions = useMemo(
-    () => skillOptions.slice(0, 50).map((option) => new SkillTypeaheadOption(option)),
-    [skillOptions]
-  )
+  const mentionMenuOptions = useMemo(() => mentionOptions.slice(0, 50), [mentionOptions])
+  const skillMenuOptions = useMemo(() => skillOptions.slice(0, 50), [skillOptions])
   const mentionMenuId = `${id || generatedId}-mention-options`
   const skillMenuId = `${id || generatedId}-skill-options`
   const menuOpen = mentionOpen || skillOpen
@@ -479,178 +451,118 @@ function ComposerBridge({
       aria-disabled={disabled || !ready} spellCheck
       placeholder={<span className="structured-mention-placeholder">{placeholder}</span>}
       aria-placeholder={placeholder} />
-    <LexicalTypeaheadMenuPlugin<MemberTypeaheadOption>
-      triggerFn={mentionTrigger} options={mentionMenuOptions}
-      onQueryChange={updateMentionQuery}
-      onClose={() => setMentionQuery(null)}
-      onSelectOption={(option, queryNode, close) => {
-        if (!queryNode || editor.isComposing()) return
-        editor.update(() => {
-          const atom: ComposerAtom = option.value.kind === 'all_members'
+    <ComposerTypeaheadPlugin match={triggerMatch}
+      optionCount={mentionOpen ? mentionMenuOptions.length : skillMenuOptions.length}
+      onMatchChange={setTriggerMatch}
+      onSelect={(index, match) => {
+        if (editor.isComposing()) return
+        if (match.kind === 'member') {
+          const option = mentionMenuOptions[index]
+          if (!option) return
+          const atom: ComposerAtom = option.kind === 'all_members'
             ? { type: 'all_members' }
             : {
                 type: 'member',
-                agentId: option.value.member.agentId,
-                labelFallback: option.value.member.displayName
+                agentId: option.member.agentId,
+                labelFallback: option.member.displayName
               }
-          $insertComposerAtomWithTrailingSpace(
-            queryNode,
-            atom,
-            option.value.kind === 'member' ? option.value.member.displayName : '所有队员'
+          editor.update(() => {
+            $replaceComposerTriggerWithAtom(
+              match,
+              atom
+            )
+          }, { tag: HISTORY_PUSH_TAG })
+        } else {
+          const option = skillMenuOptions[index]
+          if (!option) return
+          editor.update(() => {
+            $replaceComposerTriggerWithAtom(match, {
+              type: 'skill', skillId: option.id, nameAtSend: option.name
+            })
+          }, { tag: HISTORY_PUSH_TAG })
+        }
+        closeTypeaheads()
+      }}
+      renderMenu={({ selectedIndex, setHighlightedIndex, selectIndex }) => mentionOpen
+        ? renderMentionMenu(
+            mentionMenuId,
+            mentionMenuOptions,
+            selectedIndex,
+            setHighlightedIndex,
+            selectIndex
           )
-        }, { tag: HISTORY_PUSH_TAG })
-        close()
-      }}
-      menuRenderFn={mentionMenuRender(mentionMenuId)} />
-    <LexicalTypeaheadMenuPlugin<SkillTypeaheadOption>
-      triggerFn={skillTrigger} options={skillMenuOptions}
-      onQueryChange={updateSkillQuery}
-      onClose={() => setSkillQuery(null)}
-      onSelectOption={(option, queryNode, close) => {
-        if (!queryNode || editor.isComposing()) return
-        editor.update(() => {
-          $insertComposerAtomWithTrailingSpace(queryNode, {
-            type: 'skill',
-            skillId: option.value.id,
-            nameAtSend: option.value.name
-          }, option.value.name)
-        }, { tag: HISTORY_PUSH_TAG })
-        close()
-      }}
-      menuRenderFn={skillMenuRender(skillMenuId, skillCatalogStatus)} />
+        : renderSkillMenu(
+            skillMenuId,
+            skillCatalogStatus,
+            skillMenuOptions,
+            selectedIndex,
+            setHighlightedIndex,
+            selectIndex
+          )} />
   </div>
 }
 
-class MemberTypeaheadOption extends MenuOption {
-  readonly value: StructuredMentionOption
-
-  constructor(value: StructuredMentionOption) {
-    super(value.kind === 'all_members' ? 'all-members' : `member:${value.member.agentId}`)
-    this.value = value
-  }
+function renderMentionMenu(
+  menuId: string,
+  options: readonly StructuredMentionOption[],
+  selectedIndex: number,
+  setHighlightedIndex: (index: number) => void,
+  selectIndex: (index: number) => void
+): JSX.Element {
+  return <div id={menuId} className="mention-menu structured-mention-menu" role="listbox"
+    aria-label="选择接收队员">
+    <div className="mention-menu-heading"><strong>选择接收者</strong><span>↑↓ 选择 · Enter 确认</span></div>
+    {options.length === 0
+      ? <p className="structured-mention-empty">没有匹配的队员</p>
+      : options.map((option, index) => <button type="button" role="option"
+          key={option.kind === 'all_members' ? 'all-members' : `member:${option.member.agentId}`}
+          aria-selected={selectedIndex === index}
+          className={selectedIndex === index ? 'active' : ''}
+          onMouseMove={() => setHighlightedIndex(index)}
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => selectIndex(index)}>
+          <StructuredMentionOptionAvatar option={option} />
+          <span>
+            <strong>{option.kind === 'all_members' ? '所有队员' : option.member.displayName}</strong>
+            <small>{option.kind === 'all_members' ? '广播给当前全部队员' : 'Camp 成员'}</small>
+          </span>
+          <i aria-hidden="true" />
+        </button>)}
+  </div>
 }
 
-class SkillTypeaheadOption extends MenuOption {
-  readonly value: ComposerSkillOption
-
-  constructor(value: ComposerSkillOption) {
-    super(`skill:${value.id}`)
-    this.value = value
-  }
-}
-
-function mentionMenuRender(menuId: string): MenuRenderFn<MemberTypeaheadOption> {
-  return (anchorRef, { selectedIndex, selectOptionAndCleanUp, setHighlightedIndex, options }) => {
-    const anchor = anchorRef.current
-    if (!anchor) return null
-    return createPortal(
-      <div id={menuId} className="mention-menu structured-mention-menu" role="listbox"
-        aria-label="选择接收队员">
-        <div className="mention-menu-heading"><strong>选择接收者</strong><span>↑↓ 选择 · Enter 确认</span></div>
-        {options.length === 0
-          ? <p className="structured-mention-empty">没有匹配的队员</p>
+function renderSkillMenu(
+  menuId: string,
+  status: 'loading' | 'ready' | 'error',
+  options: readonly ComposerSkillOption[],
+  selectedIndex: number,
+  setHighlightedIndex: (index: number) => void,
+  selectIndex: (index: number) => void
+): JSX.Element {
+  return <div id={menuId} className="mention-menu skill-picker-menu structured-skill-menu"
+    role="listbox" aria-label="选择 Skill">
+    <div className="mention-menu-heading"><strong>选择 Skill</strong><span>↑↓ 选择 · Enter 确认</span></div>
+    {status === 'loading'
+      ? <p className="structured-mention-empty">正在读取可用 Skills…</p>
+      : status === 'error'
+        ? <p className="structured-mention-empty">Skills 暂时无法读取，请稍后重试</p>
+        : options.length === 0
+          ? <p className="structured-mention-empty">没有匹配的 Skill</p>
           : options.map((option, index) => <button type="button" role="option"
-              key={option.key} ref={(element) => option.setRefElement(element)}
+              key={`skill:${option.id}`} data-skill-name={option.name}
               aria-selected={selectedIndex === index}
               className={selectedIndex === index ? 'active' : ''}
               onMouseMove={() => setHighlightedIndex(index)}
               onMouseDown={(event) => event.preventDefault()}
-              onClick={() => selectOptionAndCleanUp(option)}>
-              <StructuredMentionOptionAvatar option={option.value} />
-              <span>
-                <strong>{option.value.kind === 'all_members'
-                  ? '所有队员'
-                  : option.value.member.displayName}</strong>
-                <small>{option.value.kind === 'all_members'
-                  ? '广播给当前全部队员'
-                  : 'Camp 成员'}</small>
+              onClick={() => selectIndex(index)}>
+              <SkillIdentityMark skillId={option.id} name={option.name} size="compact" />
+              <span className="skill-picker-copy">
+                <strong>/{option.name}</strong>
+                <small>{option.description}</small>
               </span>
-              <i aria-hidden="true" />
+              <span className="skill-picker-enter" aria-hidden="true">↵</span>
             </button>)}
-      </div>,
-      anchor
-    )
-  }
-}
-
-function skillMenuRender(
-  menuId: string,
-  status: 'loading' | 'ready' | 'error'
-): MenuRenderFn<SkillTypeaheadOption> {
-  return (anchorRef, { selectedIndex, selectOptionAndCleanUp, setHighlightedIndex, options }) => {
-    const anchor = anchorRef.current
-    if (!anchor) return null
-    return createPortal(
-      <div id={menuId} className="mention-menu skill-picker-menu structured-skill-menu"
-        role="listbox" aria-label="选择 Skill">
-        <div className="mention-menu-heading"><strong>选择 Skill</strong><span>↑↓ 选择 · Enter 确认</span></div>
-        {status === 'loading'
-          ? <p className="structured-mention-empty">正在读取可用 Skills…</p>
-          : status === 'error'
-            ? <p className="structured-mention-empty">Skills 暂时无法读取，请稍后重试</p>
-            : options.length === 0
-              ? <p className="structured-mention-empty">没有匹配的 Skill</p>
-              : options.map((option, index) => <button type="button" role="option"
-                  key={option.key} ref={(element) => option.setRefElement(element)}
-                  data-skill-name={option.value.name}
-                  aria-selected={selectedIndex === index}
-                  className={selectedIndex === index ? 'active' : ''}
-                  onMouseMove={() => setHighlightedIndex(index)}
-                  onMouseDown={(event) => event.preventDefault()}
-                  onClick={() => selectOptionAndCleanUp(option)}>
-                  <SkillIdentityMark skillId={option.value.id} name={option.value.name} size="compact" />
-                  <span className="skill-picker-copy">
-                    <strong>/{option.value.name}</strong>
-                    <small>{option.value.description}</small>
-                  </span>
-                  <span className="skill-picker-enter" aria-hidden="true">↵</span>
-                </button>)}
-      </div>,
-      anchor
-    )
-  }
-}
-
-function createTypeaheadTrigger(symbol: '@' | '/', kind: 'member' | 'skill'): TriggerFn {
-  const queryPattern = kind === 'member'
-    ? '[\\p{L}\\p{N}_-]'
-    : '[A-Za-z0-9-]'
-  const boundaryPattern = '[\\s，。！？；：、（(\\[【{「『]'
-  const pattern = new RegExp(
-    `(^|${boundaryPattern})${symbol}(${queryPattern}{0,${MAX_TYPEAHEAD_QUERY_LENGTH}})$`,
-    'u'
-  )
-  return (text: string, editor: LexicalEditor): MenuTextMatch | null => {
-    if (editor.isComposing()) return null
-    const bounded = text.slice(-(MAX_TYPEAHEAD_QUERY_LENGTH + 2))
-    const match = pattern.exec(bounded)
-    if (!match) return null
-    const query = match[2] ?? ''
-    const replaceableString = `${symbol}${query}`
-    const leadOffset = text.length - replaceableString.length
-    if (leadOffset === 0) {
-      const selection = $getSelection()
-      if (!$isRangeSelection(selection) || !selection.isCollapsed()) return null
-      const previous = selection.anchor.getNode().getPreviousSibling()
-      if (previous && !$isLineBreakNode(previous)) return null
-    }
-    return { leadOffset, matchingString: query, replaceableString }
-  }
-}
-
-function fallbackForAtom(
-  atom: ComposerAtom,
-  input: Pick<StructuredMentionComposerProps, 'members' | 'skills'>
-): string | undefined {
-  if (atom.type === 'member') {
-    return input.members.find((member) => member.agentId === atom.agentId)?.displayName
-      ?? atom.labelFallback
-  }
-  if (atom.type === 'skill') {
-    return (input.skills ?? []).find((skill) => skill.id === atom.skillId)?.name
-      ?? atom.nameAtSend
-  }
-  return '所有队员'
+  </div>
 }
 
 function atomPresentation(

--- a/apps/desktop/src/renderer/src/composer-draft-sync.test.ts
+++ b/apps/desktop/src/renderer/src/composer-draft-sync.test.ts
@@ -11,7 +11,9 @@ import {
 import { ComposerAtomNode } from './ComposerAtomNode'
 import {
   ComposerDraftSync,
-  ROVAI_ATOM_PRESENTATION_TAG
+  COMPOSER_DRAFT_RETRY_DELAYS_MS,
+  ROVAI_ATOM_PRESENTATION_TAG,
+  StaleComposerSyncEpochError
 } from './composer-draft-sync'
 import {
   $replaceEditorWithComposerDocument
@@ -50,11 +52,10 @@ describe('ComposerDraftSync', () => {
     const editor = createComposerEditor()
     const persisted: string[] = []
     const sync = new ComposerDraftSync(editor, editor.getEditorState(), {
-      currentResult: () => ({ revision: 0 }),
+      currentDraft: () => ({ revision: 0 }),
       atomIsAvailable: () => true,
       persist: async (document) => {
         persisted.push(editorStateText(document))
-        return { revision: persisted.length }
       }
     })
     const unregister = editor.registerUpdateListener((payload) => sync.handleEditorUpdate(payload))
@@ -80,12 +81,11 @@ describe('ComposerDraftSync', () => {
     let releaseFirst!: () => void
     const firstSave = new Promise<void>((resolve) => { releaseFirst = resolve })
     const sync = new ComposerDraftSync(editor, editor.getEditorState(), {
-      currentResult: () => ({ revision: 0 }),
+      currentDraft: () => ({ revision: 0 }),
       atomIsAvailable: () => true,
       persist: async (document) => {
         persisted.push(editorStateText(document))
         if (persisted.length === 1) await firstSave
-        return { revision: persisted.length }
       }
     })
     const unregister = editor.registerUpdateListener((payload) => sync.handleEditorUpdate(payload))
@@ -119,7 +119,7 @@ describe('ComposerDraftSync', () => {
     let concurrent = 0
     let maxConcurrent = 0
     const sync = new ComposerDraftSync(editor, editor.getEditorState(), {
-      currentResult: () => ({ revision: 0 }),
+      currentDraft: () => ({ revision: 0 }),
       atomIsAvailable: () => true,
       persist: async (document) => {
         persisted.push(editorStateText(document))
@@ -127,7 +127,6 @@ describe('ComposerDraftSync', () => {
         maxConcurrent = Math.max(maxConcurrent, concurrent)
         await new Promise<void>((resolve) => releases.push(resolve))
         concurrent -= 1
-        return { revision: persisted.length }
       }
     })
     const unregister = editor.registerUpdateListener((payload) => sync.handleEditorUpdate(payload))
@@ -154,11 +153,10 @@ describe('ComposerDraftSync', () => {
     const editor = createComposerEditor()
     const persisted: string[] = []
     const sync = new ComposerDraftSync(editor, editor.getEditorState(), {
-      currentResult: () => ({ revision: 0 }),
+      currentDraft: () => ({ revision: 0 }),
       atomIsAvailable: () => true,
       persist: async (document) => {
         persisted.push(editorStateText(document))
-        return { revision: persisted.length }
       }
     })
     const unregister = editor.registerUpdateListener((payload) => sync.handleEditorUpdate(payload))
@@ -178,11 +176,10 @@ describe('ComposerDraftSync', () => {
     const editor = createComposerEditor()
     const persisted: string[] = []
     const sync = new ComposerDraftSync(editor, editor.getEditorState(), {
-      currentResult: () => ({ revision: 0 }),
+      currentDraft: () => ({ revision: 0 }),
       atomIsAvailable: () => true,
       persist: async (document) => {
         persisted.push(editorStateText(document))
-        return { revision: persisted.length }
       }
     })
     const unregister = editor.registerUpdateListener((payload) => sync.handleEditorUpdate(payload))
@@ -215,7 +212,7 @@ describe('ComposerDraftSync', () => {
     let available = true
     const statuses: boolean[] = []
     const sync = new ComposerDraftSync(editor, editor.getEditorState(), {
-      currentResult: () => ({ revision: 1 }),
+      currentDraft: () => ({ revision: 1 }),
       atomIsAvailable: () => available,
       onStatusChange: (status) => statuses.push(status.hasUnavailableAtom)
     })
@@ -223,7 +220,7 @@ describe('ComposerDraftSync', () => {
 
     available = false
     sync.updateBindings({
-      currentResult: () => ({ revision: 1 }),
+      currentDraft: () => ({ revision: 1 }),
       atomIsAvailable: () => available,
       onStatusChange: (status) => statuses.push(status.hasUnavailableAtom)
     })
@@ -237,6 +234,81 @@ describe('ComposerDraftSync', () => {
     expect(sync.isDirty()).toBe(false)
 
     unregister()
+    sync.destroy()
+  })
+
+  it('keeps a failed autosave dirty, exposes an error, and retries with a finite backoff', async () => {
+    vi.useFakeTimers()
+    const editor = createComposerEditor()
+    const statuses: string[] = []
+    let attempts = 0
+    const sync = new ComposerDraftSync(editor, editor.getEditorState(), {
+      atomIsAvailable: () => true,
+      persist: async () => {
+        attempts += 1
+        if (attempts < 3) throw new Error(`save ${attempts} failed`)
+      },
+      onPersistenceStatusChange: (status) => statuses.push(status.state)
+    })
+    const unregister = editor.registerUpdateListener((payload) => sync.handleEditorUpdate(payload))
+
+    replaceText(editor, '需要重试')
+    await vi.advanceTimersByTimeAsync(350)
+    expect(attempts).toBe(1)
+    expect(sync.isDirty()).toBe(true)
+    expect(sync.getPersistenceStatus()).toMatchObject({ state: 'error' })
+
+    await vi.advanceTimersByTimeAsync(COMPOSER_DRAFT_RETRY_DELAYS_MS[0])
+    expect(attempts).toBe(2)
+    await vi.advanceTimersByTimeAsync(COMPOSER_DRAFT_RETRY_DELAYS_MS[1])
+    expect(attempts).toBe(3)
+    expect(sync.isDirty()).toBe(false)
+    expect(sync.getPersistenceStatus()).toEqual({ state: 'saved' })
+    expect(statuses).toContain('error')
+
+    unregister()
+    sync.destroy()
+  })
+
+  it('does not let an old epoch save completion mark replacement content as saved', async () => {
+    const editor = createComposerEditor()
+    let release!: () => void
+    const pending = new Promise<void>((resolve) => { release = resolve })
+    const sync = new ComposerDraftSync(editor, editor.getEditorState(), {
+      atomIsAvailable: () => true,
+      persist: async () => pending
+    })
+    const unregister = editor.registerUpdateListener((payload) => sync.handleEditorUpdate(payload))
+
+    replaceText(editor, 'old draft')
+    const oldFlush = sync.flush()
+    await Promise.resolve()
+    const replacement = createComposerEditor('new draft').getEditorState()
+    sync.acceptAuthoritativeState(replacement)
+    release()
+    await expect(oldFlush).rejects.toBeInstanceOf(StaleComposerSyncEpochError)
+
+    expect(sync.getLocalVersion()).toBe(0)
+    expect(sync.getSavedVersion()).toBe(0)
+    expect(sync.isDirty()).toBe(false)
+    expect(sync.getPersistenceStatus()).toEqual({ state: 'saved' })
+
+    unregister()
+    sync.destroy()
+  })
+
+  it('returns the authoritative value read after the captured snapshot is persisted', async () => {
+    const editor = createComposerEditor()
+    let authority = { revision: 3 }
+    const sync = new ComposerDraftSync(editor, editor.getEditorState(), {
+      atomIsAvailable: () => true,
+      currentDraft: () => authority,
+      waitForAuthority: async () => { authority = { revision: 4 } }
+    })
+
+    const flushed = await sync.flush()
+
+    expect(flushed.draft).toEqual({ revision: 4 })
     sync.destroy()
   })
 })

--- a/apps/desktop/src/renderer/src/composer-draft-sync.ts
+++ b/apps/desktop/src/renderer/src/composer-draft-sync.ts
@@ -3,18 +3,20 @@ import {
   $getNodeByKey,
   $getRoot,
   $isTextNode,
+  $nodesOfType,
   type EditorState,
   type LexicalEditor,
+  type LexicalNode,
   type NodeKey,
-  type TextNode,
   type UpdateListenerPayload
 } from 'lexical'
-import { $isComposerAtomNode, type ComposerAtomNode } from './ComposerAtomNode'
+import { $isComposerAtomNode, ComposerAtomNode } from './ComposerAtomNode'
 import { editorStateToComposerDocument } from './composer-editor-state'
 import type { ComposerLocalStatus } from './composer-document'
 
 export const COMPOSER_DRAFT_DEBOUNCE_MS = 350
 export const COMPOSER_DRAFT_MAX_WAIT_MS = 1_500
+export const COMPOSER_DRAFT_RETRY_DELAYS_MS = [500, 1_500] as const
 
 export const ROVAI_ATOM_PRESENTATION_TAG = 'rovai:atom-presentation'
 export const ROVAI_COMPOSER_INITIALIZE_TAG = 'rovai:composer-initialize'
@@ -24,24 +26,39 @@ export interface ComposerPersistContext {
   localVersion: number
 }
 
-export interface ComposerFlushResult<Result = unknown> {
+export interface ComposerFlushResult<Draft = unknown> {
   document: ComposerDocument
   localVersion: number
   savedVersion: number
-  result: Result | null
+  draft: Draft | null
 }
 
 export interface ComposerFlushOptions {
   holdPersistence?: boolean
 }
 
-export interface ComposerDraftSyncBindings<Result = unknown> {
-  persist?: (document: ComposerDocument, context: ComposerPersistContext) => Promise<Result>
-  currentResult?: () => Result | null
+export interface ComposerDraftSyncBindings<Draft = unknown> {
+  persist?: (document: ComposerDocument, context: ComposerPersistContext) => Promise<void>
+  waitForAuthority?: () => Promise<void>
+  currentDraft?: () => Draft | null
   atomIsAvailable(node: ComposerAtomNode): boolean
-  onSaved?: (result: Result, localVersion: number) => void
+  onSaved?: (localVersion: number) => void
   onStatusChange?: (status: ComposerLocalStatus) => void
   onDirtyChange?: (dirty: boolean) => void
+  onPersistenceStatusChange?: (status: ComposerDraftPersistenceStatus) => void
+}
+
+export type ComposerDraftPersistenceStatus =
+  | { state: 'saved' }
+  | { state: 'dirty' }
+  | { state: 'saving' }
+  | { state: 'error'; error: Error }
+
+export class StaleComposerSyncEpochError extends Error {
+  constructor() {
+    super('Composer persistence operation belongs to a stale editing epoch.')
+    this.name = 'StaleComposerSyncEpochError'
+  }
 }
 
 interface NodeContribution {
@@ -58,19 +75,22 @@ const EMPTY_CONTRIBUTION: NodeContribution = {
   unavailableAtom: 0
 }
 
-export class ComposerDraftSync<Result = unknown> {
+export class ComposerDraftSync<Draft = unknown> {
   readonly editor: LexicalEditor
-  private bindings: ComposerDraftSyncBindings<Result>
+  private bindings: ComposerDraftSyncBindings<Draft>
   private latestEditorState: EditorState
   private localVersion = 0
   private savedVersion = 0
   private savingVersion: number | null = null
-  private latestResult: Result | null = null
+  private epoch = 0
   private dirty = false
   private debounceTimer: ReturnType<typeof setTimeout> | null = null
   private maxWaitTimer: ReturnType<typeof setTimeout> | null = null
-  private inFlight: Promise<void> | null = null
+  private retryTimer: ReturnType<typeof setTimeout> | null = null
+  private retryAttempt = 0
+  private inFlight: { epoch: number; promise: Promise<void> } | null = null
   private persistenceHeld = false
+  private persistenceStatus: ComposerDraftPersistenceStatus = { state: 'saved' }
   private contributions = new Map<NodeKey, NodeContribution>()
   private totals: NodeContribution = { ...EMPTY_CONTRIBUTION }
   private lastStatus: ComposerLocalStatus | null = null
@@ -78,29 +98,31 @@ export class ComposerDraftSync<Result = unknown> {
   constructor(
     editor: LexicalEditor,
     editorState: EditorState,
-    bindings: ComposerDraftSyncBindings<Result>
+    bindings: ComposerDraftSyncBindings<Draft>
   ) {
     this.editor = editor
     this.latestEditorState = editorState
     this.bindings = bindings
-    this.latestResult = bindings.currentResult?.() ?? null
     this.rebuildContributions(editorState)
   }
 
-  updateBindings(bindings: ComposerDraftSyncBindings<Result>): void {
+  updateBindings(bindings: ComposerDraftSyncBindings<Draft>): void {
     this.bindings = bindings
     this.refreshAtomAvailability()
   }
 
-  acceptAuthoritativeState(editorState: EditorState, result: Result | null): void {
+  acceptAuthoritativeState(editorState: EditorState): void {
     this.clearTimers()
+    this.epoch += 1
     this.latestEditorState = editorState
     this.localVersion = 0
     this.savedVersion = 0
     this.savingVersion = null
-    this.latestResult = result
+    this.inFlight = null
+    this.retryAttempt = 0
     this.persistenceHeld = false
     this.setDirty(false)
+    this.setPersistenceStatus({ state: 'saved' })
     this.rebuildContributions(editorState)
   }
 
@@ -115,7 +137,10 @@ export class ComposerDraftSync<Result = unknown> {
 
     this.applyDirtyLeaves(payload.editorState, payload.dirtyLeaves)
     this.localVersion += 1
+    this.retryAttempt = 0
+    this.clearRetryTimer()
     this.setDirty(true)
+    this.setPersistenceStatus({ state: 'dirty' })
     if (this.bindings.persist) this.scheduleSave()
   }
 
@@ -127,27 +152,40 @@ export class ComposerDraftSync<Result = unknown> {
     return this.dirty
   }
 
+  getSavedVersion(): number {
+    return this.savedVersion
+  }
+
+  getPersistenceStatus(): ComposerDraftPersistenceStatus {
+    return this.persistenceStatus
+  }
+
   getStatus(): ComposerLocalStatus {
     return this.statusFromTotals()
   }
 
-  async flush(options: ComposerFlushOptions = {}): Promise<ComposerFlushResult<Result>> {
+  async flush(options: ComposerFlushOptions = {}): Promise<ComposerFlushResult<Draft>> {
     if (options.holdPersistence) this.persistenceHeld = true
     this.clearTimers()
     const targetVersion = this.localVersion
     const targetEditorState = this.latestEditorState
+    const targetEpoch = this.epoch
     if (this.bindings.persist) {
-      if (this.inFlight) await this.inFlight.catch(() => undefined)
-      if (this.savedVersion < targetVersion || this.latestResult === null) {
-        await this.startSave(targetVersion, targetEditorState)
+      const preceding = this.inFlight?.epoch === targetEpoch ? this.inFlight.promise : null
+      if (preceding) await preceding.catch(() => undefined)
+      this.assertEpoch(targetEpoch)
+      if (this.savedVersion < targetVersion) {
+        await this.startSave(targetEpoch, targetVersion, targetEditorState, false)
       }
-      if (this.inFlight) await this.inFlight
+      this.assertEpoch(targetEpoch)
     }
+    await this.bindings.waitForAuthority?.()
+    this.assertEpoch(targetEpoch)
     return {
       document: editorStateToComposerDocument(targetEditorState),
       localVersion: targetVersion,
       savedVersion: this.savedVersion,
-      result: this.latestResult ?? this.bindings.currentResult?.() ?? null
+      draft: this.bindings.currentDraft?.() ?? null
     }
   }
 
@@ -157,8 +195,22 @@ export class ComposerDraftSync<Result = unknown> {
     if (this.bindings.persist && this.savedVersion < this.localVersion) this.scheduleSave()
   }
 
+  advancePersistenceEpoch(savedLocalVersion = this.savedVersion): void {
+    this.clearTimers()
+    this.epoch += 1
+    this.inFlight = null
+    this.savingVersion = null
+    this.savedVersion = Math.min(savedLocalVersion, this.localVersion)
+    this.retryAttempt = 0
+    const dirty = this.localVersion > this.savedVersion
+    this.setDirty(dirty)
+    this.setPersistenceStatus(dirty ? { state: 'dirty' } : { state: 'saved' })
+  }
+
   destroy(): void {
     this.clearTimers()
+    this.epoch += 1
+    this.inFlight = null
   }
 
   private scheduleSave(): void {
@@ -184,33 +236,70 @@ export class ComposerDraftSync<Result = unknown> {
 
   private async saveLatest(): Promise<void> {
     if (!this.bindings.persist) return
-    if (this.inFlight) return this.inFlight
-    if (this.savedVersion >= this.localVersion && this.latestResult !== null) return
-    return this.startSave(this.localVersion, this.latestEditorState)
+    const existing = this.inFlight?.epoch === this.epoch ? this.inFlight.promise : null
+    if (existing) return existing
+    if (this.savedVersion >= this.localVersion) return
+    return this.startSave(this.epoch, this.localVersion, this.latestEditorState, true)
   }
 
-  private startSave(version: number, editorState: EditorState): Promise<void> {
+  private startSave(
+    epoch: number,
+    version: number,
+    editorState: EditorState,
+    allowRetry: boolean
+  ): Promise<void> {
     const persist = this.bindings.persist
     if (!persist) return Promise.resolve()
-    if (this.inFlight) return this.inFlight
+    const existing = this.inFlight?.epoch === epoch ? this.inFlight.promise : null
+    if (existing) return existing
     const document = editorStateToComposerDocument(editorState)
     this.savingVersion = version
+    this.setPersistenceStatus({ state: 'saving' })
     const operation = persist(document, { localVersion: version })
-      .then((result) => {
+      .then(() => {
+        if (epoch !== this.epoch) return
         this.savedVersion = Math.max(this.savedVersion, version)
-        this.latestResult = result
-        this.bindings.onSaved?.(result, version)
-        if (this.localVersion === version) this.setDirty(false)
+        this.retryAttempt = 0
+        this.bindings.onSaved?.(version)
+        const clean = this.localVersion === version
+        if (clean) this.setDirty(false)
+        this.setPersistenceStatus(clean ? { state: 'saved' } : { state: 'dirty' })
+      }, (error: unknown) => {
+        if (epoch !== this.epoch) return
+        const normalized = error instanceof Error ? error : new Error(String(error))
+        this.setDirty(true)
+        this.setPersistenceStatus({ state: 'error', error: normalized })
+        if (allowRetry) this.scheduleRetry(epoch)
+        throw error
       })
       .finally(() => {
-        this.savingVersion = null
+        if (this.inFlight?.promise !== operation) return
         this.inFlight = null
+        if (epoch !== this.epoch) return
+        this.savingVersion = null
         if (!this.persistenceHeld && this.localVersion > version && this.bindings.persist) {
-          void this.startSave(this.localVersion, this.latestEditorState).catch(() => undefined)
+          void this.startSave(
+            epoch,
+            this.localVersion,
+            this.latestEditorState,
+            true
+          ).catch(() => undefined)
         }
       })
-    this.inFlight = operation
+    this.inFlight = { epoch, promise: operation }
     return operation
+  }
+
+  private scheduleRetry(epoch: number): void {
+    if (this.persistenceHeld || this.retryTimer || epoch !== this.epoch) return
+    const delay = COMPOSER_DRAFT_RETRY_DELAYS_MS[this.retryAttempt]
+    if (delay === undefined) return
+    this.retryAttempt += 1
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null
+      if (epoch !== this.epoch || this.persistenceHeld) return
+      void this.saveLatest().catch(() => undefined)
+    }, delay)
   }
 
   private clearTimers(): void {
@@ -218,6 +307,12 @@ export class ComposerDraftSync<Result = unknown> {
     if (this.maxWaitTimer) clearTimeout(this.maxWaitTimer)
     this.debounceTimer = null
     this.maxWaitTimer = null
+    this.clearRetryTimer()
+  }
+
+  private clearRetryTimer(): void {
+    if (this.retryTimer) clearTimeout(this.retryTimer)
+    this.retryTimer = null
   }
 
   private setDirty(dirty: boolean): void {
@@ -226,11 +321,29 @@ export class ComposerDraftSync<Result = unknown> {
     this.bindings.onDirtyChange?.(dirty)
   }
 
+  private setPersistenceStatus(status: ComposerDraftPersistenceStatus): void {
+    if (
+      this.persistenceStatus.state === status.state
+      && (status.state !== 'error'
+        || (this.persistenceStatus.state === 'error'
+          && this.persistenceStatus.error === status.error))
+    ) return
+    this.persistenceStatus = status
+    this.bindings.onPersistenceStatusChange?.(status)
+  }
+
+  private assertEpoch(epoch: number): void {
+    if (epoch !== this.epoch) throw new StaleComposerSyncEpochError()
+  }
+
   private rebuildContributions(editorState: EditorState): void {
     this.contributions.clear()
     this.totals = { ...EMPTY_CONTRIBUTION }
     editorState.read(() => {
       for (const node of $getRoot().getAllTextNodes()) {
+        this.replaceContribution(node.getKey(), contributionForNode(node, this.bindings))
+      }
+      for (const node of $nodesOfType(ComposerAtomNode)) {
         this.replaceContribution(node.getKey(), contributionForNode(node, this.bindings))
       }
     })
@@ -243,7 +356,7 @@ export class ComposerDraftSync<Result = unknown> {
         const node = $getNodeByKey(key)
         this.replaceContribution(
           key,
-          node && $isTextNode(node)
+          node && ($isTextNode(node) || $isComposerAtomNode(node))
             ? contributionForNode(node, this.bindings)
             : null
         )
@@ -302,7 +415,7 @@ export class ComposerDraftSync<Result = unknown> {
 }
 
 function contributionForNode(
-  node: TextNode,
+  node: LexicalNode,
   bindings: AtomAvailabilityBinding
 ): NodeContribution {
   if ($isComposerAtomNode(node)) {
@@ -313,6 +426,7 @@ function contributionForNode(
       unavailableAtom: bindings.atomIsAvailable(node) ? 0 : 1
     }
   }
+  if (!$isTextNode(node)) return EMPTY_CONTRIBUTION
   return {
     content: node.getTextContent().trim().length > 0 ? 1 : 0,
     explicitRecipient: 0,

--- a/apps/desktop/src/renderer/src/composer-editor-state.test.ts
+++ b/apps/desktop/src/renderer/src/composer-editor-state.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from 'vitest'
+import type { ComposerDocument } from '@contracts'
 import {
   $createParagraphNode,
+  $createNodeSelection,
   $createTextNode,
   $getRoot,
+  $isDecoratorNode,
   $isElementNode,
   $isLineBreakNode,
   $isParagraphNode,
+  $setSelection,
   createEditor,
   type LexicalEditor
 } from 'lexical'
@@ -13,6 +17,7 @@ import { ComposerAtomNode, $isComposerAtomNode } from './ComposerAtomNode'
 import {
   $insertComposerAtomWithTrailingSpace,
   $replaceEditorWithComposerDocument,
+  $selectedComposerDocument,
   composerDocumentToEditorState,
   editorStateToComposerDocument
 } from './composer-editor-state'
@@ -35,7 +40,7 @@ describe('Composer Lexical state boundary', () => {
         { kind: 'atom', atom: { type: 'member', agentId: 'agent-a' } },
         { kind: 'text', text: ' 处理\n下一项' }
       ]
-    }, () => '洛可')
+    })
 
     state.read(() => {
       const children = $getRoot().getChildren()
@@ -89,7 +94,7 @@ describe('Composer Lexical state boundary', () => {
     })
   })
 
-  it('serializes one Atom node with token and unmergeable behavior', () => {
+  it('serializes one identity-only inline Decorator Atom', () => {
     const editor = createComposerEditor()
     composerDocumentToEditorState(editor, {
       version: 2,
@@ -103,10 +108,11 @@ describe('Composer Lexical state boundary', () => {
       const atom = $getRoot().getFirstDescendant()
       expect($isComposerAtomNode(atom)).toBe(true)
       if (!$isComposerAtomNode(atom)) return
-      expect(atom.getMode()).toBe('token')
-      expect(atom.isUnmergeable()).toBe(true)
-      expect(atom.canInsertTextBefore()).toBe(false)
-      expect(atom.canInsertTextAfter()).toBe(false)
+      expect($isDecoratorNode(atom)).toBe(true)
+      expect(atom.isInline()).toBe(true)
+      expect(atom.isKeyboardSelectable()).toBe(true)
+      expect(atom.isIsolated()).toBe(false)
+      expect(atom.getTextContent()).toBe('')
     })
     const atomJson = (editor.getEditorState().toJSON().root.children[0] as unknown as {
       children: Array<Record<string, unknown>>
@@ -114,9 +120,10 @@ describe('Composer Lexical state boundary', () => {
     expect(atomJson).toMatchObject({
       type: 'composer-atom',
       referenceId: 'agent-a',
-      fallbackLabel: '洛可',
-      mode: 'token'
+      fallbackLabel: '洛可'
     })
+    expect(atomJson).not.toHaveProperty('text')
+    expect(atomJson).not.toHaveProperty('mode')
     expect(atomJson).not.toHaveProperty('presentationState')
   })
 
@@ -146,6 +153,36 @@ describe('Composer Lexical state boundary', () => {
         },
         { kind: 'text', text: ' 继续' }
       ]
+    })
+  })
+
+  it('projects a keyboard-selected Decorator Atom for structured clipboard copy', () => {
+    const editor = createComposerEditor()
+    let selected: ComposerDocument = { version: 2, segments: [] }
+    editor.update(() => {
+      $replaceEditorWithComposerDocument({
+        version: 2,
+        segments: [{
+          kind: 'atom',
+          atom: { type: 'skill', skillId: 'skill-review', nameAtSend: 'review-pr' }
+        }]
+      })
+      const paragraph = $getRoot().getFirstChildOrThrow()
+      if (!$isElementNode(paragraph)) throw new Error('expected paragraph')
+      const atom = paragraph.getFirstChild()
+      if (!$isComposerAtomNode(atom)) throw new Error('expected atom')
+      const selection = $createNodeSelection()
+      selection.add(atom.getKey())
+      $setSelection(selection)
+      selected = $selectedComposerDocument()
+    }, { discrete: true })
+
+    expect(selected).toEqual({
+      version: 2,
+      segments: [{
+        kind: 'atom',
+        atom: { type: 'skill', skillId: 'skill-review', nameAtSend: 'review-pr' }
+      }]
     })
   })
 })

--- a/apps/desktop/src/renderer/src/composer-editor-state.ts
+++ b/apps/desktop/src/renderer/src/composer-editor-state.ts
@@ -7,6 +7,7 @@ import {
   $getSelection,
   $isElementNode,
   $isLineBreakNode,
+  $isNodeSelection,
   $isRangeSelection,
   $isTextNode,
   type EditorState,
@@ -22,28 +23,24 @@ import {
   normalizeComposerDocument
 } from './composer-document'
 
-export type ComposerAtomFallback = (atom: ComposerAtom) => string | undefined
-
 export function $replaceEditorWithComposerDocument(
-  document: ComposerDocument,
-  fallbackForAtom?: ComposerAtomFallback
+  document: ComposerDocument
 ): void {
   const root = $getRoot()
   root.clear()
   const paragraph = $createParagraphNode()
   root.append(paragraph)
-  for (const node of $composerNodesFromDocument(document, fallbackForAtom)) paragraph.append(node)
+  for (const node of $composerNodesFromDocument(document)) paragraph.append(node)
 }
 
 export function composerDocumentToEditorState(
   editor: LexicalEditor,
-  document: ComposerDocument,
-  fallbackForAtom?: ComposerAtomFallback
+  document: ComposerDocument
 ): EditorState {
   const previous = editor.getEditorState()
   let next = previous
   editor.update(() => {
-    $replaceEditorWithComposerDocument(document, fallbackForAtom)
+    $replaceEditorWithComposerDocument(document)
   }, {
     discrete: true,
     onUpdate: () => { next = editor.getEditorState() }
@@ -71,6 +68,13 @@ export function $rootToComposerDocument(): ComposerDocument {
 
 export function $selectedComposerDocument(): ComposerDocument {
   const selection = $getSelection()
+  if ($isNodeSelection(selection)) {
+    const segments: ComposerSegment[] = []
+    for (const node of selection.getNodes()) {
+      if (!$isElementNode(node)) appendNodeSegment(segments, node)
+    }
+    return normalizeComposerDocument({ version: COMPOSER_DOCUMENT_VERSION, segments })
+  }
   if (!$isRangeSelection(selection) || selection.isCollapsed()) return emptyComposerDocument()
   const selectedNodes = selection.getNodes()
   const orderedPoints = selection.isBackward()
@@ -110,21 +114,19 @@ export function $selectedComposerDocument(): ComposerDocument {
 }
 
 export function $insertComposerDocument(
-  document: ComposerDocument,
-  fallbackForAtom?: ComposerAtomFallback
+  document: ComposerDocument
 ): void {
   const selection = $getSelection()
   if (!$isRangeSelection(selection)) return
-  selection.insertNodes($composerNodesFromDocument(document, fallbackForAtom))
+  selection.insertNodes($composerNodesFromDocument(document))
 }
 
 export function $insertComposerAtomWithTrailingSpace(
   queryNode: TextNode,
-  atom: ComposerAtom,
-  fallbackLabel?: string
+  atom: ComposerAtom
 ): void {
   const nextSibling = queryNode.getNextSibling()
-  const atomNode = $createComposerAtomNode(atom, fallbackLabel)
+  const atomNode = $createComposerAtomNode(atom)
   queryNode.replace(atomNode)
 
   if ($isTextNode(nextSibling) && !$isComposerAtomNode(nextSibling)) {
@@ -144,13 +146,12 @@ export function $insertComposerAtomWithTrailingSpace(
 }
 
 function $composerNodesFromDocument(
-  document: ComposerDocument,
-  fallbackForAtom?: ComposerAtomFallback
+  document: ComposerDocument
 ): LexicalNode[] {
   const nodes: LexicalNode[] = []
   for (const segment of normalizeComposerDocument(document).segments) {
     if (segment.kind === 'atom') {
-      nodes.push($createComposerAtomNode(segment.atom, fallbackForAtom?.(segment.atom)))
+      nodes.push($createComposerAtomNode(segment.atom))
       continue
     }
     const text = segment.text.replace(/\r\n?/gu, '\n')

--- a/apps/desktop/src/renderer/src/composer-trigger.test.ts
+++ b/apps/desktop/src/renderer/src/composer-trigger.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  $getRoot,
+  $isElementNode,
+  $isTextNode,
+  createEditor,
+  type LexicalEditor
+} from 'lexical'
+import { ComposerAtomNode } from './ComposerAtomNode'
+import { $replaceEditorWithComposerDocument, editorStateToComposerDocument } from './composer-editor-state'
+import {
+  $findComposerTriggerMatch,
+  $replaceComposerTriggerWithAtom,
+  readComposerTriggerWindow
+} from './composer-trigger'
+import { MAX_TYPEAHEAD_QUERY_LENGTH } from './composer-document'
+
+function createComposerEditor(text: string): LexicalEditor {
+  const editor = createEditor({
+    namespace: `ComposerTriggerTest-${crypto.randomUUID()}`,
+    nodes: [ComposerAtomNode],
+    onError(error) { throw error }
+  })
+  editor.update(() => {
+    $replaceEditorWithComposerDocument({
+      version: 2,
+      segments: [{ kind: 'text', text }]
+    })
+  }, { discrete: true })
+  return editor
+}
+
+function selectEnd(editor: LexicalEditor): void {
+  editor.update(() => {
+    const paragraph = $getRoot().getFirstChildOrThrow()
+    if (!$isElementNode(paragraph)) throw new Error('expected paragraph')
+    const text = paragraph.getLastChildOrThrow()
+    if (!$isTextNode(text)) throw new Error('expected text')
+    text.selectEnd()
+  }, { discrete: true })
+}
+
+function match(editor: LexicalEditor) {
+  return editor.getEditorState().read(() => $findComposerTriggerMatch(editor))
+}
+
+describe('Composer bounded trigger scan', () => {
+  it('requests at most the final 128 characters from its text source', () => {
+    const read = vi.fn((start: number, end: number) => 'x'.repeat(end - start))
+
+    const window = readComposerTriggerWindow(10_000, 9_000, read)
+
+    expect(read).toHaveBeenCalledWith(9_000 - MAX_TYPEAHEAD_QUERY_LENGTH, 9_000)
+    expect(window.text).toHaveLength(MAX_TYPEAHEAD_QUERY_LENGTH)
+    expect(window.startOffset).toBe(8_872)
+  })
+
+  it('matches member and Skill queries only at their allowed local boundaries', () => {
+    const member = createComposerEditor('请让 @Ali')
+    selectEnd(member)
+    expect(match(member)).toMatchObject({
+      kind: 'member', query: 'Ali', fromOffset: 3, toOffset: 7
+    })
+
+    const skill = createComposerEditor('请处理：/review')
+    selectEnd(skill)
+    expect(match(skill)).toMatchObject({
+      kind: 'skill', query: 'review', fromOffset: 4, toOffset: 11
+    })
+
+    for (const value of ['https://example.com/a/b', 'src/components/a/b.ts', 'word/review']) {
+      const editor = createComposerEditor(value)
+      selectEnd(editor)
+      expect(match(editor)).toBeNull()
+    }
+  })
+
+  it('does not cross an Atom but permits a query immediately after a LineBreak', () => {
+    const afterAtom = createEditor({
+      namespace: `ComposerTriggerAtom-${crypto.randomUUID()}`,
+      nodes: [ComposerAtomNode],
+      onError(error) { throw error }
+    })
+    afterAtom.update(() => {
+      $replaceEditorWithComposerDocument({
+        version: 2,
+        segments: [
+          { kind: 'atom', atom: { type: 'member', agentId: 'agent-a' } },
+          { kind: 'text', text: '/rev' }
+        ]
+      })
+      const paragraph = $getRoot().getFirstChildOrThrow()
+      if (!$isElementNode(paragraph)) throw new Error('expected paragraph')
+      const text = paragraph.getLastChildOrThrow()
+      if (!$isTextNode(text)) throw new Error('expected text')
+      text.selectEnd()
+    }, { discrete: true })
+    expect(match(afterAtom)).toBeNull()
+
+    const afterBreak = createEditor({
+      namespace: `ComposerTriggerBreak-${crypto.randomUUID()}`,
+      nodes: [ComposerAtomNode],
+      onError(error) { throw error }
+    })
+    afterBreak.update(() => {
+      $replaceEditorWithComposerDocument({
+        version: 2,
+        segments: [{ kind: 'text', text: '前文\n/rev' }]
+      })
+      const paragraph = $getRoot().getFirstChildOrThrow()
+      if (!$isElementNode(paragraph)) throw new Error('expected paragraph')
+      const text = paragraph.getLastChildOrThrow()
+      if (!$isTextNode(text)) throw new Error('expected text')
+      text.selectEnd()
+    }, { discrete: true })
+    expect(match(afterBreak)).toMatchObject({ kind: 'skill', query: 'rev', fromOffset: 0 })
+  })
+
+  it('replaces exactly the matched query and preserves surrounding text and spacing', () => {
+    const editor = createComposerEditor('请让 @Ali 处理')
+    editor.update(() => {
+      const paragraph = $getRoot().getFirstChildOrThrow()
+      if (!$isElementNode(paragraph)) throw new Error('expected paragraph')
+      const text = paragraph.getFirstChildOrThrow()
+      if (!$isTextNode(text)) throw new Error('expected text')
+      text.select(7, 7)
+      const trigger = $findComposerTriggerMatch(editor)
+      expect(trigger).not.toBeNull()
+      if (trigger) {
+        expect($replaceComposerTriggerWithAtom(trigger, {
+          type: 'member', agentId: 'agent-a', labelFallback: 'Alice'
+        })).toBe(true)
+      }
+    }, { discrete: true })
+
+    expect(editorStateToComposerDocument(editor.getEditorState())).toEqual({
+      version: 2,
+      segments: [
+        { kind: 'text', text: '请让 ' },
+        { kind: 'atom', atom: { type: 'member', agentId: 'agent-a', labelFallback: 'Alice' } },
+        { kind: 'text', text: ' 处理' }
+      ]
+    })
+  })
+})

--- a/apps/desktop/src/renderer/src/composer-trigger.ts
+++ b/apps/desktop/src/renderer/src/composer-trigger.ts
@@ -1,0 +1,128 @@
+import type { ComposerAtom } from '@contracts'
+import {
+  $getNodeByKey,
+  $getSelection,
+  $isLineBreakNode,
+  $isRangeSelection,
+  $isTextNode,
+  type LexicalEditor,
+  type NodeKey,
+  type TextNode
+} from 'lexical'
+import { $isComposerAtomNode } from './ComposerAtomNode'
+import { $insertComposerAtomWithTrailingSpace } from './composer-editor-state'
+import { MAX_TYPEAHEAD_QUERY_LENGTH } from './composer-document'
+
+export interface ComposerTriggerMatch {
+  kind: 'member' | 'skill'
+  query: string
+  nodeKey: NodeKey
+  fromOffset: number
+  toOffset: number
+}
+
+export interface ComposerTriggerWindow {
+  startOffset: number
+  text: string
+}
+
+const TRIGGER_BOUNDARY = '[\\s，。！？；：、（(\\[【{「『]'
+const MEMBER_TRIGGER = new RegExp(`(^|${TRIGGER_BOUNDARY})@([\\p{L}\\p{N}_-]*)$`, 'u')
+const SKILL_TRIGGER = new RegExp(`(^|${TRIGGER_BOUNDARY})/([A-Za-z0-9-]*)$`, 'u')
+
+/**
+ * Requests only a bounded suffix from the source. TextNode currently exposes
+ * a string reference rather than a range reader, so the production callback
+ * performs the sole substring allocation for this window.
+ */
+export function readComposerTriggerWindow(
+  textLength: number,
+  caretOffset: number,
+  read: (startOffset: number, endOffset: number) => string
+): ComposerTriggerWindow {
+  const safeCaret = Math.max(0, Math.min(caretOffset, textLength))
+  const startOffset = Math.max(0, safeCaret - MAX_TYPEAHEAD_QUERY_LENGTH)
+  return {
+    startOffset,
+    text: read(startOffset, safeCaret)
+  }
+}
+
+export function $findComposerTriggerMatch(
+  editor: Pick<LexicalEditor, 'isComposing'>
+): ComposerTriggerMatch | null {
+  if (editor.isComposing()) return null
+  const selection = $getSelection()
+  if (!$isRangeSelection(selection) || !selection.isCollapsed()) return null
+  if (selection.anchor.type !== 'text') return null
+  const node = selection.anchor.getNode()
+  if (!$isTextNode(node) || $isComposerAtomNode(node)) return null
+
+  const caretOffset = selection.anchor.offset
+  const window = readComposerTriggerWindow(
+    node.getTextContentSize(),
+    caretOffset,
+    (start, end) => node.getTextContent().slice(start, end)
+  )
+  const previous = window.startOffset === 0 ? node.getPreviousSibling() : null
+  const nodeStartIsBoundary = window.startOffset === 0
+    && (previous === null || $isLineBreakNode(previous))
+  return matchComposerTriggerWindow(window, node.getKey(), caretOffset, nodeStartIsBoundary)
+}
+
+export function $replaceComposerTriggerWithAtom(
+  match: ComposerTriggerMatch,
+  atom: ComposerAtom
+): boolean {
+  const node = $getNodeByKey(match.nodeKey)
+  if (!$isTextNode(node) || $isComposerAtomNode(node)) return false
+  const expected = `${match.kind === 'member' ? '@' : '/'}${match.query}`
+  if (
+    match.fromOffset < 0
+    || match.toOffset > node.getTextContentSize()
+    || match.fromOffset >= match.toOffset
+    || node.getTextContent().slice(match.fromOffset, match.toOffset) !== expected
+  ) return false
+
+  const queryNode = isolateTextRange(node, match.fromOffset, match.toOffset)
+  $insertComposerAtomWithTrailingSpace(queryNode, atom)
+  return true
+}
+
+function matchComposerTriggerWindow(
+  window: ComposerTriggerWindow,
+  nodeKey: NodeKey,
+  caretOffset: number,
+  nodeStartIsBoundary: boolean
+): ComposerTriggerMatch | null {
+  const candidates = [
+    matchKind('member', MEMBER_TRIGGER, window, nodeKey, caretOffset, nodeStartIsBoundary),
+    matchKind('skill', SKILL_TRIGGER, window, nodeKey, caretOffset, nodeStartIsBoundary)
+  ].filter((value): value is ComposerTriggerMatch => value !== null)
+  return candidates.sort((left, right) => right.fromOffset - left.fromOffset)[0] ?? null
+}
+
+function matchKind(
+  kind: ComposerTriggerMatch['kind'],
+  pattern: RegExp,
+  window: ComposerTriggerWindow,
+  nodeKey: NodeKey,
+  caretOffset: number,
+  nodeStartIsBoundary: boolean
+): ComposerTriggerMatch | null {
+  const match = pattern.exec(window.text)
+  if (!match) return null
+  const boundary = match[1] ?? ''
+  if (!boundary && match.index === 0 && !nodeStartIsBoundary) return null
+  const query = match[2] ?? ''
+  const fromOffset = window.startOffset + match.index + boundary.length
+  return { kind, query, nodeKey, fromOffset, toOffset: caretOffset }
+}
+
+function isolateTextRange(node: TextNode, fromOffset: number, toOffset: number): TextNode {
+  const size = node.getTextContentSize()
+  if (fromOffset === 0 && toOffset === size) return node
+  if (fromOffset === 0) return node.splitText(toOffset)[0]
+  if (toOffset === size) return node.splitText(fromOffset)[1]
+  return node.splitText(fromOffset, toOffset)[1]
+}

--- a/apps/desktop/src/renderer/src/draft-mutation-coordinator.test.ts
+++ b/apps/desktop/src/renderer/src/draft-mutation-coordinator.test.ts
@@ -1,0 +1,148 @@
+import type { CampComposerDraftView, ComposerDocument } from '@contracts'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  DraftMutationCoordinator,
+  StaleDraftEpochError,
+  type DraftMutation
+} from './draft-mutation-coordinator'
+
+function document(text: string): ComposerDocument {
+  return {
+    version: 2,
+    segments: text ? [{ kind: 'text', text }] : []
+  }
+}
+
+function draft(campId: string, revision: number, text = ''): CampComposerDraftView {
+  return {
+    campId,
+    body: text,
+    content: document(text),
+    revision,
+    attachments: [],
+    replyIntent: null,
+    continuationIntent: null,
+    updatedAt: null,
+    expiresAt: null
+  }
+}
+
+describe('DraftMutationCoordinator', () => {
+  it('serializes every mutation against the latest authoritative revision', async () => {
+    const calls: Array<{ kind: DraftMutation['kind']; revision: number }> = []
+    let releaseAttachment!: () => void
+    const attachmentPending = new Promise<void>((resolve) => { releaseAttachment = resolve })
+    const coordinator = new DraftMutationCoordinator({
+      load: async () => draft('camp-a', 1),
+      mutate: async (current, mutation) => {
+        calls.push({ kind: mutation.kind, revision: current.revision })
+        if (mutation.kind === 'add_source_attachment') await attachmentPending
+        return {
+          ...current,
+          content: mutation.kind === 'save_content' ? mutation.content : current.content,
+          revision: current.revision + 1
+        }
+      }
+    })
+    coordinator.beginEpoch('camp-a', draft('camp-a', 10, 'old'))
+
+    const attachment = coordinator.addSourceAttachment({ name: 'design.png' } as File)
+    const save = coordinator.saveContent(document('new'))
+    await Promise.resolve()
+
+    expect(calls).toEqual([{ kind: 'add_source_attachment', revision: 10 }])
+    releaseAttachment()
+    await Promise.all([attachment, save])
+
+    expect(calls).toEqual([
+      { kind: 'add_source_attachment', revision: 10 },
+      { kind: 'save_content', revision: 11 }
+    ])
+    expect(coordinator.getCurrentDraft()).toMatchObject({ revision: 12, content: document('new') })
+  })
+
+  it('waits for earlier mutations before deciding that a content snapshot is unchanged', async () => {
+    const mutate = vi.fn(async (current: CampComposerDraftView, mutation: DraftMutation) => ({
+      ...current,
+      revision: current.revision + 1,
+      content: mutation.kind === 'save_content' ? mutation.content : current.content
+    }))
+    const coordinator = new DraftMutationCoordinator({ load: async () => draft('camp-a', 1), mutate })
+    coordinator.beginEpoch('camp-a', draft('camp-a', 4, 'same'))
+
+    const reply = coordinator.startReply('message-1')
+    const unchanged = coordinator.saveContent(document('same'))
+    await Promise.all([reply, unchanged])
+
+    expect(mutate).toHaveBeenCalledTimes(1)
+    expect(mutate.mock.calls[0]?.[0].revision).toBe(4)
+    expect(await coordinator.waitForIdle()).toMatchObject({ revision: 5 })
+  })
+
+  it('serializes an authoritative reload with mutations that arrive while it is pending', async () => {
+    let releaseLoad!: () => void
+    const loadPending = new Promise<void>((resolve) => { releaseLoad = resolve })
+    const calls: Array<{ kind: 'load' | DraftMutation['kind']; revision?: number }> = []
+    const coordinator = new DraftMutationCoordinator({
+      load: async () => {
+        calls.push({ kind: 'load' })
+        await loadPending
+        return draft('camp-a', 11, 'remote')
+      },
+      mutate: async (current, mutation) => {
+        calls.push({ kind: mutation.kind, revision: current.revision })
+        return { ...current, revision: current.revision + 1 }
+      }
+    })
+    coordinator.beginEpoch('camp-a', draft('camp-a', 10, 'local'))
+
+    const reload = coordinator.load()
+    const reply = coordinator.startReply('message-1')
+    await Promise.resolve()
+
+    expect(calls).toEqual([{ kind: 'load' }])
+    releaseLoad()
+    await Promise.all([reload, reply])
+
+    expect(calls).toEqual([
+      { kind: 'load' },
+      { kind: 'start_reply', revision: 11 }
+    ])
+    expect(coordinator.getCurrentDraft()).toMatchObject({ revision: 12 })
+  })
+
+  it('fences late results from an earlier Draft epoch', async () => {
+    let releaseOld!: () => void
+    const oldPending = new Promise<void>((resolve) => { releaseOld = resolve })
+    const coordinator = new DraftMutationCoordinator({
+      load: async (campId) => draft(campId, 1),
+      mutate: async (current) => {
+        if (current.campId === 'camp-a') await oldPending
+        return { ...current, revision: current.revision + 1 }
+      }
+    })
+    coordinator.beginEpoch('camp-a', draft('camp-a', 7))
+    const oldOperation = coordinator.cancelReply()
+    await Promise.resolve()
+
+    coordinator.beginEpoch('camp-b', draft('camp-b', 20))
+    releaseOld()
+
+    await expect(oldOperation).rejects.toBeInstanceOf(StaleDraftEpochError)
+    expect(coordinator.getCurrentDraft()).toMatchObject({ campId: 'camp-b', revision: 20 })
+  })
+
+  it('refreshes authority after a failed mutation without hiding the original failure', async () => {
+    const failure = new Error('revision conflict')
+    const load = vi.fn(async () => draft('camp-a', 9, 'remote'))
+    const coordinator = new DraftMutationCoordinator({
+      load,
+      mutate: async () => { throw failure }
+    })
+    coordinator.beginEpoch('camp-a', draft('camp-a', 8, 'local'))
+
+    await expect(coordinator.removeSourceAttachment('attachment-1')).rejects.toBe(failure)
+    expect(load).toHaveBeenCalledWith('camp-a')
+    expect(coordinator.getCurrentDraft()).toMatchObject({ revision: 9, body: 'remote' })
+  })
+})

--- a/apps/desktop/src/renderer/src/draft-mutation-coordinator.ts
+++ b/apps/desktop/src/renderer/src/draft-mutation-coordinator.ts
@@ -1,0 +1,217 @@
+import type {
+  CampComposerDraftView,
+  CampComposerReplyRecipient,
+  ComposerDocument
+} from '@contracts'
+import { composerDocumentsEqual } from './composer-document'
+
+export type DraftMutation =
+  | { kind: 'save_content'; content: ComposerDocument }
+  | { kind: 'add_source_attachment'; file: File }
+  | { kind: 'remove_source_attachment'; attachmentId: string }
+  | { kind: 'start_reply'; replyToCampMessageId: string }
+  | { kind: 'cancel_reply' }
+  | { kind: 'resolve_reply_recipient'; recipient: CampComposerReplyRecipient }
+  | { kind: 'dismiss_continuation'; sourceCampMessageId: string }
+  | { kind: 'resolve_continuation_recipient'; agentId: string }
+
+export interface DraftMutationCoordinatorBindings {
+  load(campId: string): Promise<CampComposerDraftView>
+  mutate(
+    currentDraft: CampComposerDraftView,
+    mutation: DraftMutation
+  ): Promise<CampComposerDraftView>
+  onChange?(draft: CampComposerDraftView | null, epoch: number): void
+}
+
+export class StaleDraftEpochError extends Error {
+  constructor() {
+    super('Composer Draft operation belongs to a stale editing epoch.')
+    this.name = 'StaleDraftEpochError'
+  }
+}
+
+/**
+ * The only Renderer owner of the complete authoritative Camp Draft view.
+ * Callers may observe the current value, but every mutation and revision
+ * transition is serialized here.
+ */
+export class DraftMutationCoordinator {
+  private readonly bindings: DraftMutationCoordinatorBindings
+  private campId: string | null = null
+  private currentDraft: CampComposerDraftView | null = null
+  private epoch = 0
+  private queue: Promise<void> = Promise.resolve()
+
+  constructor(bindings: DraftMutationCoordinatorBindings) {
+    this.bindings = bindings
+  }
+
+  beginEpoch(campId: string, draft: CampComposerDraftView | null = null): number {
+    if (draft && draft.campId !== campId) {
+      throw new Error('Composer Draft does not belong to the active Camp.')
+    }
+    this.epoch += 1
+    this.campId = campId
+    this.currentDraft = draft
+    this.queue = Promise.resolve()
+    this.bindings.onChange?.(draft, this.epoch)
+    return this.epoch
+  }
+
+  getEpoch(): number {
+    return this.epoch
+  }
+
+  getCurrentDraft(): CampComposerDraftView | null {
+    return this.currentDraft
+  }
+
+  load(): Promise<CampComposerDraftView> {
+    const epoch = this.epoch
+    const campId = this.requireCampId()
+    const result = this.queue.then(async () => {
+      this.assertActive(epoch, campId)
+      const loaded = await this.bindings.load(campId)
+      this.assertActive(epoch, campId)
+      return this.acceptDraft(loaded, epoch, campId)
+    })
+    this.queue = result.then(() => undefined, () => undefined)
+    return result
+  }
+
+  acceptAuthoritativeDraft(draft: CampComposerDraftView, advanceEpoch = false): number {
+    if (advanceEpoch || this.campId !== draft.campId) {
+      return this.beginEpoch(draft.campId, draft)
+    }
+    this.currentDraft = draft
+    this.bindings.onChange?.(draft, this.epoch)
+    return this.epoch
+  }
+
+  saveContent(content: ComposerDocument): Promise<CampComposerDraftView> {
+    return this.enqueue(async (current) => {
+      if (composerDocumentsEqual(current.content, content)) return current
+      return this.bindings.mutate(current, { kind: 'save_content', content })
+    })
+  }
+
+  addSourceAttachment(file: File): Promise<CampComposerDraftView> {
+    return this.enqueue((current) => this.bindings.mutate(
+      current,
+      { kind: 'add_source_attachment', file }
+    ))
+  }
+
+  removeSourceAttachment(attachmentId: string): Promise<CampComposerDraftView> {
+    return this.enqueue((current) => this.bindings.mutate(
+      current,
+      { kind: 'remove_source_attachment', attachmentId }
+    ))
+  }
+
+  startReply(replyToCampMessageId: string): Promise<CampComposerDraftView> {
+    return this.enqueue((current) => this.bindings.mutate(
+      current,
+      { kind: 'start_reply', replyToCampMessageId }
+    ))
+  }
+
+  cancelReply(): Promise<CampComposerDraftView> {
+    return this.enqueue((current) => this.bindings.mutate(current, { kind: 'cancel_reply' }))
+  }
+
+  resolveReplyRecipient(recipient: CampComposerReplyRecipient): Promise<CampComposerDraftView> {
+    return this.enqueue((current) => this.bindings.mutate(
+      current,
+      { kind: 'resolve_reply_recipient', recipient }
+    ))
+  }
+
+  dismissContinuation(sourceCampMessageId: string): Promise<CampComposerDraftView> {
+    return this.enqueue((current) => this.bindings.mutate(
+      current,
+      { kind: 'dismiss_continuation', sourceCampMessageId }
+    ))
+  }
+
+  resolveContinuationRecipient(agentId: string): Promise<CampComposerDraftView> {
+    return this.enqueue((current) => this.bindings.mutate(
+      current,
+      { kind: 'resolve_continuation_recipient', agentId }
+    ))
+  }
+
+  async waitForIdle(): Promise<CampComposerDraftView> {
+    const epoch = this.epoch
+    const campId = this.requireCampId()
+    await this.queue
+    this.assertActive(epoch, campId)
+    return this.requireCurrentDraft()
+  }
+
+  private enqueue(
+    operation: (current: CampComposerDraftView) => Promise<CampComposerDraftView>
+  ): Promise<CampComposerDraftView> {
+    const epoch = this.epoch
+    const campId = this.requireCampId()
+    const result = this.queue.then(async () => {
+      this.assertActive(epoch, campId)
+      const current = this.currentDraft ?? await this.loadForOperation(epoch, campId)
+      const next = await operation(current)
+      this.assertActive(epoch, campId)
+      return this.acceptDraft(next, epoch, campId)
+    }).catch(async (error: unknown) => {
+      if (error instanceof StaleDraftEpochError) throw error
+      if (this.isActive(epoch, campId)) {
+        try {
+          const refreshed = await this.bindings.load(campId)
+          if (this.isActive(epoch, campId)) this.acceptDraft(refreshed, epoch, campId)
+        } catch {
+          // Preserve the mutation error; an explicit later operation can reload.
+        }
+      }
+      throw error
+    })
+    this.queue = result.then(() => undefined, () => undefined)
+    return result
+  }
+
+  private async loadForOperation(epoch: number, campId: string): Promise<CampComposerDraftView> {
+    const loaded = await this.bindings.load(campId)
+    this.assertActive(epoch, campId)
+    return this.acceptDraft(loaded, epoch, campId)
+  }
+
+  private acceptDraft(
+    draft: CampComposerDraftView,
+    epoch: number,
+    campId: string
+  ): CampComposerDraftView {
+    this.assertActive(epoch, campId)
+    if (draft.campId !== campId) {
+      throw new Error('Core returned a Composer Draft for a different Camp.')
+    }
+    this.currentDraft = draft
+    this.bindings.onChange?.(draft, epoch)
+    return draft
+  }
+
+  private requireCampId(): string {
+    if (!this.campId) throw new Error('Composer Draft context is not initialized.')
+    return this.campId
+  }
+
+  private requireCurrentDraft(): CampComposerDraftView {
+    if (!this.currentDraft) throw new Error('Composer Draft is not loaded.')
+    return this.currentDraft
+  }
+
+  private isActive(epoch: number, campId: string): boolean {
+    return this.epoch === epoch && this.campId === campId
+  }
+
+  private assertActive(epoch: number, campId: string): void {
+    if (!this.isActive(epoch, campId)) throw new StaleDraftEpochError()
+  }
+}

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -33,7 +33,7 @@ last_updated: 2026-09-04
 | [Planned Shutdown](planned-shutdown.md) | Core execution/terminal 双准入、durable shutdown cycle、退出时 AgentRun 全量取消、product fence 启动补偿、分层 deadline、route reap 与 Desktop child-exit 边界 |
 | [Public A2A Message 与 Message Delivery](public-a2a-message-delivery.md) | 公共 Structured Message、统一历史 publication seam、canonical/line-leading display-name addressing、正交 Current User Attention、forward/caller-return Delivery、原子通知、Context gate 与 UI projection 边界 |
 | [Camp Activation Lifecycle](camp-activation-lifecycle.md) | 一键 Pending、Composer Draft、Navigation、Restorable Location、首消息原子激活与启动清理的组件权威 |
-| [Camp Composer Draft](camp-composer-draft.md) | Lexical 本地 EditorState、Text + Atom V2、低频 single-flight Draft Snapshot、source refs、Pending、持久 reply/continuation 与 exact-revision user send 的组件权威 |
+| [Camp Composer Draft](camp-composer-draft.md) | Lexical 本地 EditorState、唯一 Renderer Draft Mutation Coordinator、Text + inline Decorator Atom、源头有界 Typeahead、低频 Snapshot、source refs、Pending 与 exact-revision send 的组件权威 |
 | [Camp Open Read Path](camp-open-read-path.md) | Desktop 两阶段冷启动壳层、enter/reconcile、不读 event_log 的业务 open projection、渐进消息、当前会话精确查找/anchored 定位、Run detail、high-water/cache 与 meaningful-paint 后台维护边界 |
 | [Camp Attachments：Source Refs、Agent Managed Artifacts 与 Legacy View](camp-published-attachment-view.md) | Desktop 用户 source refs、Pending 原生携带、Run-local resolver、Agent Managed v2 及 legacy Authority/View 兼容边界 |
 | [First-run Onboarding](first-run-onboarding.md) | Full Core authority-origin 首次安装 admission、schema 2 三页状态、无 Runtime 延后完成、幂等 provisioning 与 Draft-only 第四页边界 |

--- a/docs/architecture/camp-composer-draft.md
+++ b/docs/architecture/camp-composer-draft.md
@@ -21,7 +21,8 @@ Pending Camp Input 拥有。字段和行为见 [Camp Composer Draft v8](../contr
 | React Composer Shell | 稳定挂载编辑器；拥有 Member/Skill Catalog、placeholder、disabled、Picker UI、发送编排和 dirty/saving 等小型状态；不逐字符保存完整正文 |
 | Lexical Editor | 输入期间唯一拥有节点树、selection、composition、局部 DOM reconciliation、undo/redo、当前 local version 与最新 EditorState snapshot |
 | Composer adapters | 在 Lexical tree 与 `ComposerDocument` V2 间双向转换；生成纯文本；校验/恢复私有 Clipboard；不把 Lexical JSON 变成领域协议 |
-| Draft Sync | 识别真实内容更新，维护 local/saving/saved version，以 debounce/max-wait single-flight 保存，并在业务边界 flush exact snapshot |
+| Draft Sync | 只拥有 EditorState ref、epoch、local/saved version、dirty 与 persistence status；以 debounce/max-wait single-flight 请求内容保存，并在业务边界 flush 捕获 snapshot；不保存完整 Draft View 或 Core revision |
+| Draft Mutation Coordinator | Renderer 唯一完整 `CampComposerDraftView` owner；将正文、附件、Reply、Continuation 与接收者 mutation 串入同一队列，并用每次 Core 返回的完整 View 原子替换 authority |
 | Camp Draft module | 持久化 V2 document、source refs、legacy Prepared 互斥状态、Reply/Continuation、recipient touched、revision 与 expiry；从 document 派生 body |
 | Pending module | 原子保存已提交的完整 V2 下一轮意图、FIFO、edit token/revision、working source refs 与 needs-repair 状态 |
 | Collaboration send | 从 exact Draft/Pending 读取 V2，物化 continuation，最终校验 Reply/Atom/source availability，转换成公共 Structured Content，并只在 accepted transaction 消费 owner |
@@ -41,9 +42,9 @@ RootNode
 ```
 
 普通 TextNode 不直接挂 Root；换行使用 LineBreakNode。粘贴或外部状态产生多个 Paragraph 时，节点 transform
-把段落边界归一成 LineBreakNode 并合并到前一个 Paragraph。`ComposerAtomNode` 是单一自定义 TextNode，使用
-token mode 与 unmergeable，Member、All Members、Skill 只由 payload 区分；它拒绝前后直接插字，并以一个
-简单 span DOM 呈现。
+把段落边界归一成 LineBreakNode 并合并到前一个 Paragraph。`ComposerAtomNode` 是单一 identity-only inline
+`DecoratorNode<null>`；Member、All Members、Skill 只由 payload 区分。Atom 没有字符 offset，允许键盘 NodeSelection，
+并以一个 `contentEditable=false` span DOM 呈现；`decorate()` 返回 null，不挂载独立 React 子树。
 
 领域层只有：
 
@@ -69,7 +70,8 @@ Skill Atom.skillId  ──> current Skill Catalog       ──> current presenta
                        nameAtSend remains the semantic snapshot
 ```
 
-Catalog 变化使用 `rovai:atom-presentation` 更新标签和 DOM 属性。Draft Sync 忽略该 tag；更新不增加 local
+Catalog 变化使用 `rovai:atom-presentation` 只更新标签和 DOM 属性。节点不保存当前动态 label，Lexical 文本长度与
+DOM 展示不会因改名分叉。Draft Sync 忽略该 tag；更新不增加 local
 version、不触发保存、不进入 undo。不可解析对象保留原 identity 并显示 unavailable，不按显示名重绑、不转普通
 文本、不在输入阶段删除。Member `labelFallback` 与 Skill `nameAtSend` 只承担合同规定的降级/快照职责。
 
@@ -85,12 +87,12 @@ beforeinput / composition
 ```
 
 普通按键路径禁止完整 tree serialization、完整纯文本投影、全文 trigger 正则、完整 React content setState、DOM
-snapshot、Core IPC 或 Draft persistence。Typeahead 只读取当前普通 TextNode 和必要的相邻边界，从光标向左最多
-128 字符；遇到 Atom、LineBreak、空白、非法标点或 Paragraph 边界即停止。composition 期间不查询、不插 Atom、
-不发送、不替换 EditorState。
+snapshot、Core IPC 或 Draft persistence。Member 与 Skill 共用一个 Trigger Plugin 和一个 Editor update listener；
+它从当前普通 TextNode 的 caret 位置只分配最多 128 字符 suffix，并在同一 matcher 内区分 `@` 与 `/`。查询不跨
+Atom、LineBreak、非法标点或 Paragraph 边界。composition 期间不更新候选、不插 Atom、不发送、不替换 EditorState。
 
 Editor Extension 图是模块级稳定引用，由 `LexicalExtensionComposer` 挂载 Plain Text、History、Atom、command、
-clipboard 与 Draft Sync；React Typeahead 只负责候选和 Portal。普通 Catalog、placeholder、disabled 或父组件 render
+clipboard 与 Draft Sync；统一 React Typeahead Plugin 负责有界匹配、候选键盘所有权和 Portal。普通 Catalog、placeholder、disabled 或父组件 render
 不重新创建 Editor。
 
 ## Draft synchronization
@@ -100,15 +102,19 @@ committed EditorState
   -> localVersion / latestEditorState ref
   -> debounce 350 ms (max wait 1500 ms)
   -> serialize one ComposerDocument snapshot
-  -> exact-revision Core mutation
-  -> savedVersion / coreRevision
+  -> DraftMutationCoordinator queue
+  -> current Draft exact-revision Core mutation
+  -> authoritative Draft replacement + savedVersion
 ```
 
-同一 Draft 只允许一个 save 在途。若 version 10 保存时继续输入至 version 13，不并发提交 11/12；10 完成后直接
-保存当时最新的 13。完成只确认对应 version；`localVersion > completedVersion` 时保持 dirty 并继续追赶。selection、
-focus、Picker highlight、Catalog presentation、placeholder、disabled 和 history bookkeeping 不增加版本。
+同一 Draft 的全部 mutation 共用 Coordinator queue，内容层仍只允许一个 save 在途。若 version 10 保存时继续输入至
+version 13，不并发提交 11/12；10 完成后直接保存当时最新的 13。完成只确认同 epoch 对应 version；
+`localVersion > completedVersion` 时保持 dirty 并继续追赶。selection、focus、Picker highlight、Catalog presentation、
+placeholder、disabled 和 history bookkeeping 不增加版本。
 
-以下动作先停止 timer，等待在途 save，读取最新已提交 EditorState，保存 exact V2 并取得 Core revision：发送、
+自动保存失败保持 dirty，记录 `error` persistence status，并只在当前 epoch 做有限退避重试；显式 flush/发送直接暴露
+失败。以下动作先停止 timer，等待在途 save 与 Coordinator queue，读取最新已提交 EditorState，按需保存 exact V2
+并取得 Coordinator 当前 Core revision：发送、
 Reply、Continuation、依赖 Draft revision 的 mutation、Camp/Draft 切换，以及需要持久草稿的上下文关闭。离散提交
 只用于显式更新后必须立即读取的边界，不用于普通输入。
 
@@ -118,10 +124,10 @@ Reply、Continuation、依赖 Draft revision 的 mutation、Camp/Draft 切换，
 identity 会新建 editor 并清除 history、Picker、pending save、selection 和 composition。相同 identity 下，Core
 返回当前已保存 revision、Catalog/placeholder/disabled 更新或页面其他 render 都不得替换 EditorState。
 
-本地 `dirty = false` 时可以接收明确 authoritative replacement。本地有未保存修改时，自己的 save 回执只更新
-revision；普通迟到 props 不得调用 `setEditorState` 覆盖输入。Draft restore、放弃本地修改等动作必须由上层明确
-决定后调用 replacement。发送成功仅当 current local version 等于发送开始记录的 version 才清空；否则保留发送中
-新增内容并恢复同步。
+本地 `dirty = false` 时可以接收明确 authoritative replacement。本地有未保存修改时，自己的 save 回执只由
+Coordinator 更新 Core authority；普通迟到 props 不得调用 `setEditorState` 覆盖输入。切换 Camp/Draft、restore、
+发送后下一 Draft 或明确 replacement 推进 epoch；旧 epoch 结果不能更新新编辑对象的 saved/dirty/UI 状态。发送成功
+仅当 current local version 等于发送开始记录的 version 才清空；否则保留发送中新增内容，在下一 Draft epoch 恢复同步。
 
 ## Clipboard and commands
 
@@ -131,13 +137,13 @@ Copy/Cut 同时写 `text/plain`、兼容 `text/html` 和 `application/x-rovai-co
 `@name`、`/skill` 永远不能成为 identity 来源。
 
 Enter 在非 composition、菜单未消费、内容可发送时交给发送；Shift+Enter 插入 LineBreakNode。Escape 先关闭
-Typeahead，再关闭 Atom 激活展示并保留内容。Backspace/Delete 与 History 由 Lexical 处理，token Atom 一次整体删除；
+Typeahead，再关闭 Atom 激活展示并保留内容。Backspace/Delete 与 History 由 Lexical 处理，Decorator Atom 一次整体删除；
 编辑器绝对起点继续调用 Rovai 的 `onBackspaceAtStart`。
 
 ## Send and queue flow
 
 ```text
-flush latest local version -> exact Core Draft revision
+capture local version -> flush through Coordinator -> current exact Core Draft revision
   -> derived body non-empty OR source/legacy attachment exists
      -> Camp idle and Pending empty
         -> validate current Atom/source availability
@@ -182,3 +188,6 @@ pendingInputId、pending revision 与 editToken fencing，且不会消费或覆�
 - [Camp 会话工作区](../ui/components/conversation-workspace.md)
 - [V1.43-D01](../versions/v1.43/decisions.md#v1-43-d01)
 - [V1.43-D02](../versions/v1.43/decisions.md#v1-43-d02)
+- [V1.45-D01](../versions/v1.45/decisions.md#v1-45-d01)
+- [V1.45-D02](../versions/v1.45/decisions.md#v1-45-d02)
+- [V1.45-D03](../versions/v1.45/decisions.md#v1-45-d03)

--- a/docs/decisions/CURRENT.md
+++ b/docs/decisions/CURRENT.md
@@ -118,7 +118,7 @@ last_updated: 2026-09-04
 ## Camp 连续消息
 
 - 当前规范：[Pending Camp Input v3](../contracts/pending-camp-input-v3.md)、[Camp Composer Draft v8](../contracts/camp-composer-draft-v8.md)、[Composer 架构](../architecture/camp-composer-draft.md)。
-- 私有准入、单编辑占用和显式恢复的理由：[V1.33-D01](../versions/v1.33/decisions.md#v1-33-d01)；source refs、排队附件与 Runtime 适配理由：[V1.40-D01](../versions/v1.40/decisions.md#v1-40-d01)；V2 content 与低频 flush 理由：[V1.43-D01](../versions/v1.43/decisions.md#v1-43-d01)、[V1.43-D02](../versions/v1.43/decisions.md#v1-43-d02)。
+- 私有准入、单编辑占用和显式恢复的理由：[V1.33-D01](../versions/v1.33/decisions.md#v1-33-d01)；source refs、排队附件与 Runtime 适配理由：[V1.40-D01](../versions/v1.40/decisions.md#v1-40-d01)；V2 content 与低频 flush 理由：[V1.43-D01](../versions/v1.43/decisions.md#v1-43-d01)、[V1.43-D02](../versions/v1.43/decisions.md#v1-43-d02)；唯一 Draft authority、inline Decorator Atom 与统一有界 Trigger 理由：[V1.45-D01](../versions/v1.45/decisions.md#v1-45-d01)、[V1.45-D02](../versions/v1.45/decisions.md#v1-45-d02)、[V1.45-D03](../versions/v1.45/decisions.md#v1-45-d03)。
 
 ## 取消事务与 Runtime 清理
 

--- a/docs/ui/components/structured-mentions.md
+++ b/docs/ui/components/structured-mentions.md
@@ -24,9 +24,9 @@ DOM 形态，但 identity、候选来源、激活行为和发送校验保持强�
 信息卡打开时只使用既有 8% mention feedback。Skill 使用既有 Skill 行内语言。unavailable 状态保留可见标签，
 通过弱化样式和明确状态反馈表达，不消失、不变回可编辑文字。
 
-每个 Composer Atom 只对应一个简单 span DOM；不得挂载独立 React Root、Portal 或 Catalog 订阅。Atom 内没有
-独立可聚焦按钮，光标不能进入其中，Backspace/Delete 一次删除整个 Atom。普通字符落在 Atom 前后的独立
-TextNode，不能与 Atom 合并。
+每个 Composer Atom 是 identity-only inline `DecoratorNode<null>`，只对应一个 `contentEditable=false` span DOM；
+`decorate()` 返回 null，不得挂载独立 React Root、Portal 或 Catalog 订阅。Atom 内没有独立可聚焦按钮，光标不能
+进入其中，键盘可以 NodeSelection，Backspace/Delete 一次删除整个 Atom。普通字符落在 Atom 前后的独立 TextNode。
 
 Member 的唯一身份是 `agentId`，显示名称/头像从当前 Camp Catalog 解析；改名只刷新显示。离队或不可解析时
 保留 identity 和 fallback label，不按同名成员重新绑定。Skill 的唯一身份是 `skillId`，`nameAtSend` 保留发送时
@@ -35,16 +35,17 @@ Member 的唯一身份是 `agentId`，显示名称/头像从当前 Camp Catalog 
 ## Member Typeahead
 
 `@`、`@a`、`@alice` 只在折叠光标、普通 TextNode、非 composition，且 `@` 位于文本开头或允许分隔符之后时
-打开。查询不得跨 Atom、换行或 Paragraph，最多读取光标左侧 128 个字符。方向键移动候选，Enter 选择，Esc
-关闭；菜单消费按键时不得触发发送。
+打开。Member 与 Skill 共用一个 Trigger Plugin 和一个 Editor update listener；查询不得跨 Atom、换行或 Paragraph，
+从当前 TextNode 的 caret 位置只分配光标左侧最多 128 个字符。方向键移动候选，Enter 选择，Esc 关闭；菜单消费
+按键时不得触发发送。
 
 选择 Member/All Members 后，匹配查询被一个 Atom 替换。右侧已有空白时复用；否则插入一个普通空格，并把
 光标放在空格之后。查询或显示文本都不构成 identity。
 
 ## Skill Typeahead
 
-`/`、`/rev`、`/review` 只在文本开头、空白、换行、中文标点或明确允许的命令边界之后打开，并使用同样的
-128 字符局部扫描。`https://example.com/a/b`、`src/components/a/b.ts` 和 `word/review` 不触发。
+`/`、`/rev`、`/review` 只在文本开头、空白、换行、中文标点或明确允许的命令边界之后打开，并与 Member 查询使用
+同一个 128 字符 suffix matcher。`https://example.com/a/b`、`src/components/a/b.ts` 和 `word/review` 不触发。
 
 选择候选后用 `skillId + nameAtSend` Atom 替换查询并执行同样的尾随空格规则。`/review` 只是查询/显示形式，
 不是 Skill identity。Skill 不可用时保留 Atom，发送前由 Core 返回明确错误或既定降级结果；Composer 不重绑
@@ -93,7 +94,8 @@ Composer 选区 Copy/Cut 同时写：
 
 - `text/plain`：Member 使用当前名称或 fallback、All Members 为 `@所有队员`、Skill 为 `/<nameAtSend>`、
   LineBreak 为 `\n`；
-- `application/x-rovai-composer+json`：选区对应的 `ComposerDocument` V2，不是 Lexical JSON；
+- `application/x-rovai-composer+json`：选区对应的 `ComposerDocument` V2，不是 Lexical JSON；RangeSelection 与
+  键盘选中的 Atom NodeSelection 都必须产生对应投影；
 - `text/html`：仅兼容可见文本，不拥有 identity。
 
 粘贴时文件优先交给附件入口。没有文件时优先读取私有 MIME，严格校验 version、closed Segment/Atom shape 和
@@ -102,6 +104,9 @@ identity；当前 Catalog 中可恢复的引用还原为 Atom，不可恢复引�
 
 不得从纯文本 `@Alice`、`/review-code` 或外部 HTML 的 `data-reference-id`、`data-atom-type`、`data-skill-id`
 猜测 identity。整条历史用户消息的专用复制入口继续保留文件链接原始 target，不因显示 label 丢失路径。
+
+Draft 自动保存失败时 Composer 保留内容与 dirty 状态，显示可恢复的保存错误；当前 epoch 内可有限退避重试，发送
+必须通过显式 flush 确认持久化后继续。保存状态反馈不进入 EditorState 或 undo history。
 
 <a id="current-user-mention"></a>
 

--- a/docs/versions/README.md
+++ b/docs/versions/README.md
@@ -1,7 +1,7 @@
 ---
 document_type: versions-index
 authority: version-lifecycle
-current_version: v1.44
+current_version: v1.45
 last_updated: 2026-09-04
 ---
 
@@ -195,4 +195,5 @@ last_updated: 2026-09-04
 | v1.41 | `historical` | Sidecar 首次冻结用户现有 Project 顺序，后续仅同步成员变化，不再按消息活动移动 Project | [v1.41/README.md](v1.41/README.md) |
 | v1.42 | `historical` | 只有显式 Markdown 链接产生消息资源入口；共享 Markdown/代码图标与用户附件卡宽度收敛 | [v1.42/README.md](v1.42/README.md) |
 | v1.43 | `historical` | Lexical 驱动的 Text + Atom 结构化纯文本 Composer、低频 Draft Snapshot 与 V2 领域协议 | [v1.43/README.md](v1.43/README.md) |
-| v1.44 | `current` | Pi 原生输入边界、单一完整能力启动与 Fleet 并发创建 | [v1.44/README.md](v1.44/README.md) |
+| v1.44 | `historical` | Pi 原生输入边界、单一完整能力启动与 Fleet 并发创建 | [v1.44/README.md](v1.44/README.md) |
+| v1.45 | `current` | Composer 单一 Draft Authority、inline Decorator Atom 与源头有界 Typeahead | [v1.45/README.md](v1.45/README.md) |

--- a/docs/versions/v1.44/README.md
+++ b/docs/versions/v1.44/README.md
@@ -1,7 +1,7 @@
 ---
 document_type: version-overview
 version: v1.44
-lifecycle: current
+lifecycle: historical
 authority: version-scope-and-status
 design_status: confirmed
 implementation_status: complete
@@ -11,7 +11,7 @@ last_updated: 2026-09-04
 
 # Rovai-ai v1.44：Pi 原生输入边界与 Fleet 并发启动
 
-前置：[v1.43](../v1.43/README.md)。本版本收敛 Pi Coding Agent 的责任边界：Rovai 只投递普通 Agent
+前置：[v1.43](../v1.43/README.md)。后续：[v1.45](../v1.45/README.md)。本版本收敛 Pi Coding Agent 的责任边界：Rovai 只投递普通 Agent
 Prompt、结构化图片、Bootstrap、最小 receipt 与部分审批，Pi 自己发现原生资源；同时把公共 Runtime Fleet 的
 耗时 spawn 移出全局锁，并精确限定 exact-resume replacement。
 

--- a/docs/versions/v1.44/decisions.md
+++ b/docs/versions/v1.44/decisions.md
@@ -1,7 +1,7 @@
 ---
 document_type: version-decisions
 version: v1.44
-lifecycle: current
+lifecycle: historical
 last_updated: 2026-09-04
 ---
 

--- a/docs/versions/v1.45/README.md
+++ b/docs/versions/v1.45/README.md
@@ -1,0 +1,58 @@
+---
+document_type: version-overview
+version: v1.45
+lifecycle: current
+authority: version-scope-and-status
+design_status: confirmed
+implementation_status: complete
+model_context_change: false
+last_updated: 2026-09-04
+---
+
+# Rovai-ai v1.45：Composer 权威、Atom 与查询边界收口
+
+前置：[v1.44](../v1.44/README.md)。本版本不改变 `ComposerDocument` V2、Core Draft wire、source attachment、
+Reply/Continuation 或 exact-revision send 合同；它收敛 Renderer 内部的权威与高频编辑路径，消除多份完整 Draft
+缓存、文本伪装 Atom 和 Typeahead 先取全文再截断的问题。
+
+## 范围与当前状态
+
+- `DraftMutationCoordinator` 是 Renderer 唯一完整 `CampComposerDraftView` owner；正文、附件、Reply、
+  Continuation 与接收者修改进入同一队列，每次只从当前 Draft 读取 `expectedRevision`，成功回执原子替换 authority。
+- `ComposerDraftSync` 只保留 EditorState、epoch、local/saved version、dirty 与持久化状态；flush 等待 Draft 队列、
+  按需保存捕获快照，并在完成后读取 Coordinator 当前 Draft。自动保存失败保持 dirty、显示 error，并在当前 epoch
+  内有限退避重试；显式 flush 不吞错。
+- 发送冻结一个 local version，flush 后只使用 Coordinator 返回的 exact revision；发送过程中出现的新本地版本不会
+  被成功回执清空，并在下一 Draft epoch 继续保存。
+- `ComposerAtomNode` 改为 identity-only inline `DecoratorNode<null>`。Catalog 只更新一个不可编辑 span 的展示，
+  不改变节点字符长度、领域内容、local version、Draft revision 或 history。
+- `@` 与 `/` 共用一个 React Typeahead 插件和一个 Editor update listener；扫描只为当前普通 TextNode 的光标左侧
+  分配最多 128 字符，不跨 Atom、LineBreak 或 Paragraph，IME 期间暂停。
+
+## 保留边界
+
+`ComposerDocument` 仍只有 Text + Atom，Core 不保存 Lexical JSON，`body` 仍从 document 派生。Core Draft revision、
+Pending、附件 source refs、公开 Structured Content 映射和发送时身份校验均不改变，因此不创建新的 wire contract。
+Composer 仍是结构化纯文本输入框，不引入 Rich Text、Markdown 或通用文档能力。
+
+## 跨版本文档影响
+
+| 范围 | 结论 | 证据或理由 |
+| --- | --- | --- |
+| Version lifecycle | 已更新 | v1.44 冻结为 historical；本概览、[实施计划](implementation-plan.md)、版本索引与前后链接建立唯一 current v1.45 |
+| Decisions | 已更新 | [V1.45-D01](decisions.md#v1-45-d01)、[V1.45-D02](decisions.md#v1-45-d02)与[V1.45-D03](decisions.md#v1-45-d03)分别记录 Draft authority、Decorator Atom 与源头有界统一 Trigger；CURRENT 已纳入导航 |
+| Contracts | 确认无需更新 | `ComposerDocument` V2、`CampComposerDraftView`、Core command、revision、Pending 与 send wire shape/错误/幂等语义均未改变；当前 [Camp Composer Draft v8](../../contracts/camp-composer-draft-v8.md)继续适用 |
+| Architecture | 已更新 | [Camp Composer Draft 架构](../../architecture/camp-composer-draft.md)与架构索引同步 Coordinator、epoch、失败恢复、Decorator 与统一 Trigger 的组件职责 |
+| UI | 已更新 | [结构化 Mention 与 Atom](../../ui/components/structured-mentions.md)同步真实 inline Atom、单监听器 Typeahead、NodeSelection Clipboard 与持久化失败反馈 |
+| Runtime Activity | 确认无需更新 | Runtime 输入、活动归一、证据与执行台呈现均未变化 |
+| Runtime compatibility | 确认无需更新 | Runtime adapter、版本、能力、资格与兼容性均未变化 |
+| Documentation routing | 已更新 | 版本指针、Architecture 索引、当前决定导航和 Context 术语已指向新的当前边界；任务入口路径不变 |
+| Root README | 确认无需更新 | 产品定位、安装与公开能力没有变化，Renderer 内部收口不属于根 README 范围 |
+
+## References
+
+- [实施与验收](implementation-plan.md)
+- [版本决定](decisions.md)
+- [Camp Composer Draft 架构](../../architecture/camp-composer-draft.md)
+- [Camp Composer Draft v8](../../contracts/camp-composer-draft-v8.md)
+- [结构化 Mention 与 Atom](../../ui/components/structured-mentions.md)

--- a/docs/versions/v1.45/decisions.md
+++ b/docs/versions/v1.45/decisions.md
@@ -1,0 +1,76 @@
+---
+document_type: version-decisions
+version: v1.45
+lifecycle: current
+last_updated: 2026-09-04
+---
+
+# v1.45 决定
+
+<a id="v1-45-d01"></a>
+## V1.45-D01：Renderer 只保留一个完整 Camp Draft authority
+
+### 背景
+
+`ComposerDraftSync.latestResult`、`CampWorkspace.composerDraftRef` 和 React Draft state 都曾缓存完整
+`CampComposerDraftView`。正文保存后，附件或 Reply mutation 可以推进 Core revision，而 Sync 仍返回旧回执；发送再以
+“最近 result 或外层 ref”选择 Draft，无法证明正文、附件、路由意图和 revision 属于同一事务状态。
+
+### 决定
+
+`DraftMutationCoordinator` 是 Renderer 唯一完整 Draft owner。正文、附件、Reply、Continuation 和接收者修改进入同一
+Promise queue；每个操作在实际执行时读取 Coordinator 当前 revision，Core 返回完整 View 后再替换 authority。React
+只保存重渲染 tick 和派生 UI 状态；`ComposerDraftSync` 不缓存 View/revision，只在 flush 结束时读取 Coordinator。
+
+编辑对象整体替换会推进 epoch。异步操作只在 epoch 仍一致时更新当前 UI/本地保存状态；旧 epoch 的 Core 工作可完成，
+但其回执不能进入新 Draft。失败 mutation 尝试刷新当前 authority，同时向调用者保留原始错误。
+
+### 后果与被拒绝方案
+
+- flush 的含义是“捕获版本已落到当前权威 Draft 并返回队列结束后的 View”，不是返回最近一次 autosave 回执。
+- exact send 不再有 `latestResult ?? currentResult` 分支；附件和正文不能并行争用同一 revision。
+- 拒绝用更多 refs 互相同步：它只能缩小竞态窗口，不能建立唯一顺序或权威。
+- 拒绝把完整 Draft 放入逐字符 React state：它会重新引入全文 render 和双 owner。
+
+<a id="v1-45-d02"></a>
+## V1.45-D02：Composer Atom 是 identity-only inline DecoratorNode
+
+### 背景
+
+token `TextNode` 同时保存旧显示文本，而 Catalog presentation 直接改 DOM `textContent`。成员改名后 Lexical 字符长度
+仍是旧标签，DOM 却是新标签，selection offset、浏览器范围和编辑模型不再同构。
+
+### 决定
+
+`ComposerAtomNode` 继承 `DecoratorNode<null>`，显式 inline、keyboard-selectable、non-isolated。节点只保存领域允许的
+identity/fallback/snapshot state；`createDOM` 建立一个 `contentEditable=false` span，`updateDOM` 用当前 Catalog 投影
+label/availability，`decorate()` 返回 `null`，不创建 Atom 级 React 子树。
+
+### 后果与被拒绝方案
+
+- Atom 没有字符 offset，光标只能位于前后节点边界；相邻删除按 Lexical Decorator 语义整体处理。
+- 键盘 NodeSelection 的 Copy/Cut 也投影 `ComposerDocument`，不会因 `getTextContent()` 为空丢失 identity。
+- 拒绝继续同步 TextNode 文本与 Catalog label：动态显示不属于领域内容，也不应进入 undo/Draft revision。
+- 拒绝每 Atom React Root：简单 span 不需要独立生命周期、Portal 或 Catalog subscription。
+
+<a id="v1-45-d03"></a>
+## V1.45-D03：`@` 与 `/` 共用源头有界的 Trigger listener
+
+### 背景
+
+标准 `LexicalTypeaheadMenuPlugin` 会先取得光标前的完整 TextNode prefix，再把字符串交给 trigger；尽管 Rovai
+随后截取 128 字符，较长 prefix 的分配已经发生。分别挂载 Member 和 Skill 插件还重复 selection/update 监听。
+
+### 决定
+
+Rovai 使用一个 React Plugin 和一个 Lexical update listener。它只接受 collapsed plain-Text selection，按 caret offset
+请求当前 TextNode 最后最多 128 字符的 suffix，在同一个 matcher 内区分 Member/Skill，并输出 node key 与精确
+`fromOffset/toOffset`。节点起点只在无前置节点或 LineBreak 后成立；Atom、Paragraph 和非法边界不跨越。IME 期间保持
+候选状态但不重新匹配、选择或发送，compositionend 后再计算。
+
+### 后果与被拒绝方案
+
+- 查询成本和分配上限与 Draft 总长度无关；URL、路径和单词内部 slash 继续是负例。
+- 候选 UI 仍由一个 React Portal 呈现，键盘行为与现有视觉合同不变。
+- 拒绝在 trigger callback 内才截断：那无法撤销标准插件已经完成的 prefix 分配。
+- 拒绝两套自定义 listener：Member 与 Skill 的 selection、IME、键盘和关闭语义应共享一个 owner。

--- a/docs/versions/v1.45/implementation-plan.md
+++ b/docs/versions/v1.45/implementation-plan.md
@@ -1,0 +1,38 @@
+---
+document_type: implementation-plan
+version: v1.45
+authority: implementation-and-acceptance-status
+status: complete
+last_updated: 2026-09-04
+---
+
+# v1.45 实施与验收
+
+## 实施范围
+
+1. 以独立 Coordinator 收口完整 Draft authority 和所有 expected-revision mutation。
+2. 把 Draft Sync 收窄为本地 EditorState/version/dirty/epoch/persistence status，并建立有限重试和显式 flush 失败。
+3. 调整发送冻结、成功清空和下一 Draft epoch，保留发送期间的新输入。
+4. 把 Atom 从 token TextNode 改为 identity-only inline DecoratorNode，并补齐 NodeSelection Clipboard。
+5. 用一个自定义 React Plugin 替换两套标准 Typeahead，限定 128 字符 source window 和结构边界。
+6. 删除旧完整 Draft refs/result caches 与标准 Typeahead 全前缀读取路径，更新当前权威文档。
+
+## 验收矩阵
+
+| Gate | 状态 | 证据 |
+| --- | --- | --- |
+| Coordinator revision/queue/epoch/failure 单元测试 | `passed` | `draft-mutation-coordinator.test.ts` 的 5 个测试覆盖串行 revision、排队 reload、no-op flush、stale epoch 与失败刷新 |
+| Draft Sync debounce/single-flight/error/retry/epoch 单元测试 | `passed` | `composer-draft-sync.test.ts` 覆盖 autosave、send hold、有限退避与 authoritative result late read |
+| Atom/serialization/Clipboard 单元测试 | `passed` | `composer-editor-state.test.ts` 覆盖 Decorator identity round-trip、换行、NodeSelection 与尾随空格 |
+| Trigger boundary 单元测试 | `passed` | `composer-trigger.test.ts` 覆盖 128 字符 read request、URL/path 负例、Atom/LineBreak 与精确替换 |
+| Renderer TypeScript、Vitest 与 fixture build | `passed` | `pnpm typecheck`；全仓 149 个 Vitest suite、1504 个 test；独立 Composer fixture Vite build 通过 |
+| 原生 Composer/Continuation Electron | `blocked` | 当前嵌套 macOS sandbox 阻止 Chromium sandbox 初始化；按仓库规则不是通过结果，等待 CI/非嵌套主机执行 |
+| 全仓测试、生产构建与文档治理 | `passed` | `pnpm test`、`pnpm build:desktop`、`pnpm docs:test`、`pnpm docs:check` 与 diff-aware `docs:check:ci` 均通过 |
+
+## 完成条件
+
+- Renderer 中不存在 `composerDraftRef`、per-Camp Draft queue、`ComposerDraftSync.latestResult` 或标准
+  `LexicalTypeaheadMenuPlugin` 路径。
+- 所有 Draft mutation 从 Coordinator 当前 revision 发起；flush/send 返回并使用队列结束后的 authority。
+- Catalog presentation 不改内容版本；Atom 内无动态显示文本；触发查询只分配有界 suffix。
+- 自动化、构建、文档门禁和 PR CI 通过；原生 Electron 若因环境阻断，必须如实保留 blocked 证据并由 CI 补证。

--- a/scripts/fixtures/structured-mention-composer/main.cjs
+++ b/scripts/fixtures/structured-mention-composer/main.cjs
@@ -216,7 +216,7 @@ app.whenReady().then(async () => {
       ])
     })
 
-    await run('Backspace deletes a token-mode Atom as one unit', async () => {
+    await run('Backspace deletes an inline Decorator Atom as one unit', async () => {
       await reset({
         version: 2,
         segments: [{ kind: 'atom', atom: { type: 'member', agentId: 'agent-a' } }]

--- a/scripts/fixtures/structured-mention-composer/renderer.tsx
+++ b/scripts/fixtures/structured-mention-composer/renderer.tsx
@@ -1,4 +1,4 @@
-import type { CampComposerDraftView, ComposerDocument } from '@contracts'
+import type { ComposerDocument } from '@contracts'
 import { useLayoutEffect, useRef, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 import {
@@ -9,8 +9,7 @@ import {
 import {
   ROVAI_COMPOSER_CLIPBOARD_MIME,
   cloneComposerDocument,
-  composerDocumentFromText,
-  composerDocumentToPlainText
+  composerDocumentFromText
 } from '../../../apps/desktop/src/renderer/src/composer-document'
 import type { ComposerSkillOption } from '../../../apps/desktop/src/renderer/src/composer-skill-picker'
 import '../../../apps/desktop/src/renderer/src/styles.css'
@@ -48,7 +47,6 @@ let localStatus = {
   hasUnavailableAtom: false
 }
 let dirty = false
-let revision = 0
 
 function editor(): HTMLElement {
   const element = document.getElementById('composer')
@@ -84,20 +82,6 @@ function normalizeInput(value: string | ComposerDocument): ComposerDocument {
     : cloneComposerDocument(value)
 }
 
-function draftResult(document: ComposerDocument): CampComposerDraftView {
-  return {
-    campId: 'fixture-camp',
-    body: composerDocumentToPlainText(document, initialMembers),
-    content: cloneComposerDocument(document),
-    revision,
-    attachments: [],
-    replyIntent: null,
-    continuationIntent: null,
-    updatedAt: '2026-09-04T00:00:00Z',
-    expiresAt: '2026-09-11T00:00:00Z'
-  }
-}
-
 function Harness() {
   const composerRef = useRef<StructuredMentionComposerHandle>(null)
   const [draftIdentity, setDraftIdentity] = useState('fixture-camp:draft-0')
@@ -119,11 +103,10 @@ function Harness() {
           backspaceAtStartCount = 0
           activatedAtom = null
           pastedFileCount = 0
-          revision = 0
           setMembers(initialMembers)
           setSkills(fixtureSkills)
           setDisabled(false)
-          composerRef.current?.replaceDocument(normalizeInput(value), null, 'end')
+          composerRef.current?.replaceDocument(normalizeInput(value), 'end')
           composerRef.current?.focus('end')
         },
         setDocument(value: string | ComposerDocument, boundary: 'start' | 'end' = 'end') {
@@ -264,8 +247,6 @@ function Harness() {
       disabled={disabled}
       persistDocument={async (document) => {
         savedDocuments.push(cloneComposerDocument(document))
-        revision += 1
-        return draftResult(document)
       }}
       onLocalStatusChange={(status) => { localStatus = status }}
       onDirtyChange={(value) => { dirty = value }}


### PR DESCRIPTION
## Summary

- add a single DraftMutationCoordinator for content, attachments, Reply, Continuation, recipients, exact revisions, and epoch fencing
- narrow ComposerDraftSync to local Lexical version/persistence state with debounce, single-flight, retry, explicit flush, and safe post-send preservation
- replace TextNode-shaped atoms with identity-only inline DecoratorNode spans and structured NodeSelection clipboard handling
- replace duplicate Lexical typeahead plugins with one bounded @ and / trigger listener
- publish v1.45 architecture, decisions, UI contract, and acceptance status

## Verification

- pnpm typecheck
- pnpm build:desktop
- pnpm test (149 Vitest files / 1504 tests plus repository Node gates)
- pnpm docs:test
- pnpm docs:check
- DOCS_BASE_REF=20f7a21393f6490dab698205b8d683b4a85e3eb1 pnpm docs:check:ci
- isolated structured Composer fixture Vite build
- Impeccable detector: no findings

## Native acceptance

Local native Composer and Continuation Electron assertions are explicitly BLOCKED because the nested macOS sandbox prevents Chromium sandbox initialization. They did not run locally and are not reported as passing; CI is the merge gate for those assertions.