### PR TITLE
chore(release): prepare v0.0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "rovai-core"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/rovai-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.6"
+version = "0.0.7"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rovai/desktop",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": true,
   "license": "MIT",
   "type": "module"

--- a/apps/desktop/src/main/package-metadata.test.ts
+++ b/apps/desktop/src/main/package-metadata.test.ts
@@ -9,7 +9,7 @@ const packageMetadata = JSON.parse(readFileSync(
 describe('desktop package metadata', () => {
   it('keeps the visible brand separate from Electron helper bundle identity', () => {
     expect(packageMetadata.productName).toBe('Rovai AI')
-    expect(packageMetadata.version).toBe('0.0.6')
+    expect(packageMetadata.version).toBe('0.0.7')
     expect(packageMetadata.build.productName).toBe('Rovai AI')
     expect(packageMetadata.build.mac.executableName).toBeUndefined()
     expect(packageMetadata.build.win.executableName).toBe('Rovai-ai')

--- a/build/release-notes.md
+++ b/build/release-notes.md
@@ -1,17 +1,18 @@
-# Rovai AI v0.0.6
+# Rovai AI v0.0.7
 
-Rovai AI 0.0.6 improves persistent Camp controls, safer resource navigation, trustworthy Runtime compaction visibility, and DingTalk channel management.
+Rovai AI 0.0.7 adds the Pi coding agent, strengthens Camp message composition and attachment handling, and makes conversations easier to read and navigate.
 
-macOS arm64 and x64 builds use the same fixed Rovai Release Signing certificate as 0.0.5. Windows x64 remains an unsigned Preview build and may show a SmartScreen warning.
+macOS arm64 and x64 builds use the same fixed Rovai Release Signing certificate as 0.0.6. Windows x64 remains an unsigned Preview build and may show a SmartScreen warning.
 
 ## What's Changed
 
-- Keep execution, task, and member detail popovers open while you work elsewhere, with explicit dismissal from the active entry, close button, or Escape.
-- Fix the shared-memory review drawer layering so its content stays visible and interactive above the page overlay.
-- Recognize local resources only from explicit Markdown links or whole inline-code references, with clearer file-type and web-link icons and the existing safe-open boundary preserved.
-- Show explicitly attributable Runtime compaction as a standalone non-Tool execution row with bounded token or summary details, neutral imminent state, and active started state.
-- Keep compaction display tied to existing native Runtime events without installing display-only hooks, plugins, or configuration overlays.
-- Add durable DingTalk multi-bot aggregation, ordered target admission, restart-safe collection, replay deduplication, bounded parent-message context, and privacy-safe diagnostics.
-- Open DingTalk as a selectable channel provider with typed account, connection, Bot, and management-link controls, while unsupported attachment and native-interaction capabilities remain independently gated.
+- Add and qualify the Pi coding agent on macOS arm64, macOS x64, and Windows x64, with native execution, lifecycle ownership, runtime capabilities, private storage, and platform-specific verification.
+- Replace the Camp composer with structured Text + Atom editing, a single Core-owned draft authority, safer synchronization, and reliable publication of attachment-only pending messages.
+- Persist the latest draft before Camp navigation, app quit, and macOS window close so accepted exits no longer lose recent composition state.
+- Preserve source attachments, unify pending and published attachment cards, partition Runtime attachments by author, and make file-drop routing consistent.
+- Improve conversation reading with automatic history loading, stable prepend anchors, remembered timeline positions, clearer Markdown code layers, compact user bubbles, and refined long-message actions.
+- Tighten explicit Markdown file-link recognition and resource opening, with clearer file-type and preview-tab icons while preserving the existing safe-open boundary.
+- Stabilize Sidecar project order, reduce execution-detail rendering cost, and place agent actions after complete output.
+- Show each Camp member's configured team role in the `@` mention picker, with a clear fallback when no role is configured.
 
-**Full changelog:** https://github.com/murray17/rovai-ai/compare/v0.0.5...v0.0.6
+**Full changelog:** https://github.com/murray17/rovai-ai/compare/v0.0.6...v0.0.7

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rovai-ai",
   "productName": "Rovai AI",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": true,
   "type": "module",
   "description": "A desktop workspace for long-lived agent teams, shared Camps, visible execution, and collaborative memory.",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rovai/contracts",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/scripts/accept-app-updates-ui.mjs
+++ b/scripts/accept-app-updates-ui.mjs
@@ -56,7 +56,7 @@ try {
     outputDir,
     verified: {
       isolatedPackagedApplication: true,
-      packagedVersion: '0.0.6',
+      packagedVersion: '0.0.7',
       typedIdleUpdaterSnapshot: true,
       productAndBundleName: 'Rovai AI',
       existingSettingsVisualWorld: true,
@@ -93,12 +93,12 @@ async function openAboutUpdates(cdp) {
   assert(selected, 'About & Updates Settings entry was unavailable')
   await waitForSelector(cdp, '.about-updates-settings')
   await waitForExpression(cdp,
-    `document.querySelector('.about-version-value code')?.textContent === 'v0.0.6'`)
+    `document.querySelector('.about-version-value code')?.textContent === 'v0.0.7'`)
 }
 
 async function assertAboutUpdates(cdp, context) {
   const updaterSnapshot = await evaluate(cdp, 'window.rovai.appUpdates.get()', true)
-  assert(updaterSnapshot?.currentVersion === '0.0.6'
+  assert(updaterSnapshot?.currentVersion === '0.0.7'
     && updaterSnapshot.status === 'idle'
     && updaterSnapshot.availableRelease === null
     && updaterSnapshot.lastCheckSource === null
@@ -136,7 +136,7 @@ async function assertAboutUpdates(cdp, context) {
   assert(state.heading === '关于与更新', `${context} omitted the page heading`)
   assert(state.description === 'Rovai AI 会在正式打包版本中主动检查更新；下载、安装和重启始终由你确认。',
     `${context} used the wrong description`)
-  assert(state.product === 'Rovai AI' && state.version === 'v0.0.6',
+  assert(state.product === 'Rovai AI' && state.version === 'v0.0.7',
     `${context} used the wrong product/version: ${JSON.stringify(state)}`)
   assert(state.action === '检查更新' && state.actionTag === 'BUTTON' && state.actionFocused,
     `${context} did not expose a keyboard-focusable check action`)

--- a/scripts/benchmark/protocol/product-contract.test.mjs
+++ b/scripts/benchmark/protocol/product-contract.test.mjs
@@ -4,8 +4,8 @@ import { collectProductContractFingerprint } from './product-contract.mjs'
 
 test('Product Contract Fingerprint reads code/build authority and marks unavailable data explicitly', async () => {
   const fingerprint = await collectProductContractFingerprint()
-  assert.equal(fingerprint.dataContractVersion.value, 'v1.48')
-  assert.equal(fingerprint.dataContractSchemaVersion.value, 89)
+  assert.equal(fingerprint.dataContractVersion.value, 'v1.49')
+  assert.equal(fingerprint.dataContractSchemaVersion.value, 90)
   assert.equal(fingerprint.campSnapshotSchemaVersion.value, 34)
   assert.equal(fingerprint.contextManifestVersion.value, 22)
   assert.equal(fingerprint.contextFormatterVersion.value, 22)


### PR DESCRIPTION
## Summary

- bump desktop, contracts, and Rust package versions to 0.0.7
- refresh release notes for all changes since v0.0.6, including Pi qualification and Camp member roles in the @ mention picker
- advance stale Product Contract Fingerprint test expectations to the current v1.49 / schema 90 authority

## Validation

- pnpm install --frozen-lockfile
- pnpm typecheck
- pnpm build:desktop
- pnpm test (Vitest: 1524 passed; Node/protocol: 220 passed, 1 Windows-only skipped)
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- pnpm test:rust:pr (library: 496 passed; CLI: 32 passed; slow: 301 passed)

## Release

- base includes PR #237 at bad5382ca1e2c1e49153f8b49e8635aa38f04f7d
- macOS arm64/x64 remains bound to Rovai Release Signing
- Windows x64 remains the documented unsigned Preview build