### PR TITLE
fix(single-chat): remove stale send version fence

### DIFF
--- a/apps/desktop/src/renderer/src/SingleChatPanel.tsx
+++ b/apps/desktop/src/renderer/src/SingleChatPanel.tsx
@@ -267,7 +267,6 @@ function resultMessage(result: StoredCommandResult): string {
   if (typeof message === 'string' && message.trim()) return message
   if (result.code === 'single_chat.runtime_not_ready') return '这位队员的运行时暂不可用。'
   if (result.code === 'single_chat.member_unavailable') return '这位队员已不在当前会话中。'
-  if (result.code === 'single_chat.version_conflict') return '对话刚刚发生变化，请重试。'
   if (result.code === 'single_chat.draft_changed') return '附件草稿刚刚发生变化，请重试。'
   if (result.code === 'single_chat.pending_input_changed') return '这条排队消息刚刚发生变化，请重试。'
   if (result.code === 'single_chat.pending_input_edit_open') return '另一处正在编辑这条排队消息。'
@@ -1410,7 +1409,6 @@ export function SingleChatPanel({
           campId,
           conversationId: current.conversation.id,
           body,
-          expectedConversationVersion: current.conversation.version,
           draftRevision: current.draft.revision
         }
       })

--- a/crates/rovai-core/src/context.rs
+++ b/crates/rovai-core/src/context.rs
@@ -13025,7 +13025,6 @@ mod slow_tests {
                         conversation_id,
                         body: "只检查当前单聊输入".to_string(),
                         draft_revision: 0,
-                        expected_conversation_version: 1,
                     },
                 },
             )

--- a/crates/rovai-core/src/single_chat.rs
+++ b/crates/rovai-core/src/single_chat.rs
@@ -59,7 +59,6 @@ pub struct SendSingleChatMessageCommand {
     pub camp_id: String,
     pub conversation_id: String,
     pub body: String,
-    pub expected_conversation_version: i64,
     pub draft_revision: i64,
 }
 
@@ -541,12 +540,6 @@ impl SingleChatService {
                 return Ok(rejected(
                     "single_chat.camp_mismatch",
                     "Single Chat command is outside the Camp",
-                ));
-            }
-            if target.version != envelope.payload.expected_conversation_version {
-                return Ok(CommandHandlerResult::rejected(
-                    "single_chat.version_conflict",
-                    json!({ "currentVersion": target.version }),
                 ));
             }
             if !active_member(transaction, &target.camp_id, &target.agent_id)? {
@@ -2563,7 +2556,6 @@ mod tests {
         database: &mut Database,
         camp_id: &str,
         conversation_id: &str,
-        version: i64,
         command_id: &str,
     ) -> CommandExecution {
         let draft_revision = database
@@ -2584,7 +2576,6 @@ mod tests {
                         camp_id: camp_id.to_string(),
                         conversation_id: conversation_id.to_string(),
                         body: "请检查这一处设计".to_string(),
-                        expected_conversation_version: version,
                         draft_revision,
                     },
                 ),
@@ -2593,17 +2584,16 @@ mod tests {
     }
 
     #[test]
-    fn send_is_atomic_and_end_uses_exact_identity_without_fencing_a_successor() {
+    fn send_uses_current_state_and_end_uses_exact_identity_without_fencing_a_successor() {
         let (mut database, camp_id) = fixture();
         let service = SingleChatService::default();
-        let (conversation_id, version) =
+        let (conversation_id, _) =
             open(&service, &mut database, &camp_id, "single-chat-open-first");
         let first = send(
             &service,
             &mut database,
             &camp_id,
             &conversation_id,
-            version,
             "single-chat-send-first",
         );
         assert_eq!(first.result.status, CommandResultStatus::Accepted);
@@ -2629,12 +2619,20 @@ mod tests {
                 .contains("agent_run output route is immutable"),
             "a Single Chat Run cannot be rewritten into an ordinary public route"
         );
+        // Runtime input acknowledgement can advance the Conversation version while the
+        // Renderer still holds the Snapshot used to prepare this queued input.
+        database
+            .connection()
+            .execute(
+                "UPDATE conversation SET version = version + 1 WHERE id = ?1",
+                [&conversation_id],
+            )
+            .unwrap();
         let busy = send(
             &service,
             &mut database,
             &camp_id,
             &conversation_id,
-            version + 1,
             "single-chat-send-busy",
         );
         assert_eq!(busy.result.status, CommandResultStatus::Accepted);
@@ -2655,16 +2653,11 @@ mod tests {
             user_messages, 1,
             "a queued send must not append user input before publication"
         );
-        let queued_inputs: i64 = database
-            .connection()
-            .query_row(
-                "SELECT COUNT(*) FROM single_chat_pending_input
-                 WHERE conversation_id = ?1 AND state = 'queued'",
-                [&conversation_id],
-                |row| row.get(0),
-            )
+        let queued_snapshot = service
+            .snapshot(&database, &conversation_id)
+            .unwrap()
             .unwrap();
-        assert_eq!(queued_inputs, 1);
+        assert_eq!(queued_snapshot.pending_inputs.items.len(), 1);
         let editing = service
             .edit_pending_input(
                 &mut database,
@@ -2841,7 +2834,7 @@ mod tests {
             .unwrap();
         assert_eq!(unchanged_end_state, (ended_version, ended_events));
 
-        let (successor_id, successor_version) = open(
+        let (successor_id, _) = open(
             &service,
             &mut database,
             &camp_id,
@@ -2853,7 +2846,6 @@ mod tests {
             &mut database,
             &camp_id,
             &successor_id,
-            successor_version,
             "single-chat-send-successor",
         );
         assert_eq!(successor.result.status, CommandResultStatus::Accepted);
@@ -2864,7 +2856,7 @@ mod tests {
         let (mut database, camp_id) = fixture();
         let service = SingleChatService::default();
         let runtime = ExecutionRuntimeService::default();
-        let (conversation_id, version) = open(
+        let (conversation_id, _) = open(
             &service,
             &mut database,
             &camp_id,
@@ -2875,7 +2867,6 @@ mod tests {
             &mut database,
             &camp_id,
             &conversation_id,
-            version,
             "single-chat-send-terminal",
         );
         let run_id = sent.result.payload["agentRunId"]
@@ -2933,7 +2924,7 @@ mod tests {
             .unwrap();
         assert_eq!(private_messages, 1);
 
-        let (cancel_conversation_id, cancel_version) = {
+        let (cancel_conversation_id, _) = {
             service
                 .end(
                     &mut database,
@@ -2954,7 +2945,6 @@ mod tests {
             &mut database,
             &camp_id,
             &cancel_conversation_id,
-            cancel_version,
             "single-chat-send-cancel",
         );
         let cancelled_run_id = cancelled_send.result.payload["agentRunId"]
@@ -3021,14 +3011,13 @@ mod tests {
     fn built_in_policy_is_a_closed_allowlist_and_restart_cancels_only_the_reply() {
         let (mut database, camp_id) = fixture();
         let service = SingleChatService::default();
-        let (conversation_id, version) =
+        let (conversation_id, _) =
             open(&service, &mut database, &camp_id, "single-chat-open-policy");
         let sent = send(
             &service,
             &mut database,
             &camp_id,
             &conversation_id,
-            version,
             "single-chat-send-policy",
         );
         let run_id = sent.result.payload["agentRunId"]
@@ -3116,7 +3105,6 @@ mod tests {
             &mut database,
             &camp_id,
             &conversation_id,
-            version + 1,
             "single-chat-send-after-restart",
         );
         assert_eq!(next.result.status, CommandResultStatus::Accepted);
@@ -3126,7 +3114,7 @@ mod tests {
     fn source_attachments_are_consumed_by_one_message_and_resolved_for_its_run() {
         let (mut database, camp_id) = fixture();
         let service = SingleChatService::default();
-        let (conversation_id, version) = open(
+        let (conversation_id, _) = open(
             &service,
             &mut database,
             &camp_id,
@@ -3156,7 +3144,6 @@ mod tests {
                         camp_id: camp_id.clone(),
                         conversation_id: conversation_id.clone(),
                         body: String::new(),
-                        expected_conversation_version: version,
                         draft_revision: 1,
                     },
                 ),
@@ -3234,7 +3221,7 @@ mod tests {
         let (mut database, camp_id) = fixture();
         let service = SingleChatService::default();
         let runtime = ExecutionRuntimeService::default();
-        let (conversation_id, version) = open(
+        let (conversation_id, _) = open(
             &service,
             &mut database,
             &camp_id,
@@ -3245,7 +3232,6 @@ mod tests {
             &mut database,
             &camp_id,
             &conversation_id,
-            version,
             "single-chat-send-pending-first",
         );
         let first_run_id = first.result.payload["agentRunId"]
@@ -3270,7 +3256,6 @@ mod tests {
                         camp_id: camp_id.clone(),
                         conversation_id: conversation_id.clone(),
                         body: "读取排队附件".to_string(),
-                        expected_conversation_version: version + 1,
                         draft_revision: 2,
                     },
                 ),
@@ -3367,7 +3352,7 @@ mod tests {
         let (mut database, camp_id) = fixture();
         let service = SingleChatService::default();
         let runtime = ExecutionRuntimeService::default();
-        let (conversation_id, version) = open(
+        let (conversation_id, _) = open(
             &service,
             &mut database,
             &camp_id,
@@ -3378,7 +3363,6 @@ mod tests {
             &mut database,
             &camp_id,
             &conversation_id,
-            version,
             "single-chat-send-repair-first",
         );
         let first_run_id = first.result.payload["agentRunId"]
@@ -3403,7 +3387,6 @@ mod tests {
                         camp_id: camp_id.clone(),
                         conversation_id: conversation_id.clone(),
                         body: "附件坏了仍可修复".to_string(),
-                        expected_conversation_version: version + 1,
                         draft_revision: 2,
                     },
                 ),
@@ -3423,7 +3406,6 @@ mod tests {
                         camp_id: camp_id.clone(),
                         conversation_id: conversation_id.clone(),
                         body: "后续排队消息".to_string(),
-                        expected_conversation_version: version + 1,
                         draft_revision: 3,
                     },
                 ),
@@ -3565,7 +3547,7 @@ mod tests {
         let (mut database, camp_id) = fixture();
         let service = SingleChatService::default();
         let runtime = ExecutionRuntimeService::default();
-        let (conversation_id, version) = open(
+        let (conversation_id, _) = open(
             &service,
             &mut database,
             &camp_id,
@@ -3584,7 +3566,6 @@ mod tests {
             &mut database,
             &camp_id,
             &conversation_id,
-            version,
             "single-chat-send-history-first",
         );
         let first_run_id = first.result.payload["agentRunId"].as_str().unwrap();
@@ -3624,7 +3605,6 @@ mod tests {
             &mut database,
             &camp_id,
             &conversation_id,
-            version + 2,
             "single-chat-send-history-current",
         );
         let current_run_id = second.result.payload["agentRunId"]

--- a/docs/architecture/single-chat.md
+++ b/docs/architecture/single-chat.md
@@ -52,6 +52,10 @@ Scheduler 发现该 Conversation 空闲
   → 用户可独占编辑、takeover、增删/重排附件、保存或删除
 ```
 
+发送命令以固定 Conversation ID 为目标，不接收 expected Conversation version。`SingleChatService` 在同一事务内读取当前
+Conversation 状态并决定直接准入或 Pending 入队；后台 ACK、final 等对 Conversation version 的推进不构成用户输入冲突，
+只有独立的 Draft revision 继续保护附件 Draft 的精确消费。
+
 队列以 `conversation_id + enqueue_sequence` 定序。Camp 公屏队列、其他 Single Chat、同一队员的 successor Conversation
 和普通 Scheduler capacity 都不共享这个顺序域。Pending 尚未发布时不占用 ConversationMessage sequence，不创建
 CampTurn/AgentRun，也不推进 Conversation version。

--- a/docs/contracts/single-chat-v2.md
+++ b/docs/contracts/single-chat-v2.md
@@ -104,7 +104,7 @@ Single Chat agent final 和其他无附件 ConversationMessage 保存 `[]`。本
 | `singleChat.open` | command envelope + `{ campId, agentId }` | 已有 active 会话则幂等返回，否则创建新 Conversation |
 | `singleChat.sourceAttachments.addFromPath` | `{ conversationId, expectedDraftRevision, sourcePath, displayName, mediaType? }` | 公共观察/校验后把一个 Source Ref 追加到 Draft，不复制内容 |
 | `singleChat.composerDraft.removeAttachment` | `{ conversationId, expectedDraftRevision, attachmentRefId }` | 只从 Draft 删除指定 Source Ref |
-| `singleChat.send` | command envelope + `{ campId, conversationId, body, expectedConversationVersion, draftRevision }` | 原子消费当前 Draft，直接准入或进入该 Conversation 的 Pending FIFO |
+| `singleChat.send` | command envelope + `{ campId, conversationId, body, draftRevision }` | 原子消费当前 Draft，直接准入或进入该 Conversation 的 Pending FIFO |
 | `singleChat.pendingInputs.edit` | command envelope + `EditSingleChatPendingInputCommand` | begin/takeover/save/remove/reorder/cancel/delete 排队编辑 |
 | `singleChat.pendingInputs.addSourceAttachmentFromPath` | `{ campId, conversationId, pendingInputId, expectedRevision, editToken, sourcePath, displayName, mediaType? }` | 向已验证 edit working copy 追加公共 Source Ref |
 | `singleChat.end` | command envelope + `{ campId, conversationId }` | 按精确 Conversation 身份结束当前状态；已 ended 时成功 no-op |
@@ -115,6 +115,10 @@ payload Camp。除 `end` 对同一 exact ended Conversation 的成功 no-op 外�
 Member。附件路径必须为绝对路径且在观察时存在、可读并为公共规则支持的普通文件或目录；名称、媒体类型、数量和 Source
 shape 上限沿用 Camp Composer。
 
+`singleChat.send` 按固定 Conversation ID 在事务中读取当前实际状态，不接收 expected Conversation version。Runtime Input
+Delivery ACK、Agent final 或其他后台状态推进 `conversation.version` 时，不得使合法的直接发送或 Pending 入队变成陈旧请求；
+附件 Draft 仍独立使用 `draftRevision` 做 CAS。
+
 `singleChat.send` 的 trim 后正文与 Draft refs 不得同时为空，正文最多 100,000 Unicode scalar。输入不携带
 `attachmentIds`；附件权威是匹配 `draftRevision` 的有序 Draft refs。Core 在事务中重读并验证 Source 当前状态：
 
@@ -123,7 +127,7 @@ shape 上限沿用 Camp Composer。
 2. Conversation 有非终态 Run或已有 Pending 时，写 `single_chat_pending_input`，清空 Draft并推进 Draft revision，但不写
    ConversationMessage/CampTurn/AgentRun，也不推进 Conversation version。
 
-Source 丢失、不可读、类型变化、Draft/Conversation revision 冲突或其他发送校验失败时，不写 Message/Turn/Run/Pending，
+Source 丢失、不可读、类型变化、Draft revision 冲突或其他发送校验失败时，不写 Message/Turn/Run/Pending，
 不清空 Draft，不推进任一 revision/version。附件-only 输入允许。
 
 ## 5. Conversation-local Pending FIFO
@@ -281,7 +285,6 @@ single_chat.local_user_required
 single_chat.camp_mismatch
 single_chat.member_unavailable
 single_chat.not_active
-single_chat.version_conflict
 single_chat.draft_changed
 single_chat.empty_message
 single_chat.runtime_not_ready

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -802,7 +802,6 @@ export interface SendSingleChatMessageCommand {
   campId: string
   conversationId: string
   body: string
-  expectedConversationVersion: number
   draftRevision: number
 }
 


### PR DESCRIPTION
## Summary

- remove `expectedConversationVersion` from the `singleChat.send` Rust/TypeScript contract and Renderer payload
- let Core read the current Conversation state inside the command transaction before choosing direct admission or Pending FIFO
- retain exact Conversation identity, active/member checks, Draft revision CAS, attachment validation, command idempotency, and the internal transaction write fence
- align the current Single Chat contract and architecture documentation

## Regression owner

The existing `single_chat::tests::send_uses_current_state_and_end_uses_exact_identity_without_fencing_a_successor` transaction test owns direct/busy send admission. It now advances the Conversation version after the first active Run, then verifies the next send still returns `single_chat.pending_input_queued` and is visible through the Single Chat Snapshot.

Before the implementation change, this exact test failed with `left: Rejected`, `right: Accepted`. It extends the existing owner instead of adding a duplicate full-database test; a lower-level pure test cannot exercise the command transaction, active Run, and Pending projection seam together.

Minimal regression command:

```bash
cargo test -p rovai-core send_uses_current_state_and_end_uses_exact_identity_without_fencing_a_successor -- --nocapture
```

## Validation

Passed:

- `cargo fmt --all --check`
- targeted red/green regression above
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `pnpm typecheck`
- `pnpm docs:test`
- `pnpm docs:check`
- `DOCS_BASE_REF=00a2a6ba5787b40a8b9ba147b807b369da2bae7b pnpm docs:check:ci`
- `pnpm test` — 155 Vitest files / 1573 tests plus 220 Node tests passed; one expected platform skip
- `pnpm test:rust:cli` — 33 passed
- `pnpm test:rust:slow` — 305 passed
- `pnpm build:desktop`

Environment-blocked baseline checks:

- `pnpm test:rust:pr`: 507 library tests passed; `managed_process::tests::macos_runtime_sandbox_denies_user_automation_root_but_keeps_other_files_visible` failed because `sandbox-exec` exited 71. The same isolated test fails identically on unmodified `main@00a2a6ba`.
- `pnpm test:desktop-bridge`: explicitly reported `BLOCKED: nested macOS sandbox prevents Chromium sandbox initialization`; business assertions did not run.
