### PR TITLE
feat(desktop): improve file preview readability

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -3755,7 +3755,7 @@ function AuthoritativeApp({
   }
 
   return (
-    <FilePreviewProvider campId={view === 'camp' ? activeCampId : null}>
+    <FilePreviewProvider campId={view === 'camp' ? activeCampId : null} resolvedTheme={appearance.resolvedTheme}>
     <div className={view === 'camp' ? 'app-shell app-shell-camp' : 'app-shell'}>
       <CampNavigation
         platform={window.rovai.platform}

--- a/apps/desktop/src/renderer/src/FilePreviewContext.tsx
+++ b/apps/desktop/src/renderer/src/FilePreviewContext.tsx
@@ -17,7 +17,8 @@ import type {
   FilePreviewPageContent,
   OpenFilePreviewRequest,
   OpenFilePreviewResult,
-  ResolvedFilePreview
+  ResolvedFilePreview,
+  ResolvedTheme
 } from '@contracts'
 import { secureFilePreviewHtml } from './file-preview-html-document'
 import { FilePreviewLayoutProvider } from './FilePreviewLayout'
@@ -97,6 +98,7 @@ export interface FilePreviewContextValue {
   activeTabId: string | null
   openFeedback: FilePreviewOpenFeedback | null
   paneVisible: boolean
+  resolvedTheme: ResolvedTheme
   open(
     request: OpenFilePreviewRequest,
     target?: FileLocationTarget,
@@ -204,9 +206,11 @@ function restoredTab(snapshot: FilePreviewTabSnapshot): PreviewTabModel {
 
 export function FilePreviewProvider({
   campId,
+  resolvedTheme,
   children
 }: {
   campId: string | null
+  resolvedTheme: ResolvedTheme
   children: ReactNode
 }): React.JSX.Element {
   const [tabs, setTabsState] = useState<PreviewTabModel[]>([])
@@ -982,6 +986,7 @@ export function FilePreviewProvider({
     activeTabId,
     openFeedback,
     paneVisible,
+    resolvedTheme,
     open,
     openFileChanges,
     selectChangedFile,
@@ -998,7 +1003,7 @@ export function FilePreviewProvider({
     reopen,
     retry,
     changePage
-  }), [activate, activeTab, activeTabId, changePage, close, closeMany, copyDisplayPath, hidePane, move, open, openFileChanges, openFeedback, openInSystem, paneVisible, reload, reopen, revealInFolder, retry, selectChangedFile, showPane, tabs])
+  }), [activate, activeTab, activeTabId, changePage, close, closeMany, copyDisplayPath, hidePane, move, open, openFileChanges, openFeedback, openInSystem, paneVisible, reload, reopen, resolvedTheme, revealInFolder, retry, selectChangedFile, showPane, tabs])
 
   return (
     <FilePreviewContext.Provider value={value}>

--- a/apps/desktop/src/renderer/src/FilePreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/FilePreviewPane.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { SafeMarkdown } from './SafeMarkdown'
 import { useFilePreview, type FilePreviewTabModel } from './FilePreviewContext'
 import { FileChangesPreview } from './FileChangesPreview'
 import { FilePreviewTabIcon, ResourceReferenceIcon } from './FilePreviewTabIcon'
+import { ReadonlyCodeViewer } from './ReadonlyCodeViewer'
 import { previewPathIsVisible, previewTabLabel, previewTabLabels } from './file-preview-tab-presentation'
 import { filePreviewAssetUrl } from '../../file-preview-asset-url'
 import { parseUnifiedPatch } from './file-preview-patch'
@@ -38,142 +39,19 @@ function RelativePath({ path, fileName }: { path: string; fileName: string }): R
   )
 }
 
-function CodeViewer({ tab }: { tab: FilePreviewTabModel }): React.JSX.Element {
-  const rootRef = useRef<HTMLDivElement>(null)
-  const [searchOpen, setSearchOpen] = useState(false)
-  const [searchQuery, setSearchQuery] = useState('')
-  const [searchIndex, setSearchIndex] = useState(0)
+function SourceViewer({ tab }: { tab: FilePreviewTabModel }): React.JSX.Element {
+  const { resolvedTheme } = useFilePreview()
   const text = tab.content?.kind === 'page' ? tab.content.page.text
     : tab.content && 'text' in tab.content ? tab.content.text : ''
   const startLine = tab.content?.kind === 'page' ? tab.content.page.startLine : 1
-  const lines = useMemo(() => text.split('\n').map((line) => line.replace(/\r$/u, '')), [text])
-  const searchMatches = useMemo(() => {
-    const query = searchQuery.toLocaleLowerCase()
-    if (!query) return []
-    const matches: Array<{ line: number; start: number; length: number }> = []
-    for (let line = 0; line < lines.length; line += 1) {
-      const source = lines[line].toLocaleLowerCase()
-      let offset = 0
-      while (offset <= source.length - query.length) {
-        const start = source.indexOf(query, offset)
-        if (start < 0) break
-        matches.push({ line, start, length: query.length })
-        offset = start + Math.max(1, query.length)
-      }
-    }
-    return matches
-  }, [lines, searchQuery])
-
-  useEffect(() => {
-    setSearchIndex((current) => searchMatches.length === 0
-      ? 0
-      : Math.min(current, searchMatches.length - 1))
-  }, [searchMatches.length])
-
-  useLayoutEffect(() => {
-    const targetLine = tab.file?.target?.line
-    const root = rootRef.current
-    const row = targetLine ? root?.querySelector<HTMLElement>(`[data-file-row="${targetLine}"]`) : null
-    if (!root || !row) return
-    root.scrollTop += row.getBoundingClientRect().top - root.getBoundingClientRect().top
-      - (root.clientHeight - row.getBoundingClientRect().height) / 2
-  }, [startLine, tab.content, tab.file?.target])
-
-  useEffect(() => {
-    const match = searchMatches[searchIndex]
-    if (!match) return
-    rootRef.current
-      ?.querySelector<HTMLElement>(`[data-file-row="${startLine + match.line}"]`)
-      ?.scrollIntoView({ block: 'center' })
-  }, [searchIndex, searchMatches, startLine])
-
-  const changeSearchMatch = (direction: -1 | 1): void => {
-    if (searchMatches.length === 0) return
-    setSearchIndex((current) => (current + direction + searchMatches.length) % searchMatches.length)
-  }
   return (
-    <>
-      <div
-        ref={rootRef}
-        className={`file-preview-code kind-${tab.file?.kind ?? 'text'}`}
-        role="region"
-        aria-label={`${tab.presentation.fileName} 内容`}
-        tabIndex={0}
-        onKeyDown={(event) => {
-          if ((event.metaKey || event.ctrlKey) && event.key.toLocaleLowerCase() === 'f') {
-            event.preventDefault()
-            setSearchOpen(true)
-            return
-          }
-          if (event.key === 'Escape' && searchOpen) {
-            event.preventDefault()
-            setSearchOpen(false)
-          }
-        }}
-      >
-        {lines.map((line, index) => {
-          const patchClass = tab.file?.kind === 'patch'
-            ? line.startsWith('+') && !line.startsWith('+++')
-              ? 'is-addition'
-              : line.startsWith('-') && !line.startsWith('---')
-                ? 'is-deletion'
-                : line.startsWith('@@')
-                  ? 'is-hunk'
-                  : ''
-            : ''
-          const currentMatch = searchMatches[searchIndex]
-          const highlight = currentMatch?.line === index ? currentMatch : null
-          const target = tab.file?.target
-          const targeted = target?.line !== undefined && startLine + index >= target.line
-            && startLine + index <= (target.endLine ?? target.line)
-          return (
-            <div
-              className={`file-preview-code-line ${patchClass}${highlight ? ' is-search-match' : ''}${targeted ? ' is-location-target' : ''}`}
-              data-file-row={startLine + index}
-              key={`${startLine + index}:${line}`}
-            >
-              <span aria-hidden="true">{startLine + index}</span>
-              <code data-file-line={startLine + index}>{highlight
-                ? <>{line.slice(0, highlight.start)}<mark>{line.slice(highlight.start, highlight.start + highlight.length)}</mark>{line.slice(highlight.start + highlight.length) || ' '}</>
-                : line || ' '}</code>
-            </div>
-          )
-        })}
-      </div>
-      {searchOpen && (
-        <div className="file-preview-search" role="search" aria-label="在当前文件中查找">
-          <input
-            autoFocus
-            value={searchQuery}
-            placeholder="查找"
-            aria-label="查找文本"
-            onChange={(event) => {
-              setSearchQuery(event.target.value)
-              setSearchIndex(0)
-            }}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter') {
-                event.preventDefault()
-                changeSearchMatch(event.shiftKey ? -1 : 1)
-              } else if (event.key === 'Escape') {
-                event.preventDefault()
-                setSearchOpen(false)
-                rootRef.current?.focus()
-              }
-            }}
-          />
-          <span aria-live="polite">{searchQuery
-            ? `${searchMatches.length ? searchIndex + 1 : 0} / ${searchMatches.length}`
-            : ''}</span>
-          <button type="button" aria-label="上一个匹配项" disabled={searchMatches.length === 0} onClick={() => changeSearchMatch(-1)}>↑</button>
-          <button type="button" aria-label="下一个匹配项" disabled={searchMatches.length === 0} onClick={() => changeSearchMatch(1)}>↓</button>
-          <button type="button" aria-label="关闭查找" onClick={() => {
-            setSearchOpen(false)
-            rootRef.current?.focus()
-          }}>×</button>
-        </div>
-      )}
-    </>
+    <ReadonlyCodeViewer
+      fileName={tab.presentation.fileName}
+      text={text}
+      startLine={startLine}
+      target={tab.file?.target}
+      theme={resolvedTheme}
+    />
   )
 }
 
@@ -344,7 +222,7 @@ function PatchViewer({ tab }: { tab: FilePreviewTabModel }): React.JSX.Element {
   const patch = useMemo(() => parseUnifiedPatch(text), [text])
   const { open } = useFilePreview()
   const [linkError, setLinkError] = useState<string | null>(null)
-  if (!patch) return <CodeViewer tab={tab} />
+  if (!patch) return <SourceViewer tab={tab} />
 
   const scrollTo = (id: string): void => {
     document.getElementById(`${tab.id}-${id}`)?.scrollIntoView({ block: 'start' })
@@ -426,7 +304,7 @@ function PatchViewer({ tab }: { tab: FilePreviewTabModel }): React.JSX.Element {
 }
 
 function Viewer({ tab }: { tab: FilePreviewTabModel }): React.JSX.Element {
-  const { open } = useFilePreview()
+  const { open, resolvedTheme } = useFilePreview()
   const [linkError, setLinkError] = useState<string | null>(null)
   const file = tab.file
   if (!tab.content || !file) return <div className="file-preview-empty-content" />
@@ -435,6 +313,8 @@ function Viewer({ tab }: { tab: FilePreviewTabModel }): React.JSX.Element {
       <div className="file-preview-markdown">
         {linkError && <p className="file-preview-inline-error" role="alert">{linkError}</p>}
         <SafeMarkdown
+          mode="document"
+          theme={resolvedTheme}
           headingTarget={file.target?.heading}
           onHeadingTargetResult={(found) => setLinkError(found ? null : '未找到指定的标题，已保持在文件顶部。')}
           localImageUrl={(rawReference) => filePreviewAssetUrl(
@@ -467,7 +347,7 @@ function Viewer({ tab }: { tab: FilePreviewTabModel }): React.JSX.Element {
   if (tab.content.kind === 'patch') {
     return <PatchViewer tab={tab} />
   }
-  return <CodeViewer tab={tab} />
+  return <SourceViewer tab={tab} />
 }
 
 function FilePreviewDocument({ tab }: { tab: FilePreviewTabModel }): React.JSX.Element {

--- a/apps/desktop/src/renderer/src/FilePreviewTabs.test.ts
+++ b/apps/desktop/src/renderer/src/FilePreviewTabs.test.ts
@@ -88,6 +88,7 @@ beforeEach(() => {
     activeTabId: 'second',
     openFeedback: null,
     paneVisible: true,
+    resolvedTheme: 'day',
     open: vi.fn(),
     openFileChanges: vi.fn(),
     selectChangedFile: vi.fn(),

--- a/apps/desktop/src/renderer/src/MarkdownCodeBlock.tsx
+++ b/apps/desktop/src/renderer/src/MarkdownCodeBlock.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import type { ResolvedTheme } from '@contracts'
+import {
+  highlightSourceCode,
+  loadSourceLanguageForName,
+  mountSourceSyntaxHighlightStyle
+} from './source-preview'
+
+interface LoadedLanguage {
+  languageName: string
+  support: Awaited<ReturnType<typeof loadSourceLanguageForName>>
+}
+
+export function MarkdownCodeBlock({
+  code,
+  languageName,
+  theme
+}: {
+  code: string
+  languageName?: string
+  theme: ResolvedTheme
+}): React.JSX.Element {
+  const rootRef = useRef<HTMLPreElement>(null)
+  const [loadedLanguage, setLoadedLanguage] = useState<LoadedLanguage | null>(null)
+  const language = languageName && loadedLanguage?.languageName === languageName
+    ? loadedLanguage.support
+    : null
+
+  useEffect(() => {
+    if (!languageName) return undefined
+    let active = true
+    void loadSourceLanguageForName(languageName).then((support) => {
+      if (active) setLoadedLanguage({ languageName, support })
+    })
+    return () => {
+      active = false
+    }
+  }, [languageName])
+
+  useLayoutEffect(() => {
+    const root = rootRef.current?.ownerDocument
+    if (root) mountSourceSyntaxHighlightStyle(theme, root)
+  }, [theme])
+
+  const highlighted = useMemo(
+    () => language ? highlightSourceCode(code, language, theme) : [{ text: code }],
+    [code, language, theme]
+  )
+
+  return (
+    <pre ref={rootRef} className="markdown-code-block">
+      <code data-code-language={languageName || undefined}>
+        {highlighted.map((segment, index) => segment.className
+          ? <span className={segment.className} key={`${index}:${segment.text.length}`}>{segment.text}</span>
+          : segment.text)}
+      </code>
+    </pre>
+  )
+}

--- a/apps/desktop/src/renderer/src/ReadonlyCodeViewer.tsx
+++ b/apps/desktop/src/renderer/src/ReadonlyCodeViewer.tsx
@@ -1,0 +1,151 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import CodeMirror from '@uiw/react-codemirror'
+import { EditorView } from '@codemirror/view'
+import { openSearchPanel } from '@codemirror/search'
+import type { FileLocationTarget, ResolvedTheme } from '@contracts'
+import {
+  loadSourceLanguageForFilename,
+  sourceCodeMirrorTheme,
+  sourceReaderExtensions,
+  sourceTargetLocalLines
+} from './source-preview'
+
+interface LoadedLanguage {
+  filename: string
+  support: Awaited<ReturnType<typeof loadSourceLanguageForFilename>>
+}
+
+export function ReadonlyCodeViewer({
+  fileName,
+  text,
+  startLine = 1,
+  target,
+  theme
+}: {
+  fileName: string
+  text: string
+  startLine?: number
+  target?: FileLocationTarget
+  theme: ResolvedTheme
+}): React.JSX.Element {
+  const viewRef = useRef<EditorView | null>(null)
+  const previousThemeRef = useRef(theme)
+  const themeAnchorRef = useRef<{ theme: ResolvedTheme; view: EditorView; position: number } | null>(null)
+  const [editor, setEditor] = useState<EditorView | null>(null)
+  const scheduledTargetRef = useRef<{
+    view: EditorView
+    text: string
+    startLine: number
+    line: number
+    endLine?: number
+  } | null>(null)
+  const [loadedLanguage, setLoadedLanguage] = useState<LoadedLanguage | null>(null)
+  const languageSettled = loadedLanguage?.filename === fileName
+  const language = languageSettled ? loadedLanguage.support : null
+  const targetLine = target?.line
+  const targetEndLine = target?.endLine
+
+  useEffect(() => {
+    let active = true
+    void loadSourceLanguageForFilename(fileName).then((support) => {
+      if (active) setLoadedLanguage({ filename: fileName, support })
+    })
+    return () => {
+      active = false
+    }
+  }, [fileName])
+
+  const extensions = useMemo(() => sourceReaderExtensions({
+    ariaLabel: `${fileName} 内容`,
+    language,
+    startLine,
+    target,
+    theme
+  }), [fileName, language, startLine, targetEndLine, targetLine, theme])
+
+  const targetScrollTop = useCallback((view: EditorView): number | null => {
+    const local = sourceTargetLocalLines(startLine, view.state.doc.lines, target)
+    if (!local) return null
+    const block = view.lineBlockAt(view.state.doc.line(local.from).from)
+    return Math.max(0, block.top - (view.scrollDOM.clientHeight - block.height) / 2)
+  }, [startLine, targetEndLine, targetLine])
+
+  const scheduleTargetScroll = useCallback((view: EditorView): void => {
+    if (!targetLine) return
+    const scheduled = scheduledTargetRef.current
+    if (scheduled?.view === view && scheduled.text === text && scheduled.startLine === startLine
+      && scheduled.line === targetLine && scheduled.endLine === targetEndLine) return
+    scheduledTargetRef.current = { view, text, startLine, line: targetLine, endLine: targetEndLine }
+    window.requestAnimationFrame(() => {
+      if (viewRef.current !== view || !view.dom.isConnected) return
+      view.requestMeasure({
+        read: targetScrollTop,
+        write: (scrollTop) => {
+          if (scrollTop === null || viewRef.current !== view || !view.dom.isConnected) return
+          view.scrollDOM.scrollTop = scrollTop
+        }
+      })
+    })
+  }, [startLine, targetEndLine, targetLine, targetScrollTop, text])
+
+  useEffect(() => {
+    if (editor && languageSettled) scheduleTargetScroll(editor)
+  }, [editor, languageSettled, scheduleTargetScroll])
+
+  useLayoutEffect(() => {
+    if (previousThemeRef.current === theme) return undefined
+    previousThemeRef.current = theme
+    const view = viewRef.current
+    if (!view) return undefined
+    const scrollerBounds = view.scrollDOM.getBoundingClientRect()
+    const contentBounds = view.contentDOM.getBoundingClientRect()
+    const anchor = view.posAtCoords({
+      x: contentBounds.left + 1,
+      y: scrollerBounds.top + 1
+    }, false)
+    themeAnchorRef.current = { theme, view, position: anchor }
+    return undefined
+  }, [theme])
+
+  useEffect(() => {
+    const anchor = themeAnchorRef.current
+    if (!anchor || anchor.theme !== theme) return undefined
+    const frame = window.requestAnimationFrame(() => {
+      if (viewRef.current === anchor.view && anchor.view.dom.isConnected) {
+        anchor.view.dispatch({ effects: EditorView.scrollIntoView(anchor.position, { y: 'start', yMargin: 0 }) })
+      }
+    })
+    return () => window.cancelAnimationFrame(frame)
+  }, [theme])
+
+  return (
+    <div
+      className="file-preview-code"
+      role="region"
+      aria-label={`${fileName} 内容`}
+      tabIndex={0}
+      onKeyDown={(event) => {
+        if (event.defaultPrevented || !(event.metaKey || event.ctrlKey) || event.key.toLocaleLowerCase() !== 'f') return
+        const view = viewRef.current
+        if (view && openSearchPanel(view)) event.preventDefault()
+      }}
+    >
+      <CodeMirror
+        className="file-preview-code-mirror"
+        value={text}
+        width="100%"
+        height="100%"
+        theme={sourceCodeMirrorTheme(theme)}
+        extensions={extensions}
+        basicSetup={false}
+        indentWithTab={false}
+        readOnly
+        editable={false}
+        onCreateEditor={(view) => {
+          viewRef.current = view
+          setEditor(view)
+        }}
+      />
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/SafeMarkdown.test.ts
+++ b/apps/desktop/src/renderer/src/SafeMarkdown.test.ts
@@ -4,6 +4,54 @@ import { describe, expect, it } from 'vitest'
 import { SafeMarkdown } from './SafeMarkdown'
 
 describe('SafeMarkdown file preview references', () => {
+  it('keeps document headings at their native levels without changing the default message hierarchy', () => {
+    const source = [
+      '# 一级',
+      '## 二级',
+      '### 三级',
+      '#### 四级',
+      '##### 五级',
+      '###### 六级'
+    ].join('\n\n')
+    const documentMarkup = renderToStaticMarkup(createElement(SafeMarkdown, {
+      children: source,
+      mode: 'document'
+    }))
+    const messageMarkup = renderToStaticMarkup(createElement(SafeMarkdown, { children: source }))
+
+    expect(documentMarkup).toContain('class="safe-markdown is-document"')
+    for (const [level, label] of ['一级', '二级', '三级', '四级', '五级', '六级'].entries()) {
+      expect(documentMarkup).toContain(`<h${level + 1} data-markdown-heading="${label}">${label}</h${level + 1}>`)
+    }
+    expect(messageMarkup).toContain('<h3 data-markdown-heading="一级">一级</h3>')
+    expect(messageMarkup).toContain('<h3 data-markdown-heading="二级">二级</h3>')
+    expect(messageMarkup).not.toContain('class="safe-markdown is-document"')
+  })
+
+  it('renders fenced document code through the static source highlighter surface', () => {
+    const markup = renderToStaticMarkup(createElement(SafeMarkdown, {
+      children: '```tsx\nconst App = () => <main />\n```\n\n```\nplain text\n```',
+      mode: 'document',
+      theme: 'night'
+    }))
+
+    expect(markup.match(/class="markdown-code-block"/gu)).toHaveLength(2)
+    expect(markup).toContain('<code data-code-language="tsx">const App = () =&gt; &lt;main /&gt;\n</code>')
+    expect(markup).toContain('<code>plain text\n</code>')
+    expect(markup).not.toContain('cm-editor')
+  })
+
+  it('gives document tables their own horizontal scroll surface', () => {
+    const markup = renderToStaticMarkup(createElement(SafeMarkdown, {
+      children: '| 项目 | 说明 |\n| --- | --- |\n| 预览 | 宽内容 |',
+      mode: 'document'
+    }))
+
+    expect(markup).toContain('<div class="markdown-table-scroll"><table>')
+    expect(markup).toContain('<th>项目</th>')
+    expect(markup).toContain('<td>宽内容</td>')
+  })
+
   it('turns only explicit Markdown file links into resource links', () => {
     const markup = renderToStaticMarkup(createElement(SafeMarkdown, {
       onFileReference: () => undefined,

--- a/apps/desktop/src/renderer/src/SafeMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/SafeMarkdown.tsx
@@ -5,6 +5,8 @@ import { FILE_REFERENCE_FRAGMENT, FileReferenceLink, type FileReferenceActivatio
 import { ResourceReferenceIcon } from './FilePreviewTabIcon'
 import { remarkRepairCjkUrlTail } from './remark-repair-cjk-url-tail'
 import { parseFileReference } from '../../file-preview-reference'
+import { MarkdownCodeBlock } from './MarkdownCodeBlock'
+import type { ResolvedTheme } from '@contracts'
 
 type MarkdownTreeNode = {
   type?: string
@@ -42,6 +44,16 @@ function markdownHeadingText(children: ReactNode): string {
     return markdownHeadingText(children.props.children)
   }
   return ''
+}
+
+type MarkdownHeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+
+function markdownCodeBlock(children: ReactNode): { code: string; languageName?: string } | null {
+  const child = Array.isArray(children) && children.length === 1 ? children[0] : children
+  if (!isValidElement<{ children?: ReactNode; className?: string }>(child)) return null
+  const code = markdownHeadingText(child.props.children)
+  const match = /(?:^|\s)language-([^\s]+)/u.exec(child.props.className ?? '')
+  return { code, languageName: match?.[1] }
 }
 
 function markdownHeadingSlug(value: string): string {
@@ -90,7 +102,9 @@ export function SafeMarkdown({
   headingTarget,
   onHeadingTargetResult,
   leadingContent,
-  inlineLeadingContent = true
+  inlineLeadingContent = true,
+  mode = 'message',
+  theme = 'day'
 }: {
   children: string
   className?: string
@@ -101,6 +115,8 @@ export function SafeMarkdown({
   /** Trusted inline UI, never parsed from the Markdown source. */
   leadingContent?: ReactNode
   inlineLeadingContent?: boolean
+  mode?: 'message' | 'document'
+  theme?: ResolvedTheme
 }): JSX.Element {
   const rootRef = useRef<HTMLDivElement>(null)
   const callbacks = useRef({ onFileReference, onHeadingTargetResult })
@@ -124,10 +140,24 @@ export function SafeMarkdown({
   // image projection changes still invalidate it because they change the output.
   // Leading UI reads context so member/profile updates do not reparse Markdown.
   const markdown = useMemo(() => {
-    const heading = (Tag: 'h3' | 'h4') => function MarkdownHeading({ children: headingChildren }: { children?: ReactNode }) {
+    const heading = (Tag: MarkdownHeadingTag) => function MarkdownHeading({ children: headingChildren }: { children?: ReactNode }) {
       const text = markdownHeadingText(headingChildren)
       return <Tag data-markdown-heading={text}>{headingChildren}</Tag>
     }
+    const headingComponents = mode === 'document'
+      ? {
+          h1: heading('h1'),
+          h2: heading('h2'),
+          h3: heading('h3'),
+          h4: heading('h4'),
+          h5: heading('h5'),
+          h6: heading('h6')
+        }
+      : {
+          h1: heading('h3'),
+          h2: heading('h3'),
+          h3: heading('h4')
+        }
     return (
       <Markdown
         remarkPlugins={[
@@ -143,6 +173,7 @@ export function SafeMarkdown({
         ]}
         unwrapDisallowed
         components={{
+          ...headingComponents,
           p({ node, children: paragraphChildren }) {
             const leading = node?.properties['data-rovai-leading-content'] === 'true'
             return (
@@ -153,9 +184,17 @@ export function SafeMarkdown({
               </p>
             )
           },
-          h1: heading('h3'),
-          h2: heading('h3'),
-          h3: heading('h4'),
+          ...(mode === 'document' ? {
+            pre({ children: preChildren }) {
+              const block = markdownCodeBlock(preChildren)
+              return block
+                ? <MarkdownCodeBlock code={block.code} languageName={block.languageName} theme={theme} />
+                : <pre>{preChildren}</pre>
+            },
+            table({ children: tableChildren }) {
+              return <div className="markdown-table-scroll"><table>{tableChildren}</table></div>
+            }
+          } : {}),
           a({ href, children: linkChildren }) {
             if (href?.startsWith(FILE_REFERENCE_FRAGMENT) && fileReferencesEnabled) {
               let rawReference: string
@@ -219,11 +258,18 @@ export function SafeMarkdown({
         {children}
       </Markdown>
     )
-  }, [children, fileReferencesEnabled, localImageUrl, hasLeadingContent, inlineLeadingContent])
+  }, [children, fileReferencesEnabled, localImageUrl, hasLeadingContent, inlineLeadingContent, mode, theme])
 
   return (
     <LeadingMarkdownContentContext.Provider value={leadingContent}>
-      <div ref={rootRef} className={className ? `safe-markdown ${className}` : 'safe-markdown'}>
+      <div
+        ref={rootRef}
+        className={[
+          'safe-markdown',
+          mode === 'document' ? 'is-document' : '',
+          className ?? ''
+        ].filter(Boolean).join(' ')}
+      >
         {markdown}
       </div>
     </LeadingMarkdownContentContext.Provider>

--- a/apps/desktop/src/renderer/src/source-preview.test.ts
+++ b/apps/desktop/src/renderer/src/source-preview.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  highlightSourceCode,
+  loadSourceLanguageForName,
+  sourceCodeMirrorTheme,
+  sourceLanguageForFilename,
+  sourceLanguageForName,
+  sourceLineNumber,
+  sourceTargetLocalLines
+} from './source-preview'
+
+describe('source preview languages', () => {
+  it('matches filenames and fenced language names through CodeMirror language-data', () => {
+    expect(sourceLanguageForFilename('Component.tsx')?.name).toBe('TSX')
+    expect(sourceLanguageForFilename('main.rs')?.name).toBe('Rust')
+    expect(sourceLanguageForFilename('script.py')?.name).toBe('Python')
+    expect(sourceLanguageForFilename('notes.unknownrovai')).toBeNull()
+    expect(sourceLanguageForName('tsx')?.name).toBe('TSX')
+    expect(sourceLanguageForName('madeup')).toBeNull()
+  })
+
+  it('produces static syntax spans without changing the source text', async () => {
+    const language = await loadSourceLanguageForName('tsx')
+    expect(language).not.toBeNull()
+    if (!language) return
+
+    const code = 'const App = () => <main>{value}</main>\n'
+    const highlighted = highlightSourceCode(code, language, 'night')
+
+    expect(highlighted.map((segment) => segment.text).join('')).toBe(code)
+    expect(highlighted.some((segment) => Boolean(segment.className))).toBe(true)
+  })
+})
+
+describe('source preview real line coordinates', () => {
+  it('keeps paged line numbers and clips a target range to loaded content', () => {
+    expect(sourceLineNumber(95, 1)).toBe('95')
+    expect(sourceLineNumber(95, 8)).toBe('102')
+    expect(sourceTargetLocalLines(95, 8, { line: 100, endLine: 104 })).toEqual({ from: 6, to: 8 })
+    expect(sourceTargetLocalLines(95, 8, { line: 20, endLine: 30 })).toBeNull()
+  })
+
+  it('maps the resolved Rovai theme directly to the CodeMirror base theme', () => {
+    expect(sourceCodeMirrorTheme('day')).toBe('light')
+    expect(sourceCodeMirrorTheme('night')).toBe('dark')
+  })
+})

--- a/apps/desktop/src/renderer/src/source-preview.ts
+++ b/apps/desktop/src/renderer/src/source-preview.ts
@@ -1,0 +1,287 @@
+import {
+  defaultHighlightStyle,
+  LanguageDescription,
+  syntaxHighlighting,
+  type HighlightStyle,
+  type LanguageSupport
+} from '@codemirror/language'
+import { languages } from '@codemirror/language-data'
+import { search, searchKeymap } from '@codemirror/search'
+import { EditorState, StateField, type Extension } from '@codemirror/state'
+import { Decoration, EditorView, keymap, lineNumbers, type DecorationSet } from '@codemirror/view'
+import { highlightCode } from '@lezer/highlight'
+import { oneDarkHighlightStyle } from '@uiw/react-codemirror'
+import { StyleModule } from 'style-mod'
+import type { FileLocationTarget, ResolvedTheme } from '@contracts'
+
+const SOURCE_FONT_FAMILY = [
+  'ui-monospace',
+  'SFMono-Regular',
+  'Menlo',
+  'Monaco',
+  'Consolas',
+  '"Liberation Mono"',
+  '"PingFang SC"',
+  '"Microsoft YaHei"',
+  'monospace'
+].join(', ')
+
+const languageLoads = new WeakMap<LanguageDescription, Promise<LanguageSupport | null>>()
+
+const sourceReaderInterface = {
+  '&': {
+    height: '100%',
+    color: 'var(--ink)',
+    backgroundColor: 'var(--conversation-surface)'
+  },
+  '&.cm-focused': {
+    outline: '2px solid var(--focus)',
+    outlineOffset: '-2px'
+  },
+  '.cm-scroller': {
+    overflow: 'auto',
+    overflowAnchor: 'none',
+    overscrollBehavior: 'contain',
+    backgroundColor: 'var(--conversation-surface)',
+    fontFamily: SOURCE_FONT_FAMILY,
+    fontSize: '14px',
+    fontWeight: '400',
+    lineHeight: '1.6'
+  },
+  '.cm-content': {
+    minWidth: 'max-content',
+    padding: '14px 0 28px',
+    caretColor: 'var(--focus)'
+  },
+  '.cm-line': {
+    padding: '0 18px 0 12px'
+  },
+  '.cm-gutters': {
+    borderRight: '1px solid var(--line)',
+    color: 'var(--faint)',
+    backgroundColor: 'var(--conversation-surface)'
+  },
+  '.cm-lineNumbers .cm-gutterElement': {
+    minWidth: '52px',
+    padding: '0 10px 0 8px'
+  },
+  '.cm-content ::selection': {
+    color: 'inherit',
+    backgroundColor: 'var(--focus-soft)'
+  },
+  '.cm-selectionBackground, &.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground': {
+    backgroundColor: 'var(--focus-soft) !important'
+  },
+  '.cm-searchMatch': {
+    color: 'inherit',
+    backgroundColor: 'var(--conversation-find-match)',
+    outline: 'none'
+  },
+  '.cm-searchMatch.cm-searchMatch-selected': {
+    backgroundColor: 'var(--conversation-find-current)',
+    boxShadow: 'inset 0 -1px var(--conversation-find-line)'
+  },
+  '.cm-location-target': {
+    backgroundColor: 'var(--info-soft)',
+    boxShadow: 'inset 2px 0 var(--info)'
+  },
+  '.cm-panels': {
+    color: 'var(--muted)',
+    backgroundColor: 'var(--surface-raised)'
+  },
+  '.cm-panels.cm-panels-top': {
+    borderBottom: '1px solid var(--line-strong)'
+  },
+  '.cm-panel.cm-search': {
+    padding: '7px 34px 7px 10px',
+    fontFamily: '-apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif',
+    fontSize: '11px',
+    lineHeight: '1.4'
+  },
+  '.cm-panel.cm-search input': {
+    height: '27px',
+    padding: '0 7px',
+    border: '1px solid var(--control-line)',
+    borderRadius: '5px',
+    color: 'var(--ink)',
+    backgroundColor: 'var(--input)'
+  },
+  '.cm-panel.cm-search input:focus-visible': {
+    outline: '2px solid var(--focus)',
+    outlineOffset: '1px'
+  },
+  '.cm-panel.cm-search button': {
+    minHeight: '27px',
+    padding: '0 7px',
+    border: '1px solid var(--line)',
+    borderRadius: '5px',
+    color: 'var(--muted)',
+    backgroundColor: 'var(--surface-subtle)',
+    backgroundImage: 'none',
+    fontSize: '11px'
+  },
+  '.cm-panel.cm-search button:hover': {
+    color: 'var(--ink)',
+    backgroundColor: 'var(--surface-hover)'
+  },
+  '.cm-panel.cm-search [name=close]': {
+    top: '7px',
+    right: '8px',
+    border: '0',
+    backgroundColor: 'transparent'
+  },
+  '.cm-panel.cm-search label': {
+    color: 'var(--faint)',
+    fontSize: '10px'
+  }
+} as const
+
+const sourceReaderThemes: Record<ResolvedTheme, Extension> = {
+  day: EditorView.theme(sourceReaderInterface, { dark: false }),
+  night: EditorView.theme(sourceReaderInterface, { dark: true })
+}
+
+const targetLineDecoration = Decoration.line({
+  class: 'cm-location-target',
+  attributes: { 'data-file-location-target': 'true' }
+})
+
+function loadLanguage(description: LanguageDescription | null): Promise<LanguageSupport | null> {
+  if (!description) return Promise.resolve(null)
+  const existing = languageLoads.get(description)
+  if (existing) return existing
+  const pending = description.load().catch(() => null)
+  languageLoads.set(description, pending)
+  return pending
+}
+
+export function sourceLanguageForFilename(filename: string): LanguageDescription | null {
+  return LanguageDescription.matchFilename(languages, filename)
+}
+
+export function sourceLanguageForName(languageName: string): LanguageDescription | null {
+  return LanguageDescription.matchLanguageName(languages, languageName)
+}
+
+export function loadSourceLanguageForFilename(filename: string): Promise<LanguageSupport | null> {
+  return loadLanguage(sourceLanguageForFilename(filename))
+}
+
+export function loadSourceLanguageForName(languageName: string): Promise<LanguageSupport | null> {
+  return loadLanguage(sourceLanguageForName(languageName))
+}
+
+export function sourceSyntaxHighlightStyle(theme: ResolvedTheme): HighlightStyle {
+  return theme === 'night' ? oneDarkHighlightStyle : defaultHighlightStyle
+}
+
+export function sourceCodeMirrorTheme(theme: ResolvedTheme): 'light' | 'dark' {
+  return theme === 'night' ? 'dark' : 'light'
+}
+
+export function mountSourceSyntaxHighlightStyle(theme: ResolvedTheme, root: Document | ShadowRoot): void {
+  const module = sourceSyntaxHighlightStyle(theme).module
+  if (module) StyleModule.mount(root, module)
+}
+
+export function sourceLineNumber(startLine: number, localLine: number): string {
+  return String(Math.max(1, Math.trunc(startLine)) + localLine - 1)
+}
+
+export function sourceTargetLocalLines(
+  startLine: number,
+  lineCount: number,
+  target?: FileLocationTarget
+): { from: number; to: number } | null {
+  if (!target?.line || target.line < 1 || lineCount < 1) return null
+  const pageStart = Math.max(1, Math.trunc(startLine))
+  const targetStart = Math.trunc(target.line)
+  const targetEnd = Math.max(targetStart, Math.trunc(target.endLine ?? targetStart))
+  const from = Math.max(1, targetStart - pageStart + 1)
+  const to = Math.min(lineCount, targetEnd - pageStart + 1)
+  return from <= to ? { from, to } : null
+}
+
+function sourceTargetExtension(startLine: number, target?: FileLocationTarget): Extension {
+  const decorations = (state: EditorState): DecorationSet => {
+    const local = sourceTargetLocalLines(startLine, state.doc.lines, target)
+    if (!local) return Decoration.none
+    const ranges = []
+    for (let line = local.from; line <= local.to; line += 1) {
+      ranges.push(targetLineDecoration.range(state.doc.line(line).from))
+    }
+    return Decoration.set(ranges)
+  }
+
+  return StateField.define<DecorationSet>({
+    create: decorations,
+    update: (value, transaction) => (transaction.docChanged ? decorations(transaction.state) : value),
+    provide: (field) => EditorView.decorations.from(field)
+  })
+}
+
+export function sourceReaderExtensions({
+  ariaLabel,
+  language,
+  startLine,
+  target,
+  theme
+}: {
+  ariaLabel: string
+  language: LanguageSupport | null
+  startLine: number
+  target?: FileLocationTarget
+  theme: ResolvedTheme
+}): Extension[] {
+  return [
+    lineNumbers({ formatNumber: (line) => sourceLineNumber(startLine, line) }),
+    search({ top: true }),
+    keymap.of(searchKeymap),
+    EditorState.tabSize.of(2),
+    EditorState.phrases.of({
+      Find: '查找',
+      next: '下一个',
+      previous: '上一个',
+      all: '全部',
+      'match case': '区分大小写',
+      regexp: '正则表达式',
+      'by word': '全字匹配',
+      close: '关闭',
+      'current match': '当前匹配',
+      'on line': '位于行'
+    }),
+    EditorView.contentAttributes.of({
+      'aria-label': ariaLabel,
+      tabindex: '0'
+    }),
+    sourceReaderThemes[theme],
+    syntaxHighlighting(sourceSyntaxHighlightStyle(theme), { fallback: true }),
+    sourceTargetExtension(startLine, target),
+    ...(language ? [language] : [])
+  ]
+}
+
+export interface HighlightedSourceSegment {
+  text: string
+  className?: string
+}
+
+export function highlightSourceCode(
+  code: string,
+  language: LanguageSupport,
+  theme: ResolvedTheme
+): HighlightedSourceSegment[] {
+  const segments: HighlightedSourceSegment[] = []
+  try {
+    highlightCode(
+      code,
+      language.language.parser.parse(code),
+      sourceSyntaxHighlightStyle(theme),
+      (text, className) => segments.push(className ? { text, className } : { text }),
+      () => segments.push({ text: '\n' })
+    )
+  } catch {
+    return [{ text: code }]
+  }
+  return segments.length > 0 ? segments : [{ text: code }]
+}

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -2068,8 +2068,8 @@ html.file-preview-resizing .file-preview-pane { pointer-events: none; }
   box-shadow: var(--shadow-menu);
   font-size: 10px;
 }
-.file-preview-markdown { width: 100%; overflow: auto; overscroll-behavior: contain; padding: 26px clamp(24px, 6vw, 68px) 54px; }
-.file-preview-markdown .safe-markdown { max-width: 780px; margin: 0 auto; font-size: 13px; line-height: 1.72; }
+.file-preview-markdown { width: 100%; overflow: auto; overscroll-behavior: contain; padding: 28px clamp(18px, 5cqi, 52px) 54px; }
+.file-preview-markdown .safe-markdown { max-width: 780px; margin: 0 auto; }
 .file-preview-markdown .safe-markdown img { display: block; max-width: 100%; height: auto; margin: 18px auto; border-radius: 7px; box-shadow: var(--shadow-card); }
 .safe-markdown .markdown-file-reference,
 .safe-markdown .markdown-web-reference,
@@ -2253,48 +2253,17 @@ html.file-preview-resizing .file-preview-pane { pointer-events: none; }
 .file-preview-patch-line.is-deletion { background: color-mix(in srgb, var(--diff-remove) 10%, transparent); }
 .file-preview-patch-line.is-metadata { color: var(--faint); }
 .file-preview-code {
+  display: flex;
   width: 100%;
   min-width: 0;
   min-height: 0;
-  overflow: auto;
-  overscroll-behavior: contain;
-  padding: 8px 0 26px;
+  overflow: hidden;
   color: var(--ink);
   background: var(--conversation-surface);
-  font: 500 10.5px/1.58 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  tab-size: 2;
 }
-.file-preview-search {
-  position: absolute;
-  z-index: 20;
-  top: 8px;
-  right: 10px;
-  display: grid;
-  min-width: 292px;
-  min-height: 32px;
-  grid-template-columns: minmax(110px, 1fr) 50px 27px 27px 27px;
-  align-items: center;
-  overflow: hidden;
-  border: 1px solid var(--line-strong);
-  border-radius: 7px;
-  color: var(--muted);
-  background: var(--surface-raised);
-  box-shadow: var(--shadow-menu);
-}
-.file-preview-search input { min-width: 0; height: 30px; padding: 0 8px; border: 0; outline: 0; color: var(--ink); background: transparent; font-size: 10.5px; }
-.file-preview-search > span { padding: 0 5px; color: var(--faint); font-size: 9px; text-align: right; white-space: nowrap; }
-.file-preview-search button { display: grid; width: 27px; height: 27px; padding: 0; place-items: center; border: 0; border-radius: 4px; color: var(--muted); background: transparent; cursor: pointer; }
-.file-preview-search button:hover:not(:disabled) { color: var(--ink); background: var(--surface-hover); }
-.file-preview-search button:disabled { opacity: .36; }
+.file-preview-code-mirror { min-width: 0; min-height: 0; flex: 1 1 auto; }
+.file-preview-code-mirror > .cm-editor { height: 100%; }
 .file-preview-code:focus-visible { outline: 2px solid var(--focus); outline-offset: -2px; }
-.file-preview-code-line { display: grid; min-width: max-content; width: 100%; grid-template-columns: 48px minmax(max-content, 1fr); }
-.file-preview-code-line > span { padding-right: 10px; color: var(--faint); text-align: right; user-select: none; }
-.file-preview-code-line code { display: block; padding: 0 16px 0 10px; white-space: pre; }
-.file-preview-code-line mark { color: var(--ink); background: var(--attention-soft); outline: 1px solid var(--attention); }
-.file-preview-code-line.is-addition { background: color-mix(in srgb, var(--diff-add) 10%, transparent); }
-.file-preview-code-line.is-deletion { background: color-mix(in srgb, var(--diff-remove) 10%, transparent); }
-.file-preview-code-line.is-hunk { color: var(--info); background: var(--info-soft); }
-.file-preview-code-line.is-location-target { background: var(--info-soft); box-shadow: inset 2px 0 var(--info); }
 .file-preview-page-controls {
   display: flex;
   min-height: 36px;
@@ -2313,7 +2282,6 @@ html.file-preview-resizing .file-preview-pane { pointer-events: none; }
 .file-preview-page-controls button:disabled { cursor: default; opacity: .42; }
 
 @container camp-shell (max-width: 1329px) {
-  .file-preview-markdown { padding-inline: 24px; }
   .file-preview-patch { grid-template-columns: minmax(0, 1fr); }
   .file-preview-patch-outline { display: none; }
   .context-project, .context-sep { display: none; }
@@ -3354,6 +3322,30 @@ button.camp-world-map-live-caption { cursor: pointer; font: inherit; }
 .safe-markdown th { background: var(--surface-muted); font-weight: 700; }
 .safe-markdown a { color: var(--resource-link); text-decoration: underline; text-underline-offset: 2px; }
 .safe-markdown a:hover { color: var(--resource-link-hover); }
+.safe-markdown.is-document { font-size: 15px; line-height: 1.7; }
+.safe-markdown.is-document p { margin: 0 0 14px; }
+.safe-markdown.is-document h1,
+.safe-markdown.is-document h2,
+.safe-markdown.is-document h3,
+.safe-markdown.is-document h4,
+.safe-markdown.is-document h5,
+.safe-markdown.is-document h6 { color: var(--ink); font-weight: 680; }
+.safe-markdown.is-document h1 { margin: 0 0 19px; font-size: 26px; line-height: 1.24; }
+.safe-markdown.is-document h2 { margin: 34px 0 14px; font-size: 21px; line-height: 1.3; }
+.safe-markdown.is-document h3 { margin: 27px 0 11px; font-size: 17px; line-height: 1.38; }
+.safe-markdown.is-document h4 { margin: 22px 0 9px; font-size: 15px; line-height: 1.42; }
+.safe-markdown.is-document h5 { margin: 19px 0 8px; font-size: 14px; line-height: 1.45; }
+.safe-markdown.is-document h6 { margin: 17px 0 7px; color: var(--muted); font-size: 13px; line-height: 1.45; }
+.safe-markdown.is-document ul,
+.safe-markdown.is-document ol { margin: 9px 0 16px; padding-left: 24px; }
+.safe-markdown.is-document li + li { margin-top: 4px; }
+.safe-markdown.is-document blockquote { margin: 15px 0 17px; padding: 5px 13px; }
+.safe-markdown.is-document pre { margin: 16px 0 19px; padding: 13px 14px; font-size: 13px; line-height: 1.65; }
+.safe-markdown.is-document .markdown-table-scroll { max-width: 100%; margin: 17px 0 20px; overflow-x: auto; overscroll-behavior: contain; }
+.safe-markdown.is-document .markdown-table-scroll > table { display: table; width: max-content; min-width: 100%; margin: 0; overflow: visible; font-size: 14px; line-height: 1.55; }
+.safe-markdown.is-document th,
+.safe-markdown.is-document td { padding: 8px 10px; overflow-wrap: normal; word-break: normal; }
+.safe-markdown.is-document hr { margin: 28px 0; border: 0; border-top: 1px solid var(--line); }
 .markdown-inert-link { cursor: text; }
 .message-actions {
   display: flex;

--- a/docs/ui/components/file-preview.md
+++ b/docs/ui/components/file-preview.md
@@ -158,11 +158,27 @@ Renderer 不自行猜测。
 
 Viewer 不显示预览/源码切换、右上角复制按钮、整行工具栏或 `Ready` 状态。每个类型只有一个规范阅读视图：
 
-- Markdown 渲染安全 GFM；行内 code 与围栏代码块复用 Camp 工作区的 Mist Gray 分层，超出 4 MiB 显示分页原文；
+- Markdown 继续通过 `SafeMarkdown` 渲染安全 GFM，并在文件预览中显式使用 document 模式；超出 4 MiB 显示分页原文；
 - HTML 在 sandbox iframe 中执行；超限或初始化失败回退只读原文；
-- 代码/文本只读显示行号、搜索、定位、选择与系统复制，大文件分页；
+- 代码/文本通过同一个只读 CodeMirror 6 Viewer 显示行号、搜索、定位、选择与系统复制，大文件分页；
 - 图片/SVG 提供适应、原始尺寸、缩放和重置，不把 SVG 注入宿主 DOM；
 - Diff/Patch 按文件和 hunk 展示，解析失败回退文本。
+
+代码 Viewer 固定使用 14px、400 字重、1.6 行高的系统等宽字体栈和 14px 顶部留白，长行在 Viewer 内横向滚动。
+`readOnly` 与 `editable=false` 禁止修改，但不移除焦点、文本选择、无行号复制和 `Cmd/Ctrl+F`；查找只使用
+CodeMirror 自带面板，不再维护第二套文件搜索 UI。真实文件行号按当前分页起始行投影，行目标与行范围使用低强调
+底色和左侧细线，并在首次内容与语言状态稳定后进入可见区域。应用把已解析的日间/夜间状态直接映射为
+`theme="light"` / `theme="dark"`；主题切换重配现有 Editor，并保留顶部可见源码行，不重建 Viewer。
+
+源码语言只通过 `@codemirror/language-data` 的 `LanguageDescription.matchFilename` 按文件名匹配，并调用该描述的
+`load()` 按需加载；Renderer 不维护扩展名白名单。语言加载前继续显示完整纯文本，未知语言或加载失败也保持纯文本，
+不会为高亮重复读取文件。语言解析与基础明暗语法配色同时进入 Viewer；一处 `EditorView.theme` 只覆盖 Rovai
+surface、行号、选区、搜索匹配与目标行等界面样式，不另建 token 调色板。
+
+Markdown document 模式保留 H1–H6 的真实语义与层级；正文为 15px/1.7，H1、H2、H3 分别为 26px、21px、17px，
+其余标题逐级收敛。该模式只用于文件预览，原有消息调用和聊天排版不变。围栏代码块按语言标记复用同一 language-data
+加载器与基础明暗语法配色，直接输出静态高亮 span；每个代码块不创建 CodeMirror 实例，未知、无标记或加载失败时
+保留纯文本。表格使用接近正文的 14px 字号；宽表格由自身滚动容器承接水平滚动，不缩小文字或扩大整个页面。
 
 Viewer 底色与会话阅读区共用语义 surface。选中文字只保留普通系统选择/复制行为，不出现“附加到会话”浮层，
 也不向 Composer 添加引用卡片；引用能力留待后续整体设计。

--- a/package.json
+++ b/package.json
@@ -139,21 +139,29 @@
     "verify:windows": "node scripts/verify-windows-release.mjs"
   },
   "dependencies": {
+    "@codemirror/language": "6.12.4",
+    "@codemirror/language-data": "6.5.2",
+    "@codemirror/search": "6.7.2",
+    "@codemirror/state": "6.7.4",
+    "@codemirror/view": "6.43.11",
     "@larksuiteoapi/node-sdk": "1.73.0",
     "@lexical/extension": "0.50.0",
     "@lexical/history": "0.50.0",
     "@lexical/plain-text": "0.50.0",
     "@lexical/react": "0.50.0",
+    "@lezer/highlight": "1.2.3",
     "@radix-ui/react-dialog": "1.1.19",
     "@radix-ui/react-dropdown-menu": "2.1.20",
     "@radix-ui/react-tabs": "1.1.17",
+    "@uiw/react-codemirror": "4.25.11",
     "dingtalk-stream": "2.1.6-beta.1",
     "electron-updater": "6.8.9",
     "lexical": "0.50.0",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "style-mod": "4.1.3"
   },
   "devDependencies": {
     "@types/node": "26.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,21 @@ importers:
 
   .:
     dependencies:
+      '@codemirror/language':
+        specifier: 6.12.4
+        version: 6.12.4
+      '@codemirror/language-data':
+        specifier: 6.5.2
+        version: 6.5.2
+      '@codemirror/search':
+        specifier: 6.7.2
+        version: 6.7.2
+      '@codemirror/state':
+        specifier: 6.7.4
+        version: 6.7.4
+      '@codemirror/view':
+        specifier: 6.43.11
+        version: 6.43.11
       '@larksuiteoapi/node-sdk':
         specifier: 1.73.0
         version: 1.73.0(patch_hash=97c95bd39991d6d592e6a57dc9b0f79e52f8c5a5022326c139a8745acd138af8)(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
@@ -26,6 +41,9 @@ importers:
       '@lexical/react':
         specifier: 0.50.0
         version: 0.50.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(yjs@13.6.32)
+      '@lezer/highlight':
+        specifier: 1.2.3
+        version: 1.2.3
       '@radix-ui/react-dialog':
         specifier: 1.1.19
         version: 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -35,6 +53,9 @@ importers:
       '@radix-ui/react-tabs':
         specifier: 1.1.17
         version: 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@uiw/react-codemirror':
+        specifier: 4.25.11
+        version: 4.25.11(@babel/runtime@8.0.0)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.2)(@codemirror/state@6.7.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.11)(codemirror@6.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       dingtalk-stream:
         specifier: 2.1.6-beta.1
         version: 2.1.6-beta.1(supports-color@7.2.0)
@@ -56,6 +77,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1(supports-color@7.2.0)
+      style-mod:
+        specifier: 4.1.3
+        version: 4.1.3
     devDependencies:
       '@types/node':
         specifier: 26.1.1
@@ -186,6 +210,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/runtime@8.0.0':
+    resolution: {integrity: sha512-sL6cvO2IfkSu/iU+zs2S/w01B7A8V7suXSIKEN4hPFFdZoiPGxrj5pAG0lCaqLWiEIrjKzdznIWuaLcxPR53qw==}
+
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
@@ -197,6 +224,99 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@codemirror/autocomplete@6.20.3':
+    resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
+
+  '@codemirror/commands@6.11.0':
+    resolution: {integrity: sha512-/K4Rl5BN0OtTiPWmJCdqODu38XnDMsDxKY5rgrPnCkutPTJf2wVbkoixLfealF5Kwse/s8P8M5jAiURiwSwnFA==}
+
+  '@codemirror/lang-angular@0.1.4':
+    resolution: {integrity: sha512-oap+gsltb/fzdlTQWD6BFF4bSLKcDnlxDsLdePiJpCVNKWXSTAbiiQeYI3UmES+BLAdkmIC1WjyztC1pi/bX4g==}
+
+  '@codemirror/lang-cpp@6.0.3':
+    resolution: {integrity: sha512-URM26M3vunFFn9/sm6rzqrBzDgfWuDixp85uTY49wKudToc2jTHUrKIGGKs+QWND+YLofNNZpxcNGRynFJfvgA==}
+
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-go@6.0.1':
+    resolution: {integrity: sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg==}
+
+  '@codemirror/lang-html@6.4.12':
+    resolution: {integrity: sha512-pw2ReWKUqSkbvh76RAT4NYxiogRu+PWkR2ukAwO9uOgrm8uipkzjtKKtNpyeAQwHOqxEeSvAXZ6vr3AfyB9y/w==}
+
+  '@codemirror/lang-java@6.0.2':
+    resolution: {integrity: sha512-m5Nt1mQ/cznJY7tMfQTJchmrjdjQ71IDs+55d1GAa8DGaB8JXWsVCkVT284C3RTASaY43YknrK2X3hPO/J3MOQ==}
+
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/lang-jinja@6.0.1':
+    resolution: {integrity: sha512-P5kyHLObzjtbGj16h+hyvZTxJhSjBEeSx4wMjbnAf3b0uwTy2+F0zGjMZL4PQOm/mh2eGZ5xUDVZXgwP783Nsw==}
+
+  '@codemirror/lang-json@6.0.2':
+    resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
+
+  '@codemirror/lang-less@6.0.2':
+    resolution: {integrity: sha512-EYdQTG22V+KUUk8Qq582g7FMnCZeEHsyuOJisHRft/mQ+ZSZ2w51NupvDUHiqtsOy7It5cHLPGfHQLpMh9bqpQ==}
+
+  '@codemirror/lang-liquid@6.3.2':
+    resolution: {integrity: sha512-6PDVU3ZnfeYyz1at1E/ttorErZvZFXXt1OPhtfe1EZJ2V2iDFa0CwPqPgG5F7NXN0yONGoBogKmFAafKTqlwIw==}
+
+  '@codemirror/lang-markdown@6.5.2':
+    resolution: {integrity: sha512-AwBOdkWYuA//WcM0xO5PfHPUcmz/O2i5o0Nsg1U69SII/loCJlFI1Romd9xp2HYb1kYJRGZotyqRghuHH5n8Kw==}
+
+  '@codemirror/lang-php@6.0.2':
+    resolution: {integrity: sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA==}
+
+  '@codemirror/lang-python@6.2.1':
+    resolution: {integrity: sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==}
+
+  '@codemirror/lang-rust@6.0.2':
+    resolution: {integrity: sha512-EZaGjCUegtiU7kSMvOfEZpaCReowEf3yNidYu7+vfuGTm9ow4mthAparY5hisJqOHmJowVH3Upu+eJlUji6qqA==}
+
+  '@codemirror/lang-sass@6.0.2':
+    resolution: {integrity: sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q==}
+
+  '@codemirror/lang-sql@6.10.0':
+    resolution: {integrity: sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==}
+
+  '@codemirror/lang-vue@0.1.3':
+    resolution: {integrity: sha512-QSKdtYTDRhEHCfo5zOShzxCmqKJvgGrZwDQSdbvCRJ5pRLWBS7pD/8e/tH44aVQT6FKm0t6RVNoSUWHOI5vNug==}
+
+  '@codemirror/lang-wast@6.0.2':
+    resolution: {integrity: sha512-Imi2KTpVGm7TKuUkqyJ5NRmeFWF7aMpNiwHnLQe0x9kmrxElndyH0K6H/gXtWwY6UshMRAhpENsgfpSwsgmC6Q==}
+
+  '@codemirror/lang-xml@6.1.0':
+    resolution: {integrity: sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==}
+
+  '@codemirror/lang-yaml@6.1.3':
+    resolution: {integrity: sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==}
+
+  '@codemirror/language-data@6.5.2':
+    resolution: {integrity: sha512-CPkWBKrNS8stYbEU5kwBwTf3JB1kghlbh4FSAwzGW2TEscdeHHH4FGysREW86Mqnj3Qn09s0/6Ea/TutmoTobg==}
+
+  '@codemirror/language@6.12.4':
+    resolution: {integrity: sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==}
+
+  '@codemirror/legacy-modes@6.5.4':
+    resolution: {integrity: sha512-/cZr6qZyl08iYNLGsJ862CXXNI51LryRFRE40ejgoIjXZz0C1rGkD3/Ek5jM/8w1ceRjqtt4qx/KLMh4zBTgew==}
+
+  '@codemirror/lint@6.9.7':
+    resolution: {integrity: sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==}
+
+  '@codemirror/search@6.7.2':
+    resolution: {integrity: sha512-gUYkYhT2+n/+VGZ+8EzE5WFkYZUZYm1VOKDudIsNqh42uRVQJ0a6Yss9sdKT3MeOYfuL1N6AZA57oza0Oyr0LA==}
+
+  '@codemirror/state@6.7.4':
+    resolution: {integrity: sha512-QhQIVRY+xHZDxwOSFrJ1eUMapJBUID3IdeAjf7dHO7zBUzSkyooHiodnalz5MG3iHzwixKMlAAyn7244y537EA==}
+
+  '@codemirror/theme-one-dark@6.1.3':
+    resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
+
+  '@codemirror/view@6.43.11':
+    resolution: {integrity: sha512-2+esucbQX6wB2JYi1eDvdCPFTA31BN8oSy6xCmk3G6CloV11yOvEjYk+gH7kLrP0MuHG94E8WDhjs5oMiu3+Wg==}
 
   '@electron-internal/extract-zip@1.0.4':
     resolution: {integrity: sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==}
@@ -790,6 +910,57 @@ packages:
       typescript:
         optional: true
 
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/cpp@1.1.6':
+    resolution: {integrity: sha512-vh9gWWJOXFVY8HBHK3Twzq8MgwG2iN4GSyzBP9sCGTe37P15x2R14VaBQk0VA0ezTRN1KHYBBsHhvpGZ2Xy/pA==}
+
+  '@lezer/css@1.3.6':
+    resolution: {integrity: sha512-YJE78Wcg+zX8f10hiHWQ4Az48Qr/c13eId0VtRQYLBpxHDmDeSrXIlkbl+fJGW42rWC/uoUco9mhBZeVWP/A1g==}
+
+  '@lezer/go@1.0.1':
+    resolution: {integrity: sha512-xToRsYxwsgJNHTgNdStpcvmbVuKxTapV0dM0wey1geMMRc9aggoVyKgzYp41D2/vVOx+Ii4hmE206kvxIXBVXQ==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
+
+  '@lezer/java@1.1.3':
+    resolution: {integrity: sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/json@1.0.3':
+    resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
+  '@lezer/markdown@1.7.2':
+    resolution: {integrity: sha512-iTkYvoVcKt3WkeL7qUDyXHONZEwLio4wj8KTNi2dnjQEXBZKMV63BpQrPqfsM+OkvuRbiSTAcycYAsQzLhRNoQ==}
+
+  '@lezer/php@1.0.6':
+    resolution: {integrity: sha512-QJ2xNXPmsm/Z3IpThq8fnJrEIVpxhsIoj6GZBW0JYEd/l9zxpJZW216X4fzqQY4vgpdGIumypvI4uQjd4tnYtw==}
+
+  '@lezer/python@1.1.19':
+    resolution: {integrity: sha512-MhQIURHRytsNzP/YXnqpYKW6la6voAH3kyplTOOiCdjyFY6cWWGFVmYVdHIPrElqSDf4iCDktQCockB9FxuhzQ==}
+
+  '@lezer/rust@1.0.2':
+    resolution: {integrity: sha512-Lz5sIPBdF2FUXcWeCu1//ojFAZqzTQNRga0aYv6dYXqJqPfMdCAI0NzajWUd4Xijj1IKJLtjoXRPMvTKWBcqKg==}
+
+  '@lezer/sass@1.1.0':
+    resolution: {integrity: sha512-3mMGdCTUZ/84ArHOuXWQr37pnf7f+Nw9ycPUeKX+wu19b7pSMcZGLbaXwvD2APMBDOGxPmpK/O6S1v1EvLoqgQ==}
+
+  '@lezer/xml@1.0.6':
+    resolution: {integrity: sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==}
+
+  '@lezer/yaml@1.0.4':
+    resolution: {integrity: sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==}
+
   '@malept/cross-spawn-promise@1.1.1':
     resolution: {integrity: sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==}
     engines: {node: '>= 10'}
@@ -801,6 +972,9 @@ packages:
   '@malept/flatpak-bundler@0.4.0':
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
+
+  '@marijn/find-cluster-break@1.0.4':
+    resolution: {integrity: sha512-Wy0V7+SGUjnF9/TkiM1hKVDPj7jKXduPNboMVtHTA8dySMURWqfg/JZ9E2Sq8JgSJmkl7k7Qe9FLeMSrSraWmQ==}
 
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
@@ -1372,6 +1546,28 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@uiw/codemirror-extensions-basic-setup@4.25.11':
+    resolution: {integrity: sha512-otyFa+n9IOYtEjaKOxPedHkj15fTPUF21wdR9pv0GpZPfuGl27cvmcv6+tognbRu9VvEcsHKE+ESoszeo3KfTw==}
+    peerDependencies:
+      '@codemirror/autocomplete': '>=6.0.0'
+      '@codemirror/commands': '>=6.0.0'
+      '@codemirror/language': '>=6.0.0'
+      '@codemirror/lint': '>=6.0.0'
+      '@codemirror/search': '>=6.0.0'
+      '@codemirror/state': '>=6.0.0'
+      '@codemirror/view': '>=6.0.0'
+
+  '@uiw/react-codemirror@4.25.11':
+    resolution: {integrity: sha512-DYVFAKLX+F/4JS9N/7xexh+TICrlncwkX9HKKInrP1bwO0tSfc3k0GB6oawTYhelVKh20cX3TuRx+NJSkVXuMw==}
+    peerDependencies:
+      '@babel/runtime': '>=7.11.0'
+      '@codemirror/state': '>=6.0.0'
+      '@codemirror/theme-one-dark': '>=6.0.0'
+      '@codemirror/view': '>=6.0.0'
+      codemirror: '>=6.0.0'
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+
   '@ungap/structured-clone@1.3.3':
     resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
 
@@ -1603,6 +1799,9 @@ packages:
   clone-response@1.0.3:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
 
+  codemirror@6.0.2:
+    resolution: {integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1637,6 +1836,9 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  crelt@1.0.7:
+    resolution: {integrity: sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==}
 
   cross-dirname@0.1.0:
     resolution: {integrity: sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==}
@@ -2728,6 +2930,9 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
@@ -2967,6 +3172,9 @@ packages:
       jsdom:
         optional: true
 
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
   webcrypto-core@1.9.2:
     resolution: {integrity: sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==}
 
@@ -3147,6 +3355,8 @@ snapshots:
       '@babel/core': 7.29.7(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/runtime@8.0.0': {}
+
   '@babel/template@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -3169,6 +3379,264 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@codemirror/autocomplete@6.20.3':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+      '@lezer/common': 1.5.2
+
+  '@codemirror/commands@6.11.0':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-angular@0.1.4':
+    dependencies:
+      '@codemirror/lang-html': 6.4.12
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.4
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-cpp@6.0.3':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@lezer/cpp': 1.1.6
+
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.4
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.6
+
+  '@codemirror/lang-go@6.0.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.4
+      '@lezer/common': 1.5.2
+      '@lezer/go': 1.0.1
+
+  '@codemirror/lang-html@6.4.12':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.6
+      '@lezer/html': 1.3.13
+
+  '@codemirror/lang-java@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@lezer/java': 1.1.3
+
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/lint': 6.9.7
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+      '@lezer/common': 1.5.2
+      '@lezer/javascript': 1.5.4
+
+  '@codemirror/lang-jinja@6.0.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-html': 6.4.12
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-json@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@lezer/json': 1.0.3
+
+  '@codemirror/lang-less@6.0.2':
+    dependencies:
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/language': 6.12.4
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-liquid@6.3.2':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-html': 6.4.12
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-markdown@6.5.2':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-html': 6.4.12
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+      '@lezer/common': 1.5.2
+      '@lezer/markdown': 1.7.2
+
+  '@codemirror/lang-php@6.0.2':
+    dependencies:
+      '@codemirror/lang-html': 6.4.12
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.4
+      '@lezer/common': 1.5.2
+      '@lezer/php': 1.0.6
+
+  '@codemirror/lang-python@6.2.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.4
+      '@lezer/common': 1.5.2
+      '@lezer/python': 1.1.19
+
+  '@codemirror/lang-rust@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@lezer/rust': 1.0.2
+
+  '@codemirror/lang-sass@6.0.2':
+    dependencies:
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.4
+      '@lezer/common': 1.5.2
+      '@lezer/sass': 1.1.0
+
+  '@codemirror/lang-sql@6.10.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.4
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-vue@0.1.3':
+    dependencies:
+      '@codemirror/lang-html': 6.4.12
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.4
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-wast@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/lang-xml@6.1.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+      '@lezer/common': 1.5.2
+      '@lezer/xml': 1.0.6
+
+  '@codemirror/lang-yaml@6.1.3':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.4
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      '@lezer/yaml': 1.0.4
+
+  '@codemirror/language-data@6.5.2':
+    dependencies:
+      '@codemirror/lang-angular': 0.1.4
+      '@codemirror/lang-cpp': 6.0.3
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-go': 6.0.1
+      '@codemirror/lang-html': 6.4.12
+      '@codemirror/lang-java': 6.0.2
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/lang-jinja': 6.0.1
+      '@codemirror/lang-json': 6.0.2
+      '@codemirror/lang-less': 6.0.2
+      '@codemirror/lang-liquid': 6.3.2
+      '@codemirror/lang-markdown': 6.5.2
+      '@codemirror/lang-php': 6.0.2
+      '@codemirror/lang-python': 6.2.1
+      '@codemirror/lang-rust': 6.0.2
+      '@codemirror/lang-sass': 6.0.2
+      '@codemirror/lang-sql': 6.10.0
+      '@codemirror/lang-vue': 0.1.3
+      '@codemirror/lang-wast': 6.0.2
+      '@codemirror/lang-xml': 6.1.0
+      '@codemirror/lang-yaml': 6.1.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/legacy-modes': 6.5.4
+
+  '@codemirror/language@6.12.4':
+    dependencies:
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/legacy-modes@6.5.4':
+    dependencies:
+      '@codemirror/language': 6.12.4
+
+  '@codemirror/lint@6.9.7':
+    dependencies:
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+      crelt: 1.0.7
+
+  '@codemirror/search@6.7.2':
+    dependencies:
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+      crelt: 1.0.7
+
+  '@codemirror/state@6.7.4':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.4
+
+  '@codemirror/theme-one-dark@6.1.3':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+      '@lezer/highlight': 1.2.3
+
+  '@codemirror/view@6.43.11':
+    dependencies:
+      '@codemirror/state': 6.7.4
+      crelt: 1.0.7
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
 
   '@electron-internal/extract-zip@1.0.4': {}
 
@@ -3715,6 +4183,99 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/cpp@1.1.6':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/css@1.3.6':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/go@1.0.1':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/html@1.3.13':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/java@1.1.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/json@1.0.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/markdown@1.7.2':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+
+  '@lezer/php@1.0.6':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/python@1.1.19':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/rust@1.0.2':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/sass@1.1.0':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/xml@1.0.6':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/yaml@1.0.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
   '@malept/cross-spawn-promise@1.1.1':
     dependencies:
       cross-spawn: 7.0.6
@@ -3731,6 +4292,8 @@ snapshots:
       tmp-promise: 3.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@marijn/find-cluster-break@1.0.4': {}
 
   '@noble/hashes@1.4.0': {}
 
@@ -4234,6 +4797,33 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@uiw/codemirror-extensions-basic-setup@4.25.11(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.11.0)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.2)(@codemirror/state@6.7.4)(@codemirror/view@6.43.11)':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/commands': 6.11.0
+      '@codemirror/language': 6.12.4
+      '@codemirror/lint': 6.9.7
+      '@codemirror/search': 6.7.2
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+
+  '@uiw/react-codemirror@4.25.11(@babel/runtime@8.0.0)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.2)(@codemirror/state@6.7.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.11)(codemirror@6.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 8.0.0
+      '@codemirror/commands': 6.11.0
+      '@codemirror/state': 6.7.4
+      '@codemirror/theme-one-dark': 6.1.3
+      '@codemirror/view': 6.43.11
+      '@uiw/codemirror-extensions-basic-setup': 4.25.11(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.11.0)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.2)(@codemirror/state@6.7.4)(@codemirror/view@6.43.11)
+      codemirror: 6.0.2
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    transitivePeerDependencies:
+      - '@codemirror/autocomplete'
+      - '@codemirror/language'
+      - '@codemirror/lint'
+      - '@codemirror/search'
+
   '@ungap/structured-clone@1.3.3': {}
 
   '@vitejs/plugin-react@5.2.0(supports-color@7.2.0)(vite@7.3.6(@types/node@26.1.1)(jiti@2.7.0)(yaml@2.9.0))':
@@ -4523,6 +5113,16 @@ snapshots:
     dependencies:
       mimic-response: 1.0.1
 
+  codemirror@6.0.2:
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/commands': 6.11.0
+      '@codemirror/language': 6.12.4
+      '@codemirror/lint': 6.9.7
+      '@codemirror/search': 6.7.2
+      '@codemirror/state': 6.7.4
+      '@codemirror/view': 6.43.11
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -4547,6 +5147,8 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   core-util-is@1.0.3: {}
+
+  crelt@1.0.7: {}
 
   cross-dirname@0.1.0:
     optional: true
@@ -6009,6 +6611,8 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
+  style-mod@4.1.3: {}
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -6214,6 +6818,8 @@ snapshots:
       '@types/node': 26.1.1
     transitivePeerDependencies:
       - msw
+
+  w3c-keyname@2.2.8: {}
 
   webcrypto-core@1.9.2:
     dependencies:

--- a/scripts/fixtures/file-preview-layout/main.cjs
+++ b/scripts/fixtures/file-preview-layout/main.cjs
@@ -125,6 +125,73 @@ app.whenReady().then(async () => {
     await capture('preview-day-1440x920')
   })
 
+  await check('source preview uses one read-only CodeMirror with real lines, syntax, search and stable theme updates', async () => {
+    const day = await run('window.previewTest.sourceSnapshot(true)')
+    assert.equal(day.fontSize, '14px')
+    assert.equal(day.fontWeight, '400')
+    assert.equal(day.lineHeight, '22.4px')
+    assert.equal(day.contentPaddingTop, '14px')
+    assert.equal(day.contentEditable, 'false')
+    assert.equal(day.readOnly, 'true')
+    assert.equal(day.tabIndex, '0')
+    assert.notEqual(day.keywordColor, day.sourceColor, 'Loaded TS syntax receives the base theme colors')
+    assert.equal(day.horizontalScroll, true, 'Long source lines scroll inside CodeMirror')
+    assert.deepEqual(day.targetLines.map((line) => line.match(/readingLine\d+/)?.[0]), [
+      'readingLine120', 'readingLine121', 'readingLine122'
+    ])
+    assert.ok(day.gutterLines.includes('120'), 'The target keeps its real file line number')
+    assert.match(day.selectedText, /^const readingLine\d+/, 'Native source selection excludes gutter line numbers')
+    await capture('source-reader-day')
+
+    await run('window.previewTest.bookmarkSource()')
+    const readingBeforeTheme = await run('window.previewTest.sourceSnapshot()')
+    await run('window.previewTest.setTheme("night")')
+    const night = await run('window.previewTest.sourceSnapshot()')
+    assert.equal(night.sameEditor, true, 'Theme changes reconfigure the existing editor')
+    assert.equal(night.firstVisibleLine, readingBeforeTheme.firstVisibleLine,
+      'Theme changes preserve the visible source line')
+    assert.notEqual(night.keywordColor, day.keywordColor, 'Night uses the dark base syntax colors')
+    await capture('source-reader-night')
+
+    await run('document.querySelector(".file-preview-tab-panel:not([hidden]) .file-preview-code").focus()')
+    await key('f', [process.platform === 'darwin' ? 'meta' : 'control'])
+    let searching = await run('window.previewTest.sourceSnapshot()')
+    assert.equal(searching.searchVisible, true)
+    assert.equal(searching.replaceVisible, false, 'Read-only search never exposes replace controls')
+    await run('window.previewTest.setSourceSearch("readingLine120")')
+    searching = await run('window.previewTest.sourceSnapshot()')
+    assert.ok(searching.searchMatches >= 1)
+    assert.equal(searching.currentMatches, 1)
+    await capture('source-reader-search-night')
+    await key('Escape')
+    await run('window.previewTest.setTheme("day")')
+  })
+
+  await check('Markdown document mode preserves hierarchy and uses static shared syntax highlighting', async () => {
+    await run('window.previewTest.openMarkdown()')
+    const day = await run('window.previewTest.markdownSnapshot()')
+    assert.equal(day.bodyFontSize, '15px')
+    assert.equal(day.bodyLineHeight, '25.5px')
+    assert.deepEqual([day.h1, day.h2, day.h3], ['26px', '21px', '17px'])
+    assert.equal(day.codeLanguage, 'tsx')
+    assert.equal(day.codeFontSize, '13px')
+    assert.notEqual(day.syntaxColor, day.sourceColor)
+    assert.equal(day.editorCount, 0, 'Fenced blocks render static spans, not editor instances')
+    assert.equal(day.tableFontSize, '14px')
+    assert.equal(day.tableScrolls, true)
+    assert.ok(day.documentWidth <= 780 && day.documentWidth < day.paneWidth)
+    assert.equal(day.pageOverflow, false)
+    await capture('markdown-reader-day')
+
+    await run('window.previewTest.setTheme("night")')
+    const night = await run('window.previewTest.markdownSnapshot()')
+    assert.notEqual(night.syntaxColor, day.syntaxColor)
+    assert.equal(night.editorCount, 0)
+    assert.equal(night.pageOverflow, false)
+    await capture('markdown-reader-night')
+    await run('window.previewTest.setTheme("day"); window.previewTest.closeExtraTabs(); window.previewTest.open()')
+  })
+
   await check('Camp sessions restore the visible active file first and keep hidden or background files lazy', async () => {
     await run('window.previewTest.openTab(0)')
     const before = await reviewSnapshot()
@@ -183,11 +250,11 @@ app.whenReady().then(async () => {
     assert.ok(state.borderWidths.every((width) => width === '0px'))
     assert.equal(state.background, 'rgba(0, 0, 0, 0)')
     await capture('preview-missing-day')
-    await run('document.documentElement.dataset.theme = "night"')
+    await run('window.previewTest.setTheme("night")')
     await snapshot()
     assert.equal((await run('window.previewTest.recoverySnapshot()')).text, '找不到这个文件')
     await capture('preview-missing-night')
-    await run('document.documentElement.dataset.theme = "day"; window.previewTest.closeAll()')
+    await run('window.previewTest.setTheme("day"); window.previewTest.closeAll()')
     await open()
   })
 
@@ -255,7 +322,7 @@ app.whenReady().then(async () => {
     await viewport(1_200)
     equalWidths(await tabs(), 120)
     assert.equal((await tabs()).overflow, true)
-    await run('document.documentElement.dataset.theme = "night"')
+    await run('window.previewTest.setTheme("night")')
     await snapshot()
     await capture('tabs-minimum-night')
     await viewport(1_440)
@@ -265,7 +332,7 @@ app.whenReady().then(async () => {
     assert.deepEqual(expanded.edges, { left: false, right: false }, 'Widening hides both arrows when all tabs fit')
     assert.ok(expanded.tabs.every(tab => !tab.faded))
     await capture('tabs-shrinking-night')
-    await run('document.documentElement.dataset.theme = "day"; window.previewTest.closeExtraTabs()')
+    await run('window.previewTest.setTheme("day"); window.previewTest.closeExtraTabs()')
     await open()
     equalWidths(await tabs(), 180)
     assert.equal((await snapshot()).stored, null, 'Tab layout does not write preview width preferences')
@@ -288,11 +355,11 @@ app.whenReady().then(async () => {
     const reading = () => run(`({
       selected: document.querySelector('[role="tab"][aria-selected="true"]').id,
       conversation: document.querySelector('.camp-timeline').scrollTop,
-      file: document.querySelector('.file-preview-tab-panel:not([hidden]) .file-preview-code').scrollTop
+      file: document.querySelector('.file-preview-tab-panel:not([hidden]) .file-preview-code .cm-scroller').scrollTop
     })`)
     for (let index = 0; index < 8; index += 1) await run(`window.previewTest.openTab(${index})`)
     await run(`document.querySelector('.camp-timeline').scrollTop = 180;
-      document.querySelector('.file-preview-tab-panel:not([hidden]) .file-preview-code').scrollTop = 360`)
+      document.querySelector('.file-preview-tab-panel:not([hidden]) .file-preview-code .cm-scroller').scrollTop = 360`)
     const before = await reading()
     const end = await tabs()
     assert.deepEqual(end.edges, { left: true, right: false }, 'Opening the last tab reveals the right endpoint')
@@ -343,11 +410,11 @@ app.whenReady().then(async () => {
     const reduced = await tabs()
     closeTo(reduced.scrollLeft, reduced.maximum, 'Reduced motion jumps directly to the scroll target')
     assert.equal(reduced.tabs.at(-1).focused, true)
-    await run('document.documentElement.dataset.theme = "night"')
+    await run('window.previewTest.setTheme("night")')
     await snapshot()
     await capture('tabs-scroll-end-night')
     await window.webContents.debugger.sendCommand('Emulation.setEmulatedMedia', { features: [] })
-    await run(`document.documentElement.dataset.theme = "day";
+    await run(`window.previewTest.setTheme("day");
       document.querySelector('.camp-timeline').scrollTop = 0;
       window.previewTest.closeExtraTabs()`)
     await open()
@@ -536,7 +603,7 @@ app.whenReady().then(async () => {
   })
 
   await check('wide, night and 200% reduced-motion layouts preserve one boundary without overflow', async () => {
-    await run('document.documentElement.dataset.theme = "night"')
+    await run('window.previewTest.setTheme("night")')
     const wide = await viewport(2_560, 1_440)
     closeTo(wide.width, wide.available * .56, 'Wide preview ratio')
     assert.equal(wide.aligned, true)
@@ -579,7 +646,7 @@ app.whenReady().then(async () => {
   })
 
   await check('File Change opens beside the unchanged conversation with its own tab and immutable evidence', async () => {
-    await run('document.documentElement.dataset.theme = "day"; window.previewTest.bookmark()')
+    await run('window.previewTest.setTheme("day"); window.previewTest.bookmark()')
     const before = await snapshot()
     const reads = (await reviewSnapshot()).fileReads
     const opened = await click('.run-file-change-file')
@@ -654,7 +721,7 @@ app.whenReady().then(async () => {
     await click('[aria-label="关闭 File Change·styles.css"]')
     assert.deepEqual((await reviewSnapshot()).releases, before.releases)
     await viewport(2_560, 1_440)
-    await run('document.documentElement.dataset.theme = "night"')
+    await run('window.previewTest.setTheme("night")')
     assert.equal((await reviewSnapshot()).sidebarVisible, true)
     assert.deepEqual((await reviewSnapshot()).overflow, [])
     await capture('file-change-night-2560x1440')

--- a/scripts/fixtures/file-preview-layout/renderer.tsx
+++ b/scripts/fixtures/file-preview-layout/renderer.tsx
@@ -1,6 +1,6 @@
 import { StrictMode, useRef, useState } from 'react'
 import { createRoot } from 'react-dom/client'
-import type { ActionApprovalView, AgentRunFileChangesDetailView, AgentRunFileChangesView, ComposerDocument, FilePreviewApi, OpenFilePreviewRequest, ResolvedFilePreview, TaskView } from '@contracts'
+import type { ActionApprovalView, AgentRunFileChangesDetailView, AgentRunFileChangesView, ComposerDocument, FilePreviewApi, OpenFilePreviewRequest, ResolvedFilePreview, ResolvedTheme, TaskView } from '@contracts'
 import { AppHeader } from '../../../apps/desktop/src/renderer/src/App'
 import { AgentRunFileChangesTimelineCard, ApprovalDock, RuntimeRecoveryDock, TaskTimelineCard } from '../../../apps/desktop/src/renderer/src/CampWorkspace'
 import { FilePreviewProvider, useFilePreview, type FilePreviewContextValue } from '../../../apps/desktop/src/renderer/src/FilePreviewContext'
@@ -17,8 +17,37 @@ const file: ResolvedFilePreview = {
   pathPresentation: 'project_relative',
   size: 8_000, mime: 'text/plain', extension: '.ts', kind: 'code',
   hasExternalUpdate: false, contentVersion: { size: 8_000, mtimeMs: 1 },
-  contentGeneration: 'generation-1', capabilities: ['read']
+  contentGeneration: 'generation-1', capabilities: ['read'], target: { line: 120, endLine: 122 }
 }
+const markdownReference = 'docs/preview-reader.md'
+const markdownFile: ResolvedFilePreview = {
+  ...file,
+  previewKey: 'markdown-reader',
+  displayPath: markdownReference,
+  fileName: 'preview-reader.md',
+  size: 2_000,
+  mime: 'text/markdown',
+  extension: '.md',
+  kind: 'markdown',
+  target: { heading: '核心阅读' }
+}
+const markdownSource = [
+  '# 文件预览',
+  '',
+  '正文以舒适字号呈现，并保留清楚的文档层级。',
+  '',
+  '## 核心阅读',
+  '',
+  '### 静态代码高亮',
+  '',
+  '```tsx',
+  'const Preview = ({ title }: { title: string }) => <main>{title}</main>',
+  '```',
+  '',
+  '| 项目 | 说明 |',
+  '| --- | --- |',
+  `| 宽表格 | ${'wideTableColumn'.repeat(40)} |`
+].join('\n')
 const tabFiles = ['src/app.ts', 'src/layout.tsx', 'src/theme.ts', 'src/routes.ts', 'src/search.ts',
   'src/settings.tsx', 'src/navigation.ts', 'src/very-long-file-preview-reading-anchor.tsx']
 const fileNameOnlyReference = 'external-preview.ts'
@@ -50,6 +79,8 @@ async function resolvePreview(request: OpenFilePreviewRequest) {
   } else if (request.kind === 'message_reference' && request.rawReference === fileNameOnlyReference) {
     target = { ...file, previewKey: fileNameOnlyReference, displayPath: fileNameOnlyReference,
       pathPresentation: 'file_name_only', fileName: fileNameOnlyReference }
+  } else if (request.kind === 'message_reference' && request.rawReference === markdownReference) {
+    target = markdownFile
   } else if (request.kind !== 'message_reference' || request.rawReference !== file.displayPath) return unsupported()
   return { ok: true as const, value: { kind: 'file_preview' as const, file: { ...target, handleId: crypto.randomUUID() } } }
 }
@@ -64,13 +95,22 @@ const api: FilePreviewApi = {
     return resolvePreview(request)
   },
   readText: async () => { fileReads += 1; return { ok: true, value: {
-    text: Array.from({ length: 300 }, (_, index) => `const readingLine${index + 1} = "保持会话和文件的阅读位置"`).join('\n'),
+    text: Array.from({ length: 300 }, (_, index) => `const readingLine${index + 1} = "保持会话和文件的阅读位置"${index === 122 ? ' + "long-line"'.repeat(70) : ''}`).join('\n'),
     contentGeneration: file.contentGeneration, contentVersion: file.contentVersion
   } } },
   release: async ({ handleId }) => { releases.push(handleId); return { released: true } },
   onExternalUpdate: () => () => {},
   reopen: unsupported, readPage: unsupported, resolveLine: unsupported,
-  readBinary: unsupported, prepareHtml: unsupported, reload: unsupported,
+  readBinary: unsupported,
+  prepareHtml: async () => ({ ok: true, value: {
+    html: markdownSource,
+    tabToken: 'markdown-tab-token',
+    bridgeToken: 'markdown-bridge-token',
+    assetBasePath: '',
+    contentGeneration: markdownFile.contentGeneration,
+    contentVersion: markdownFile.contentVersion
+  } }),
+  reload: unsupported,
   openInSystem: unsupported, revealInFolder: unsupported, copyPath: unsupported,
   chooseAuthorizedRoot: unsupported
 }
@@ -217,10 +257,16 @@ function Workspace(): React.JSX.Element {
 }
 
 let switchCamp: () => void
+let setFixtureTheme: (theme: ResolvedTheme) => void
 function Fixture(): React.JSX.Element {
   const [camp, setCamp] = useState('camp-1')
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>('day')
   switchCamp = () => setCamp((previous) => previous === 'camp-1' ? 'camp-2' : 'camp-1')
-  return <FilePreviewProvider campId={camp}>
+  setFixtureTheme = (theme) => {
+    document.documentElement.dataset.theme = theme
+    setResolvedTheme(theme)
+  }
+  return <FilePreviewProvider campId={camp} resolvedTheme={resolvedTheme}>
     <div className="app-shell app-shell-camp">
       <aside style={{ gridRow: '1 / -1', padding: '48px 24px', background: 'var(--rail)' }}>Rovai AI</aside>
       <AppHeader campTitle="文件预览验收" contextLabel="Rovai AI" camp={null} onFocusApprovals={() => {}} />
@@ -237,6 +283,7 @@ let bookmarkedEditor: HTMLElement | null = null
 let bookmarkedTimeline: HTMLElement | null = null
 let bookmarkedTask: HTMLElement | null = null
 let bookmarkedReview: HTMLElement | null = null
+let bookmarkedSourceEditor: HTMLElement | null = null
 let lastPointer = 0
 const pointerEvents: unknown[] = []
 for (const type of ['pointerdown', 'pointermove', 'pointerup', 'pointercancel', 'gotpointercapture', 'lostpointercapture']) {
@@ -271,6 +318,12 @@ Object.assign(window, { previewTest: {
   async openFileNameOnly() {
     await previewController.open({
       kind: 'message_reference', campId: 'camp-1', messageId: 'message-1', rawReference: fileNameOnlyReference
+    })
+    await settle()
+  },
+  async openMarkdown() {
+    await previewController.open({
+      kind: 'message_reference', campId: 'camp-1', messageId: 'message-1', rawReference: markdownReference
     })
     await settle()
   },
@@ -371,12 +424,107 @@ Object.assign(window, { previewTest: {
     bookmarkedReview.scrollTop = 640
   },
   async switchCamp() { switchCamp(); await settle() },
+  async setTheme(theme: ResolvedTheme) { setFixtureTheme(theme); await settle() },
   async find(open: boolean) { showFind(open); await settle() },
   async docks(mode: 'none' | 'approval' | 'recovery' | 'both') { showDocks(mode); await settle() },
+  async bookmarkSource() {
+    bookmarkedSourceEditor = element('.file-preview-tab-panel:not([hidden]) .cm-editor')
+    const scroller = element('.file-preview-tab-panel:not([hidden]) .cm-scroller')
+    if (scroller) scroller.scrollTop = 480
+    await settle()
+  },
+  async sourceSnapshot(requireTarget = false) {
+    const deadline = performance.now() + 3_000
+    while (!element('.file-preview-tab-panel:not([hidden]) .cm-content .cm-line span')
+      || (requireTarget && !element('.file-preview-tab-panel:not([hidden]) .cm-location-target'))) {
+      if (performance.now() > deadline) throw new Error('Source highlighting did not settle')
+      await new Promise((resolve) => setTimeout(resolve, 25))
+    }
+    const panel = element('.file-preview-tab-panel:not([hidden])')!
+    const editor = panel.querySelector<HTMLElement>('.cm-editor')!
+    const scroller = panel.querySelector<HTMLElement>('.cm-scroller')!
+    const content = panel.querySelector<HTMLElement>('.cm-content')!
+    const gutter = panel.querySelector<HTMLElement>('.cm-gutters')!
+    const keyword = [...panel.querySelectorAll<HTMLElement>('.cm-line span')]
+      .find((span) => span.textContent === 'const')!
+    const scrollerBounds = scroller.getBoundingClientRect()
+    const firstVisibleLine = [...panel.querySelectorAll<HTMLElement>('.cm-line')].find((line) => {
+        const bounds = line.getBoundingClientRect()
+        return bounds.bottom > scrollerBounds.top && bounds.top < scrollerBounds.bottom
+      })!
+    const firstLine = panel.querySelector<HTMLElement>('.cm-location-target') ?? firstVisibleLine
+    const selection = window.getSelection()!
+    const range = document.createRange()
+    range.selectNodeContents(firstLine)
+    selection.removeAllRanges()
+    selection.addRange(range)
+    const selectedText = selection.toString()
+    selection.removeAllRanges()
+    return {
+      sameEditor: bookmarkedSourceEditor === editor,
+      scrollTop: scroller.scrollTop,
+      horizontalScroll: scroller.scrollWidth > scroller.clientWidth,
+      fontSize: getComputedStyle(scroller).fontSize,
+      fontWeight: getComputedStyle(scroller).fontWeight,
+      lineHeight: getComputedStyle(scroller).lineHeight,
+      contentPaddingTop: getComputedStyle(content).paddingTop,
+      contentEditable: content.getAttribute('contenteditable'),
+      readOnly: content.getAttribute('aria-readonly'),
+      tabIndex: content.getAttribute('tabindex'),
+      gutterColor: getComputedStyle(gutter).color,
+      sourceColor: getComputedStyle(content).color,
+      keywordColor: getComputedStyle(keyword).color,
+      firstVisibleLine: firstVisibleLine.textContent?.match(/readingLine\d+/)?.[0],
+      selectedText,
+      targetLines: [...panel.querySelectorAll<HTMLElement>('.cm-location-target')].map((line) => line.textContent),
+      gutterLines: [...panel.querySelectorAll<HTMLElement>('.cm-lineNumbers .cm-gutterElement')].map((line) => line.textContent),
+      searchVisible: Boolean(panel.querySelector('.cm-panel.cm-search')?.getClientRects().length),
+      replaceVisible: Boolean(panel.querySelector('[name="replace"]')),
+      searchMatches: panel.querySelectorAll('.cm-searchMatch').length,
+      currentMatches: panel.querySelectorAll('.cm-searchMatch-selected').length
+    }
+  },
+  async setSourceSearch(query: string) {
+    const input = document.querySelector<HTMLInputElement>('.file-preview-tab-panel:not([hidden]) .cm-panel.cm-search [name="search"]')!
+    input.value = query
+    input.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true, key: 'e' }))
+    document.querySelector<HTMLButtonElement>('.file-preview-tab-panel:not([hidden]) .cm-panel.cm-search [name="next"]')!.click()
+    await settle()
+  },
+  async markdownSnapshot() {
+    const deadline = performance.now() + 3_000
+    while (!element('.file-preview-tab-panel:not([hidden]) .markdown-code-block span')) {
+      if (performance.now() > deadline) throw new Error('Markdown syntax highlighting did not load')
+      await new Promise((resolve) => setTimeout(resolve, 25))
+    }
+    const panel = element('.file-preview-tab-panel:not([hidden])')!
+    const documentRoot = panel.querySelector<HTMLElement>('.safe-markdown.is-document')!
+    const code = panel.querySelector<HTMLElement>('.markdown-code-block code')!
+    const syntax = code.querySelector<HTMLElement>('span')!
+    const table = panel.querySelector<HTMLElement>('table')!
+    const tableScroll = panel.querySelector<HTMLElement>('.markdown-table-scroll')!
+    return {
+      bodyFontSize: getComputedStyle(documentRoot).fontSize,
+      bodyLineHeight: getComputedStyle(documentRoot).lineHeight,
+      h1: getComputedStyle(panel.querySelector('h1')!).fontSize,
+      h2: getComputedStyle(panel.querySelector('h2')!).fontSize,
+      h3: getComputedStyle(panel.querySelector('h3')!).fontSize,
+      codeLanguage: code.dataset.codeLanguage,
+      codeFontSize: getComputedStyle(code.parentElement!).fontSize,
+      syntaxColor: getComputedStyle(syntax).color,
+      sourceColor: getComputedStyle(code).color,
+      editorCount: panel.querySelectorAll('.cm-editor').length,
+      tableFontSize: getComputedStyle(table).fontSize,
+      tableScrolls: tableScroll.scrollWidth > tableScroll.clientWidth,
+      documentWidth: documentRoot.getBoundingClientRect().width,
+      paneWidth: panel.getBoundingClientRect().width,
+      pageOverflow: document.documentElement.scrollWidth > innerWidth
+    }
+  },
   bookmark() {
     bookmarkedViewer = element('.file-preview-code')!
-    bookmarkedViewer.scrollTop = 640
-    bookmarkedEditor = element('[contenteditable]')
+    element('.file-preview-code .cm-scroller')!.scrollTop = 640
+    bookmarkedEditor = element('.structured-mention-editor[contenteditable]')
     bookmarkedTimeline = element('.camp-timeline')
     bookmarkedTask = element('.task-event-card')
   },
@@ -394,6 +542,7 @@ Object.assign(window, { previewTest: {
     const paneBounds = pane?.getBoundingClientRect()
     const handleBounds = handle?.getBoundingClientRect()
     const viewer = element('.file-preview-code')
+    const viewerScroller = viewer?.querySelector<HTMLElement>('.cm-scroller')
     return {
       available: gridBounds.width, right: gridBounds.right,
       width: paneBounds?.width ?? 0,
@@ -413,9 +562,9 @@ Object.assign(window, { previewTest: {
       opacity: pane ? getComputedStyle(pane).opacity : null,
       resizing: document.documentElement.classList.contains('file-preview-resizing'),
       focused: (document.activeElement as HTMLElement)?.className,
-      sameViewer: bookmarkedViewer === viewer, scroll: viewer?.scrollTop,
-      draft: element('[contenteditable]')?.textContent,
-      sameEditor: bookmarkedEditor === element('[contenteditable]'),
+      sameViewer: bookmarkedViewer === viewer, scroll: viewerScroller?.scrollTop,
+      draft: element('.structured-mention-editor[contenteditable]')?.textContent,
+      sameEditor: bookmarkedEditor === element('.structured-mention-editor[contenteditable]'),
       sameTimeline: bookmarkedTimeline === element('.camp-timeline'),
       sameTask: bookmarkedTask === element('.task-event-card'),
       tabCount: document.querySelectorAll('[role="tab"]').length,

--- a/scripts/fixtures/file-reference-navigation/main.cjs
+++ b/scripts/fixtures/file-reference-navigation/main.cjs
@@ -195,7 +195,7 @@ app.whenReady().then(async () => {
     assert.equal(after.opens.length, before.opens.length + 1)
     assert.equal(after.opens.at(-1).rawReference, '../outside/config.toml')
     assert.equal(after.chooseRootCalls, 0)
-    assert.equal(after.notices.at(-1), '无法打开文件。文件可能已被移动或删除。')
+    assert.equal(after.notices.at(-1), '文件访问已失效')
   })
   const report = { ok: true, cases, measurements }
   writeFileSync(join(dirname(userData), 'report.json'), JSON.stringify(report, null, 2))

--- a/scripts/fixtures/file-reference-navigation/renderer.tsx
+++ b/scripts/fixtures/file-reference-navigation/renderer.tsx
@@ -52,7 +52,10 @@ const api: FilePreviewApi = {
   prepareHtml: unsupported, reload: unsupported, openInSystem: unsupported, revealInFolder: unsupported,
   copyPath: unsupported, chooseAuthorizedRoot: async () => { chooseRootCalls += 1; return null as never }
 }
-const draft = { campId, body: '保留原有草稿', content: [{ kind: 'text', text: '保留原有草稿' }], revision: 1,
+const draft = { campId, body: '保留原有草稿', content: {
+  version: 2 as const,
+  segments: [{ kind: 'text' as const, text: '保留原有草稿' }]
+}, revision: 1,
   attachments: [], replyIntent: null, continuationIntent: null, updatedAt: null, expiresAt: null }
 Object.assign(window, { rovai: {
   filePreview: api, platform: 'darwin', onEvent: () => () => {},
@@ -107,7 +110,9 @@ function Workspace(): React.JSX.Element {
       onNotify={(message) => notices.push(message)} />
   </div>
 }
-createRoot(document.getElementById('root')!).render(<FilePreviewProvider campId={campId}><Workspace /></FilePreviewProvider>)
+createRoot(document.getElementById('root')!).render(
+  <FilePreviewProvider campId={campId} resolvedTheme="day"><Workspace /></FilePreviewProvider>
+)
 
 const element = (selector: string): HTMLElement => document.querySelector<HTMLElement>(selector)!
 const link = () => element('[data-message-id="message-12"] [title="run_report.py:44-46"]')
@@ -142,18 +147,21 @@ Object.assign(window, { navigationTest: {
   state() {
     const scroll = timeline()
     const viewer = element('.file-preview-code')
-    const target = viewer?.querySelector<HTMLElement>('[data-file-row="44"]')
+    const target = viewer?.querySelector<HTMLElement>('.cm-location-target')
+    const viewerScroller = viewer?.querySelector<HTMLElement>('.cm-scroller')
     const message = anchorMessageId ? element(`[data-message-id="${anchorMessageId}"]`) : null
     return {
       linkY: link().getBoundingClientRect().top, scrollTop: scroll.scrollTop, width: scroll.clientWidth,
       bottomGap: scroll.scrollHeight - scroll.scrollTop - scroll.clientHeight,
       visible: Boolean(element('.file-preview-pane')?.getBoundingClientRect().width),
       sameTimeline: scroll === bookmarkedTimeline, sameLink: link() === bookmarkedLink,
-      targetLines: [...document.querySelectorAll<HTMLElement>('.is-location-target')].map((row) => Number(row.dataset.fileRow)),
-      targetVisible: Boolean(target && target.getBoundingClientRect().top >= viewer.getBoundingClientRect().top
-        && target.getBoundingClientRect().bottom <= viewer.getBoundingClientRect().bottom),
+      targetLines: [...document.querySelectorAll<HTMLElement>('.cm-location-target')]
+        .map((row) => Number(/value_(\d+)/u.exec(row.textContent ?? '')?.[1])),
+      targetVisible: Boolean(target && viewerScroller
+        && target.getBoundingClientRect().top >= viewerScroller.getBoundingClientRect().top
+        && target.getBoundingClientRect().bottom <= viewerScroller.getBoundingClientRect().bottom),
       messageY: message?.getBoundingClientRect().top, opens, notices, chooseRootCalls, trace,
-      draft: element('[contenteditable]')?.textContent,
+      draft: element('.structured-mention-editor[contenteditable]')?.textContent,
       falseLinks: [...document.querySelectorAll<HTMLAnchorElement>('a[title]')]
         .filter((a) => /FBP|run_gr_reminder/u.test(a.title)).length,
       explicitReferenceTypes: [...document.querySelectorAll<HTMLAnchorElement>(


### PR DESCRIPTION
## Summary

- replace the hand-built code preview with a read-only CodeMirror 6 reader using lazy `@codemirror/language-data` matching, real paged line numbers, native search, and target-range highlighting
- add a SafeMarkdown document mode with native H1-H6 hierarchy, responsive reading typography, scrollable tables, and shared static fenced-code highlighting
- centralize source-reader theme/typography styling, preserve editor and scroll state across theme/layout/tab changes, and extend production Electron fixtures and UI documentation

## Validation

- `pnpm typecheck`
- `pnpm test` (155 Vitest files / 1573 tests plus 220 script tests)
- `pnpm build:desktop`
- `DOCS_BASE_REF=f4c1bb12082707534243fec4a9f288ce5eeed3df pnpm docs:check:ci`
- `pnpm test:file-preview-layout`
- `pnpm test:file-reference-navigation`

## Existing fixture debt

The aggregate `pnpm test:desktop:integration` still stops on unrelated baseline fixture drift reproduced in the original checkout: the preload bridge fixture relocates an unbundled preload with a runtime relative import, and several Composer fixtures still pass the retired document shape. The file-preview layout and file-reference navigation integrations both pass.