### PR TITLE
fix(composer): show member roles in mention picker

### DIFF
--- a/apps/desktop/src/renderer/src/CampWorkspace.tsx
+++ b/apps/desktop/src/renderer/src/CampWorkspace.tsx
@@ -1714,6 +1714,7 @@ export function CampWorkspace({
     () => snapshot.members.map((member) => ({
       agentId: member.agentId,
       displayName: member.displayName,
+      teamRole: member.teamRole,
       avatarRef: member.avatarRef,
       mentionable: member.membershipStatus === 'active' && member.profilePresence === 'present'
     })),

--- a/apps/desktop/src/renderer/src/StructuredMentionComposer.test.ts
+++ b/apps/desktop/src/renderer/src/StructuredMentionComposer.test.ts
@@ -6,6 +6,7 @@ import {
   StructuredMentionOptionAvatar,
   shouldHandleStructuredComposerBackspaceAtStart,
   shouldSubmitStructuredComposerOnEnter,
+  structuredMentionMemberDescription,
   structuredMentionOptions,
   structuredSkillOptions
 } from './StructuredMentionComposer'
@@ -16,11 +17,13 @@ import type { ComposerSkillOption } from './composer-skill-picker'
 const members = [{
   agentId: 'agent_1',
   displayName: '新洛可',
+  teamRole: '默认队长',
   avatarRef: 'rovai://member-avatar/builtin/luoke/v1',
   mentionable: true
 }, {
   agentId: 'agent_2',
   displayName: '沐瓦',
+  teamRole: '',
   mentionable: true
 }]
 
@@ -87,6 +90,11 @@ describe('StructuredMentionComposer V2', () => {
     expect(memberMarkup).toContain('class="member-avatar-image"')
     expect(allMembersMarkup).toContain('class="mention-avatar"')
     expect(allMembersMarkup).toContain('>@</span>')
+  })
+
+  it('uses the catalog-backed team role as the member candidate description', () => {
+    expect(structuredMentionMemberDescription(members[0])).toBe('默认队长')
+    expect(structuredMentionMemberDescription(members[1])).toBe('团队角色未设置')
   })
 
   it('filters Skills by name and description and keeps all options for an empty query', () => {

--- a/apps/desktop/src/renderer/src/StructuredMentionComposer.tsx
+++ b/apps/desktop/src/renderer/src/StructuredMentionComposer.tsx
@@ -60,6 +60,7 @@ import {
 export interface StructuredMentionMember {
   agentId: string
   displayName: string
+  teamRole: string
   avatarRef?: string | null
   mentionable?: boolean
 }
@@ -128,6 +129,10 @@ export function structuredMentionOptions(
     options.push({ kind: 'member', member })
   }
   return options
+}
+
+export function structuredMentionMemberDescription(member: StructuredMentionMember): string {
+  return member.teamRole.trim() || '团队角色未设置'
 }
 
 export function structuredSkillOptions(
@@ -526,7 +531,9 @@ function renderMentionMenu(
           <StructuredMentionOptionAvatar option={option} />
           <span>
             <strong>{option.kind === 'all_members' ? '所有队员' : option.member.displayName}</strong>
-            <small>{option.kind === 'all_members' ? '广播给当前全部队员' : 'Camp 成员'}</small>
+            <small>{option.kind === 'all_members'
+              ? '广播给当前全部队员'
+              : structuredMentionMemberDescription(option.member)}</small>
           </span>
           <i aria-hidden="true" />
         </button>)}

--- a/docs/ui/components/structured-mentions.md
+++ b/docs/ui/components/structured-mentions.md
@@ -41,6 +41,9 @@ Member 的唯一身份是 `agentId`，显示名称/头像从当前 Camp Catalog 
 critical-priority command 从当前 selection 同步重算 trigger：Catalog loading 时消费按键但不选择，ready 且有候选时
 选择当前项，无 trigger 或 ready/error 且无候选时才交给普通发送行为。
 
+普通 Member 候选的主行显示当前 Camp Catalog 名称，副行显示同一 Catalog 的团队角色；团队角色为空时显示
+“团队角色未设置”。副行不得使用所有候选共享的“Camp 成员”等占位文案。All Members 候选继续显示广播说明。
+
 选择 Member/All Members 后，匹配查询被一个 Atom 替换。右侧已有空白时复用；否则插入一个普通空格，并把
 光标放在空格之后。查询或显示文本都不构成 identity。
 

--- a/scripts/accept-structured-mentions-ui.mjs
+++ b/scripts/accept-structured-mentions-ui.mjs
@@ -168,6 +168,7 @@ try {
 
   running = await launchApp(dataDir, debugPort, 1440, 920)
   await setTheme(running.cdp, 'day')
+  await evaluate(running.cdp, 'window.rovai.generalPreferences.setWorldMapEnabled(true)')
   const freshAgents = await request(running.cdp, 'members.list')
   assert(
     targetMemberIds.every((id) => freshAgents.some((agent) =>
@@ -514,7 +515,7 @@ try {
       key: 'Backspace', code: 'Backspace', windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 51
     })
     await waitForValue(async () => request(running.cdp, 'camp.composerDraft.get', { campId }),
-      (draft) => deepEqual(draft.content, []) && draft.replyIntent === null, 10_000)
+      (draft) => deepEqual(draft.content, emptyComposerDocument) && draft.replyIntent === null, 10_000)
 
     await closeApp(running)
     running = null
@@ -598,7 +599,7 @@ try {
       key: 'Backspace', code: 'Backspace', windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 51
     })
     await waitForValue(async () => request(running.cdp, 'camp.composerDraft.get', { campId }),
-      (draft) => deepEqual(draft.content, []), 10_000)
+      (draft) => deepEqual(draft.content, emptyComposerDocument), 10_000)
     await waitForExpression(running.cdp, `(() => {
       const rail = document.querySelector('.composer-route-rail')
       const summary = rail?.querySelector('.mention-target-summary')
@@ -676,10 +677,10 @@ try {
     const addressedDraft = await waitForValue(async () =>
       request(running.cdp, 'camp.composerDraft.get', { campId }), (draft) =>
       draft.body === `@${targetMembers[1].displayName} ${continuationMessageText}`
-        && deepEqual(draft.content, [
+        && deepEqual(draft.content, composerDocumentFromStructured([
           { kind: 'member_mention', agentId: targetMemberIds[1] },
           { kind: 'text', text: ` ${continuationMessageText}` }
-        ]), 10_000)
+        ])), 10_000)
     await waitForExpression(running.cdp,
       `document.querySelector('.composer .composer-send')?.disabled === false`)
     const continuationStartedAt = Date.now()
@@ -890,6 +891,7 @@ try {
         options: [...(menu?.querySelectorAll('button[role="option"]') ?? [])]
           .map((button) => ({
             name: button.querySelector('strong')?.textContent ?? null,
+            description: button.querySelector('small')?.textContent ?? null,
             hasMemberAvatar: Boolean(button.querySelector('.member-avatar.mention-avatar')),
             hasImage: Boolean(button.querySelector('.member-avatar.mention-avatar .member-avatar-image'))
           })),
@@ -899,6 +901,7 @@ try {
       const option = projection.options.find((candidate) => candidate.name === member.displayName)
       return projection.text === `${expectedEditorText}@`
         && projection.menu
+        && option?.description === member.teamRole
         && option?.hasMemberAvatar
         && option.hasImage
     }, 10_000)
@@ -1325,7 +1328,8 @@ try {
   await pasteWithMetaV(running.cdp)
   const downgradedDraft = await waitForValue(async () =>
     request(running.cdp, 'camp.composerDraft.get', { campId }), (draft) =>
-    deepEqual(draft.content, [{ kind: 'text', text: currentUserMentionBody }]), 10_000)
+    deepEqual(draft.content,
+      composerDocumentFromStructured([{ kind: 'text', text: currentUserMentionBody }])), 10_000)
   assert(downgradedDraft.body === currentUserMentionBody,
     `Composer paste did not downgrade Current User Mention to Text: ${JSON.stringify(downgradedDraft)}`)
   const downgradedComposer = await evaluate(running.cdp, `(() => {
@@ -1350,7 +1354,7 @@ try {
     key: 'Backspace', code: 'Backspace', windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 51
   })
   await waitForValue(async () => request(running.cdp, 'camp.composerDraft.get', { campId }),
-    (draft) => deepEqual(draft.content, []) && draft.replyIntent === null, 10_000)
+    (draft) => deepEqual(draft.content, emptyComposerDocument) && draft.replyIntent === null, 10_000)
   await reloadRenderer(running.cdp)
   await setTheme(running.cdp, 'day')
   await openCamp(running.cdp, campId)
@@ -1437,7 +1441,7 @@ try {
     key: 'Backspace', code: 'Backspace', windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 51
   })
   await waitForValue(async () => request(running.cdp, 'camp.composerDraft.get', { campId }),
-    (draft) => deepEqual(draft.content, []) && draft.replyIntent === null, 10_000)
+    (draft) => deepEqual(draft.content, emptyComposerDocument) && draft.replyIntent === null, 10_000)
   const originalAuthorProfile = await request(running.cdp, 'members.get', {
     agentId: targetMemberIds[0]
   })
@@ -2434,12 +2438,13 @@ async function acceptComposerCutRegression(cdp, campId) {
     key: 'Backspace', code: 'Backspace', windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 51
   })
   await waitForValue(async () => request(cdp, 'camp.composerDraft.get', { campId }),
-    (draft) => deepEqual(draft.content, []) && draft.body === '', 10_000)
+    (draft) => deepEqual(draft.content, emptyComposerDocument) && draft.body === '', 10_000)
 
   await focusEditorAtEnd(cdp)
   await cdp.send('Input.insertText', { text: '123' })
   await waitForValue(async () => request(cdp, 'camp.composerDraft.get', { campId }),
-    (draft) => deepEqual(draft.content, [{ kind: 'text', text: '123' }])
+    (draft) => deepEqual(draft.content,
+      composerDocumentFromStructured([{ kind: 'text', text: '123' }]))
       && draft.body === '123', 10_000)
   await evaluate(cdp, `(() => {
     window.__composerCutEditor = document.querySelector('#camp-message')
@@ -2463,7 +2468,7 @@ async function acceptComposerCutRegression(cdp, campId) {
   )
   const emptyDraft = await waitForValue(
     () => request(cdp, 'camp.composerDraft.get', { campId }),
-    (draft) => deepEqual(draft.content, []) && draft.body === '',
+    (draft) => deepEqual(draft.content, emptyComposerDocument) && draft.body === '',
     10_000
   )
   await evaluate(cdp,
@@ -2497,7 +2502,8 @@ async function acceptComposerCutRegression(cdp, campId) {
   await cdp.send('Input.insertText', { text: '7' })
   const nextDraft = await waitForValue(
     () => request(cdp, 'camp.composerDraft.get', { campId }),
-    (draft) => deepEqual(draft.content, [{ kind: 'text', text: '7' }]) && draft.body === '7',
+    (draft) => deepEqual(draft.content,
+      composerDocumentFromStructured([{ kind: 'text', text: '7' }])) && draft.body === '7',
     10_000
   )
   await evaluate(cdp,
@@ -2524,16 +2530,17 @@ async function acceptComposerCutRegression(cdp, campId) {
   )
 
   await selectWholeEditor(cdp)
-  const nativeDeleteApplied = await evaluate(cdp, `document.execCommand('delete')`)
-  assert(nativeDeleteApplied, 'Chromium did not apply the native delete command')
-  const afterNativeEmptyDraft = await waitForValue(
+  await pressKey(cdp, {
+    key: 'Backspace', code: 'Backspace', windowsVirtualKeyCode: 8, nativeVirtualKeyCode: 51
+  })
+  const afterKeyboardEmptyDraft = await waitForValue(
     () => request(cdp, 'camp.composerDraft.get', { campId }),
-    (draft) => deepEqual(draft.content, []) && draft.body === '',
+    (draft) => deepEqual(draft.content, emptyComposerDocument) && draft.body === '',
     10_000
   )
   await evaluate(cdp,
     `new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))`, true)
-  const afterNativeEmpty = await evaluate(cdp, `(() => {
+  const afterKeyboardEmpty = await evaluate(cdp, `(() => {
     const editor = document.querySelector('#camp-message')
     return {
       appShellStayedMounted: document.querySelector('.app-shell') === window.__composerCutShell,
@@ -2547,14 +2554,14 @@ async function acceptComposerCutRegression(cdp, campId) {
     }
   })()`)
   assert(
-    afterNativeEmpty.appShellStayedMounted
-      && afterNativeEmpty.workspaceStayedMounted
-      && afterNativeEmpty.editorFocused
-      && afterNativeEmpty.editorText === ''
-      && afterNativeEmpty.paragraphCount === 1
-      && afterNativeEmpty.breakCount === 1
-      && afterNativeEmpty.errors.length === 0,
-    `A native empty filler became semantic content: ${JSON.stringify(afterNativeEmpty)}`
+    afterKeyboardEmpty.appShellStayedMounted
+      && afterKeyboardEmpty.workspaceStayedMounted
+      && afterKeyboardEmpty.editorFocused
+      && afterKeyboardEmpty.editorText === ''
+      && afterKeyboardEmpty.paragraphCount === 1
+      && afterKeyboardEmpty.breakCount === 1
+      && afterKeyboardEmpty.errors.length === 0,
+    `A Lexical empty filler became semantic content: ${JSON.stringify(afterKeyboardEmpty)}`
   )
 
   return {
@@ -2563,9 +2570,8 @@ async function acceptComposerCutRegression(cdp, campId) {
     afterCut,
     nextDraft,
     afterSingleInput,
-    nativeDeleteApplied,
-    afterNativeEmptyDraft,
-    afterNativeEmpty
+    afterKeyboardEmptyDraft,
+    afterKeyboardEmpty
   }
 }
 

--- a/scripts/fixtures/structured-mention-composer/main.cjs
+++ b/scripts/fixtures/structured-mention-composer/main.cjs
@@ -140,7 +140,9 @@ app.whenReady().then(async () => {
     await run('Member Typeahead replaces only the local query with one Atom', async () => {
       await reset('请 ')
       await insert('@甲')
-      assert.equal((await state(false)).menuKind, 'mention')
+      const open = await state(false)
+      assert.equal(open.menuKind, 'mention')
+      assert.ok(open.options.some((option) => option.endsWith('\n队员甲\n系统架构师')), JSON.stringify(open))
       await key('Enter', 13)
       const current = await expectSegments([
         { kind: 'text', text: '请 ' },

--- a/scripts/fixtures/structured-mention-composer/renderer.tsx
+++ b/scripts/fixtures/structured-mention-composer/renderer.tsx
@@ -28,6 +28,7 @@ const fixtureSkills: ComposerSkillOption[] = [
 const initialMembers: StructuredMentionMember[] = [{
   agentId: 'agent-a',
   displayName: '队员甲',
+  teamRole: '系统架构师',
   mentionable: true
 }]
 


### PR DESCRIPTION
## Summary
- show each Camp member’s catalog-backed team role in the @ picker instead of the shared “Camp 成员” placeholder
- define the fallback as “团队角色未设置” and document the picker contract
- add component and packaged-App regression assertions; migrate stale Composer V2 acceptance expectations

## Validation
- `pnpm typecheck`
- `pnpm exec vitest run apps/desktop/src/renderer/src/StructuredMentionComposer.test.ts`
- `pnpm docs:test`
- `pnpm docs:check`
- `pnpm package:mac`
- targeted packaged-App run reached and passed member candidate descriptions for 游学者 / 鉴定士 / 巡夜人 and captured the picker plus selected mentions

## Known baseline failures
- `pnpm test:composer-input` still fails the pre-existing synthetic clipboard copy case on this macOS host (reproduces on `main`)
- full packaged Mention acceptance proceeds past the updated member picker and later fails the pre-existing composer mention-popover pointer click case
- Skill-picker acceptance separately exposes the pre-existing last-option scroll visibility failure
