### PR TITLE
fix: show Runtime errors directly on AgentRun

### DIFF
--- a/apps/desktop/src/renderer/src/App.test.ts
+++ b/apps/desktop/src/renderer/src/App.test.ts
@@ -5312,7 +5312,7 @@ describe('task event projections', () => {
     })
   })
 
-  it('shows a failed Claude run public failure even when no execution evidence was recorded', () => {
+  it('shows only a failed AgentRun original error even when no execution evidence was recorded', () => {
     const run: AgentRunView = {
       id: 'run-claude-failed', campTurnId: 'turn-1', conversationId: 'conversation-claude',
       agentId: 'agent-claude', taskId: null, responsibilityKey: 'direct:agent-claude',
@@ -5341,9 +5341,9 @@ describe('task event projections', () => {
     expect(markup).toContain('class="process-disclosure-slot"')
     expect(markup).toContain('<path d="m4.75 6.25 3.25 3.5 3.25-3.5"></path>')
     expect(markup).not.toContain('⌄')
-    expect(markup).toContain('Claude Code 返回错误')
-    expect(markup).toContain('请求受到速率限制')
     expect(markup).toContain('请稍后重试。')
+    expect(markup).not.toContain('Claude Code 返回错误')
+    expect(markup).not.toContain('请求受到速率限制')
     expect(markup).not.toContain('Rovai 内部错误')
   })
 

--- a/apps/desktop/src/renderer/src/CampWorkspace.tsx
+++ b/apps/desktop/src/renderer/src/CampWorkspace.tsx
@@ -8605,7 +8605,7 @@ function RunExecutionContent({
 
   return (
     <div className="process-content">
-      {publicFailure && <RuntimeFailureNotice failure={publicFailure} />}
+      {publicFailure && <RuntimeFailureNotice failure={publicFailure} presentation="agent-run" />}
       {showUnsettledWarning && (
         <p className="execution-uncertain" role="status">
           仍有外部效果待确认

--- a/apps/desktop/src/renderer/src/RuntimeFailureNotice.test.ts
+++ b/apps/desktop/src/renderer/src/RuntimeFailureNotice.test.ts
@@ -2,7 +2,11 @@ import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
 import type { RuntimeFailureOrigin, RuntimeFailureView } from '@contracts'
-import { RuntimeFailureNotice, runtimeFailureTitle } from './RuntimeFailureNotice'
+import {
+  RuntimeFailureNotice,
+  runtimeFailureMessage,
+  runtimeFailureTitle
+} from './RuntimeFailureNotice'
 
 describe('RuntimeFailureNotice', () => {
   it.each([
@@ -32,6 +36,28 @@ describe('RuntimeFailureNotice', () => {
   it('uses Rovai internal error only when Core explicitly attributes the origin to Rovai', () => {
     const failure = runtimeFailure('rovai')
     expect(runtimeFailureTitle(failure)).toBe('Rovai 内部错误')
+  })
+
+  it.each([
+    [
+      'Selected model is at capacity. Please try a different model.',
+      'Selected model is at capacity. Please try a different model.'
+    ],
+    [null, '模型额度不足']
+  ])('shows only the original safe error on AgentRun when detail is %s', (detail, message) => {
+    const failure = { ...runtimeFailure('compatibility', 'codex-cli'), detail }
+    const markup = renderToStaticMarkup(
+      createElement(RuntimeFailureNotice, { failure, presentation: 'agent-run' })
+    )
+
+    expect(runtimeFailureMessage(failure)).toBe(message)
+    expect(markup).toContain('agent-run-runtime-failure')
+    expect(markup).toContain(`>${message}</p>`)
+    expect(markup).not.toContain('Codex CLI')
+    expect(markup).not.toContain('与当前 Rovai 版本不兼容')
+    if (detail) {
+      expect(markup).not.toContain('模型额度不足')
+    }
   })
 })
 

--- a/apps/desktop/src/renderer/src/RuntimeFailureNotice.tsx
+++ b/apps/desktop/src/renderer/src/RuntimeFailureNotice.tsx
@@ -11,9 +11,25 @@ export function runtimeFailureTitle(failure: RuntimeFailureView): string {
   } as const)[failure.origin]
 }
 
-export function RuntimeFailureNotice({ failure }: {
+export function RuntimeFailureNotice({
+  failure,
+  presentation = 'default'
+}: {
   failure: RuntimeFailureView
+  presentation?: 'default' | 'agent-run'
 }): React.JSX.Element {
+  if (presentation === 'agent-run') {
+    const message = runtimeFailureMessage(failure)
+    return (
+      <section
+        className="runtime-failure-notice agent-run-runtime-failure"
+        aria-label={message}
+        role="status"
+      >
+        <p>{message}</p>
+      </section>
+    )
+  }
   const title = runtimeFailureTitle(failure)
   const detail = failure.detail?.trim()
   return (
@@ -27,6 +43,10 @@ export function RuntimeFailureNotice({ failure }: {
       {detail && detail !== failure.summary && <p className="runtime-failure-detail">{detail}</p>}
     </section>
   )
+}
+
+export function runtimeFailureMessage(failure: RuntimeFailureView): string {
+  return failure.detail?.trim() || failure.summary
 }
 
 function publicRuntimeLabel(runtimeKind: RuntimeFailureView['runtimeKind']): string {

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -3732,6 +3732,7 @@ button.task-event-card:focus-visible .task-card-chevron { color: var(--brand-ink
 .runtime-failure-notice.origin-compatibility,
 .runtime-failure-notice.origin-environment { color: var(--attention); background: var(--attention-soft); }
 .runtime-failure-notice.origin-unknown { color: var(--muted); background: var(--neutral-soft); }
+.runtime-failure-notice.agent-run-runtime-failure { color: var(--danger); background: var(--danger-soft); }
 .runtime-failure-notice > strong { color: inherit; font-size: 11.5px; font-weight: 700; line-height: 1.45; overflow-wrap: anywhere; }
 .runtime-failure-notice > p { margin: 0; color: var(--ink); font-size: 10.5px; line-height: 1.5; overflow-wrap: anywhere; white-space: pre-line; }
 .runtime-failure-notice > .runtime-failure-detail { color: var(--muted); }

--- a/crates/rovai-core/src/codex.rs
+++ b/crates/rovai-core/src/codex.rs
@@ -2236,6 +2236,16 @@ pub struct CompletedTurn {
     pub error: Option<Value>,
 }
 
+impl CompletedTurn {
+    pub fn error_message(&self) -> Option<&str> {
+        self.error.as_ref().and_then(|error| {
+            error
+                .as_str()
+                .or_else(|| error.get("message").and_then(Value::as_str))
+        })
+    }
+}
+
 pub fn completed_turn(params: &Value) -> Result<CompletedTurn> {
     let turn = params
         .get("turn")
@@ -3253,6 +3263,7 @@ while IFS= read -r ignored; do :; done
                 "codexErrorInfo": "serverOverloaded"
             }))
         );
+        assert_eq!(completed.error_message(), Some("model unavailable"));
     }
 
     #[test]

--- a/crates/rovai-core/src/main.rs
+++ b/crates/rovai-core/src/main.rs
@@ -9077,10 +9077,25 @@ impl Core {
                         .unwrap_or_else(|| "runtime_launch_failed".to_string())
                 };
                 let public_failure = public_failure.or_else(|| {
-                    unknown_one_shot_runtime_failure(
+                    let raw_detail = error.root_cause().to_string();
+                    let sensitive_paths = [
+                        (Path::new(&execution.project_path), "<project>"),
+                        (
+                            Path::new(&execution.workspace.execution_root),
+                            "<execution-root>",
+                        ),
+                        (
+                            Path::new(&execution.runtime.executable_path),
+                            "<runtime-executable>",
+                        ),
+                        (core.data_dir.as_path(), "<data-dir>"),
+                    ];
+                    Some(agent_run_public_failure(
                         execution.runtime.adapter_kind,
                         &error_code,
-                    )
+                        &raw_detail,
+                        &sensitive_paths,
+                    ))
                 });
                 if let Some((native_turn_id, delivered_error_code, delivered_failure)) =
                     delivered_one_shot_failure
@@ -9265,7 +9280,7 @@ impl Core {
         error_code: &str,
         error: &anyhow::Error,
     ) {
-        let public_failure = dispatch_public_failure(candidate, error_code);
+        let public_failure = dispatch_public_failure(candidate, error_code, error);
         let rejection = {
             let mut database = self.database.lock().await;
             ExecutionRuntimeService::default().reject_agent_run_dispatch(
@@ -13320,6 +13335,8 @@ impl Core {
         execution_epoch: i64,
         error: &anyhow::Error,
     ) {
+        let public_failure =
+            dispatch_public_failure(candidate, "runtime_configuration_invalid", error);
         let ending_git_observation = self
             .observe_run_git(&candidate.project_binding_kind, &candidate.project_path)
             .await;
@@ -13341,7 +13358,7 @@ impl Core {
                         execution_epoch,
                         error_code: "runtime_configuration_invalid".to_string(),
                         error_detail: Some(format!("{error:#}")),
-                        failure: None,
+                        failure: public_failure,
                         manual_retry_allowed: true,
                         ending_git_observation,
                     },
@@ -17859,14 +17876,14 @@ async fn persist_acp_prompt_completion(
     let error_detail = response_error
         .map(str::to_string)
         .unwrap_or_else(|| format!("ACP prompt ended as {stop_reason}"));
-    let mut public_failure = response_error.map(|detail| {
+    let mut public_failure = (planned_outcome == RuntimeTerminalOutcome::Failed).then(|| {
         public_runtime_failure_from_output(
             adapter_kind,
             RuntimeFailureOrigin::Runtime,
             RuntimeFailurePhase::Execution,
             &base_error_code,
             &format!("{} 未能完成运行", runtime_display_name(adapter_kind)),
-            Some(detail),
+            Some(&error_detail),
             &[(&core.data_dir, "<data-dir>")],
             manual_retry_allowed,
         )
@@ -18828,6 +18845,40 @@ async fn process_agent_run_codex_message(
     } else {
         RuntimeTerminalOutcome::Failed
     };
+    let base_error_code = match completed.status.as_str() {
+        "completed" => "runtime_missing_final_output".to_string(),
+        "interrupted" => "runtime_interrupted".to_string(),
+        status => format!("runtime_turn_{status}"),
+    };
+    let error_detail = match &completed.error {
+        Some(error) => format!(
+            "Codex Native Turn {} ended as {}: {}",
+            completed.turn_id, completed.status, error
+        ),
+        None if completed.status == "completed" => {
+            "Codex completed the Turn without an Agent message".to_string()
+        }
+        None => format!(
+            "Codex Native Turn {} ended as {}",
+            completed.turn_id, completed.status
+        ),
+    };
+    let public_failure = (planned_outcome == RuntimeTerminalOutcome::Failed).then(|| {
+        public_runtime_failure_from_output(
+            AdapterKind::CodexCli,
+            RuntimeFailureOrigin::Runtime,
+            RuntimeFailurePhase::Execution,
+            &base_error_code,
+            "Codex CLI 未能完成运行",
+            Some(completed.error_message().unwrap_or(&error_detail)),
+            &[(&core.data_dir, "<data-dir>")],
+            true,
+        )
+    });
+    let error_code = public_failure
+        .as_ref()
+        .map(|failure| failure.code.clone())
+        .unwrap_or_else(|| base_error_code.clone());
     let terminal_discriminator = canonical_json_digest(&params)
         .unwrap_or_else(|_| format!("{}:{}", completed.turn_id, completed.status));
     let mut terminal_admission = match core
@@ -18863,24 +18914,6 @@ async fn process_agent_run_codex_message(
                 .flatten()
                 .map(|execution| execution.workspace.execution_root)
         };
-        let error_code = match completed.status.as_str() {
-            "completed" => "runtime_missing_final_output".to_string(),
-            "interrupted" => "runtime_interrupted".to_string(),
-            status => format!("runtime_turn_{status}"),
-        };
-        let error_detail = Some(match &completed.error {
-            Some(error) => format!(
-                "Codex Native Turn {} ended as {}: {}",
-                completed.turn_id, completed.status, error
-            ),
-            None if completed.status == "completed" => {
-                "Codex completed the Turn without an Agent message".to_string()
-            }
-            None => format!(
-                "Codex Native Turn {} ended as {}",
-                completed.turn_id, completed.status
-            ),
-        });
         match core
             .settle_planned_shutdown_abortive_terminal(
                 permit,
@@ -18888,9 +18921,9 @@ async fn process_agent_run_codex_message(
                     agent_run_id: agent_run_id.to_string(),
                     execution_epoch,
                     outcome: planned_outcome,
-                    error_code,
-                    error_detail,
-                    failure: None,
+                    error_code: error_code.clone(),
+                    error_detail: Some(error_detail.clone()),
+                    failure: public_failure.clone(),
                     manual_retry_allowed: planned_outcome == RuntimeTerminalOutcome::Failed,
                 },
             )
@@ -18996,11 +19029,9 @@ async fn process_agent_run_codex_message(
                             agent_run_id: agent_run_id.to_string(),
                             expected_version: execution.version,
                             execution_epoch,
-                            error_code: "runtime_missing_final_output".to_string(),
-                            error_detail: Some(
-                                "Codex completed the Turn without an Agent message".to_string(),
-                            ),
-                            failure: None,
+                            error_code: error_code.clone(),
+                            error_detail: Some(error_detail.clone()),
+                            failure: public_failure.clone(),
                             manual_retry_allowed: true,
                             ending_git_observation: ending_git_observation.clone(),
                         },
@@ -19023,22 +19054,9 @@ async fn process_agent_run_codex_message(
                         agent_run_id: agent_run_id.to_string(),
                         expected_version: execution.version,
                         execution_epoch,
-                        error_code: if completed.status == "interrupted" {
-                            "runtime_interrupted".to_string()
-                        } else {
-                            format!("runtime_turn_{}", completed.status)
-                        },
-                        error_detail: Some(match &completed.error {
-                            Some(error) => format!(
-                                "Codex Native Turn {} ended as {}: {}",
-                                completed.turn_id, completed.status, error
-                            ),
-                            None => format!(
-                                "Codex Native Turn {} ended as {}",
-                                completed.turn_id, completed.status
-                            ),
-                        }),
-                        failure: None,
+                        error_code: error_code.clone(),
+                        error_detail: Some(error_detail.clone()),
+                        failure: public_failure.clone(),
                         manual_retry_allowed: true,
                         ending_git_observation,
                     },
@@ -19963,75 +19981,20 @@ fn runtime_check_has_capacity(active_count: usize) -> bool {
     active_count < RUNTIME_CHECK_MAX_CONCURRENCY
 }
 
-fn unknown_one_shot_runtime_failure(
+fn agent_run_public_failure(
     runtime_kind: AdapterKind,
     error_code: &str,
-) -> Option<RuntimeFailureView> {
-    let runtime_name = match runtime_kind {
-        AdapterKind::ClaudeCodeCli => "Claude Code",
-        AdapterKind::AntigravityApp => "Antigravity",
-        _ => return None,
-    };
-    let (origin, summary, retryable) = if error_code == "context_payload_too_large" {
-        (
+    raw_detail: &str,
+    sensitive_paths: &[(&Path, &str)],
+) -> RuntimeFailureView {
+    let runtime_name = runtime_display_name(runtime_kind);
+    let (origin, phase, summary, retryable) = match error_code {
+        "context_payload_too_large" => (
             RuntimeFailureOrigin::Rovai,
+            RuntimeFailurePhase::Execution,
             "Rovai 无法安全生成本次 Runtime 输入".to_string(),
             false,
-        )
-    } else {
-        (
-            RuntimeFailureOrigin::Unknown,
-            format!("{runtime_name} 未能完成运行"),
-            true,
-        )
-    };
-    Some(RuntimeFailureView::new(
-        runtime_kind,
-        origin,
-        RuntimeFailurePhase::Execution,
-        error_code,
-        summary,
-        None,
-        retryable,
-    ))
-}
-
-fn availability_environment_failure(
-    runtime_kind: AdapterKind,
-    error_code: &str,
-    summary: &str,
-) -> Option<RuntimeFailureView> {
-    let runtime_name = match runtime_kind {
-        AdapterKind::ClaudeCodeCli => "Claude Code",
-        AdapterKind::AntigravityApp => "Antigravity",
-        _ => return None,
-    };
-    Some(RuntimeFailureView::new(
-        runtime_kind,
-        RuntimeFailureOrigin::Environment,
-        RuntimeFailurePhase::Spawn,
-        error_code,
-        summary.replace("Runtime", runtime_name),
-        None,
-        true,
-    ))
-}
-
-fn dispatch_public_failure(
-    candidate: &rovai_core::runtime::QueuedAgentRunCandidate,
-    error_code: &str,
-) -> Option<RuntimeFailureView> {
-    let runtime_kind = candidate
-        .effective_config
-        .get("adapterKind")
-        .cloned()
-        .and_then(|value| serde_json::from_value::<AdapterKind>(value).ok())?;
-    let runtime_name = match runtime_kind {
-        AdapterKind::ClaudeCodeCli => "Claude Code",
-        AdapterKind::AntigravityApp => "Antigravity",
-        _ => return None,
-    };
-    let (origin, phase, summary, retryable) = match error_code {
+        ),
         "workspace_unavailable" => (
             RuntimeFailureOrigin::Environment,
             RuntimeFailurePhase::Spawn,
@@ -20069,19 +20032,60 @@ fn dispatch_public_failure(
         ),
         _ => (
             RuntimeFailureOrigin::Unknown,
-            RuntimeFailurePhase::Spawn,
-            format!("{runtime_name} 未能开始运行"),
+            RuntimeFailurePhase::Execution,
+            format!("{runtime_name} 未能完成运行"),
             true,
         ),
     };
-    Some(RuntimeFailureView::new(
+    public_runtime_failure_from_output(
         runtime_kind,
         origin,
         phase,
         error_code,
-        summary,
-        None,
+        &summary,
+        Some(raw_detail),
+        sensitive_paths,
         retryable,
+    )
+}
+
+fn availability_environment_failure(
+    runtime_kind: AdapterKind,
+    error_code: &str,
+    summary: &str,
+) -> Option<RuntimeFailureView> {
+    let runtime_name = match runtime_kind {
+        AdapterKind::ClaudeCodeCli => "Claude Code",
+        AdapterKind::AntigravityApp => "Antigravity",
+        _ => return None,
+    };
+    Some(RuntimeFailureView::new(
+        runtime_kind,
+        RuntimeFailureOrigin::Environment,
+        RuntimeFailurePhase::Spawn,
+        error_code,
+        summary.replace("Runtime", runtime_name),
+        None,
+        true,
+    ))
+}
+
+fn dispatch_public_failure(
+    candidate: &rovai_core::runtime::QueuedAgentRunCandidate,
+    error_code: &str,
+    error: &anyhow::Error,
+) -> Option<RuntimeFailureView> {
+    let runtime_kind = candidate
+        .effective_config
+        .get("adapterKind")
+        .cloned()
+        .and_then(|value| serde_json::from_value::<AdapterKind>(value).ok())?;
+    let raw_detail = error.root_cause().to_string();
+    Some(agent_run_public_failure(
+        runtime_kind,
+        error_code,
+        &raw_detail,
+        &[(Path::new(&candidate.project_path), "<project>")],
     ))
 }
 
@@ -20610,6 +20614,22 @@ mod tests {
     use super::*;
     #[cfg(feature = "slow-tests")]
     use std::fs;
+
+    #[test]
+    fn agent_run_failure_preserves_safe_runtime_detail_for_every_adapter() {
+        for runtime_kind in AdapterKind::ALL {
+            let failure = agent_run_public_failure(
+                runtime_kind,
+                "runtime_launch_failed",
+                "select model xxx",
+                &[],
+            );
+
+            assert_eq!(failure.runtime_kind, runtime_kind);
+            assert_eq!(failure.detail.as_deref(), Some("select model xxx"));
+            failure.validate().unwrap();
+        }
+    }
 
     #[test]
     fn acp_prompt_failure_is_retryable_only_when_input_was_not_accepted() {

--- a/crates/rovai-core/src/runtime_failure.rs
+++ b/crates/rovai-core/src/runtime_failure.rs
@@ -213,6 +213,18 @@ fn classify_high_value_runtime_error(
     }
     if contains_any(
         lower,
+        &["at capacity", "server overloaded", "serveroverloaded"],
+    ) {
+        return (
+            RuntimeFailureOrigin::Runtime,
+            default_phase,
+            "runtime_server_overloaded".to_string(),
+            "Runtime 服务暂时繁忙".to_string(),
+            true,
+        );
+    }
+    if contains_any(
+        lower,
         &[
             "quota exceeded",
             "quota exhausted",
@@ -619,6 +631,23 @@ mod tests {
         assert_eq!(failure.code, "runtime_rate_limited");
         assert_eq!(failure.origin, RuntimeFailureOrigin::Runtime);
         assert!(failure.retryable);
+
+        let capacity = public_runtime_failure_from_output(
+            AdapterKind::CodexCli,
+            RuntimeFailureOrigin::Runtime,
+            RuntimeFailurePhase::Execution,
+            "runtime_turn_failed",
+            "Codex CLI 未能完成运行",
+            Some("Selected model is at capacity. Please try a different model."),
+            &[],
+            false,
+        );
+        assert_eq!(capacity.code, "runtime_server_overloaded");
+        assert_eq!(
+            capacity.detail.as_deref(),
+            Some("Selected model is at capacity. Please try a different model.")
+        );
+        assert!(capacity.retryable);
 
         let compatibility = public_runtime_failure_from_output(
             AdapterKind::ClaudeCodeCli,

--- a/docs/ui/components/conversation-workspace.md
+++ b/docs/ui/components/conversation-workspace.md
@@ -554,11 +554,11 @@ notice：“Claude Code API 暂时不可用”，并显示最新重试次数、�
 凭证、用户名或绝对路径。精确合同见
 [Run Process Detail Surface v30](../../contracts/run-process-detail-surface-v30.md)。
 
-failed Claude Code 或 Antigravity Run 的公开 `failure` 必须在对应 Run stage 显示 Runtime 名称、安全
-summary 与可选 detail；即使没有任何 Execution Evidence 也默认展开，不能被空详情逻辑隐藏。标题按
-`origin` 固定为 Runtime 返回错误、与当前 Rovai 版本不兼容、本机运行环境不可用、Rovai 内部错误或
-未能完成运行。只有 `origin=rovai` 可以显示“Rovai 内部错误”；Renderer 不读取或展示原始 stderr、私有
-日志、内部 error chain 或 digest，也不从公开文本重新猜归因。
+failed AgentRun 的公开 `failure` 必须在对应 Run stage 显示 Core 已脱敏并限长的 Runtime 原始错误文本；
+非空 `detail` 优先，否则回退 `summary`。即使没有任何 Execution Evidence 也默认展开，不能被空详情逻辑
+隐藏。AgentRun 不增加 Runtime 名称或 `origin` 标题，不翻译错误文本，所有 `origin` 统一使用 danger
+错误底色；成员管理等非 AgentRun surface 继续使用各自既有标题与语义色。Renderer 不读取或展示原始
+stderr、私有日志、内部 error chain 或 digest，也不从公开文本重新猜归因。
 
 `waiting/recovery_blocked` 显示“结果待确认”，不得显示 spinner 或“恢复中”。Recovery Blocker
 必须说明 Runtime 已接受任务、重启后最终结果未知、原请求不会自动重发，并提供唯一“结束此运行”


### PR DESCRIPTION
## Summary

- persist a sanitized, bounded Runtime error detail on failed AgentRuns for every Runtime adapter, including Codex terminal failures and ACP failures without a native error field
- render the AgentRun failure detail directly, without a Runtime-specific heading or translated summary, and use the existing red danger surface for every failure origin
- keep the shared non-AgentRun failure presentation unchanged
- leave missing-send recovery, public reply creation, and the “本次运行没有产生公开回复” behavior untouched

## Verification

- `pnpm test` (152 files, 1540 tests)
- `pnpm typecheck`
- `pnpm build:desktop`
- `pnpm test:rust:core` (220 passed, 5 manual Runtime smokes ignored)
- `cargo fmt --all --check`
- `git diff --check`
- latest-main Rust PR gate: library 506/506 and CLI 33/33 passed

## Latest-main baseline issues

- `cargo clippy --workspace --all-targets -- -D warnings` stops in unchanged `crates/rovai-core/src/core_subsystems.rs` on `clippy::let_and_return`
- `pnpm test:rust:pr` reaches slow-tests, then unchanged `crates/rovai-core/src/context.rs` fails to compile because a Single Chat test fixture still supplies removed field `attachment_ids`

This branch has no diff in either baseline-failure file.
