### PR TITLE
fix(desktop): prevent premature file path truncation

### DIFF
--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -2010,10 +2010,11 @@ html.file-preview-resizing .file-preview-pane { pointer-events: none; }
   font: 500 9.5px/1.3 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 }
 .file-preview-update-row { justify-content: flex-end; }
-.file-preview-path-parts { display: flex; min-width: 0; max-width: 100%; flex: 0 1 auto; align-items: center; overflow: hidden; white-space: nowrap; }
+/* Allocate the row before shrinking its segments; content-sized flex boxes truncate even when the row has room. */
+.file-preview-path-parts { display: flex; min-width: 0; max-width: 100%; flex: 1 1 auto; align-items: center; overflow: hidden; white-space: nowrap; }
 .file-preview-path-leading,
-.file-preview-path-trailing { min-width: 0; max-width: 18ch; flex: 0 4 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.file-preview-path-middle { min-width: 18px; max-width: 28ch; flex: 0 10 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.file-preview-path-trailing { min-width: 0; flex: 0 4 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.file-preview-path-middle { min-width: 18px; flex: 0 10 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .file-preview-path-separator { flex: 0 0 auto; margin: 0 7px; color: var(--workspace-line-strong); }
 .file-preview-path-name { min-width: min(10ch, 45%); max-width: 62%; flex: 0 1 auto; overflow: hidden; color: var(--ink); font-weight: 650; text-overflow: ellipsis; white-space: nowrap; }
 .file-preview-update-action {

--- a/scripts/fixtures/file-preview-layout/main.cjs
+++ b/scripts/fixtures/file-preview-layout/main.cjs
@@ -301,6 +301,38 @@ app.whenReady().then(async () => {
     await open()
   })
 
+  await check('file paths use available width before truncating directories and preserve the filename in narrow panes', async () => {
+    await run('window.previewTest.openPath(0)')
+    const short = await run('window.previewTest.pathSnapshot()')
+    assert.equal(short.pathTitle, 'crates/rovai-core/src/acp.rs')
+    assert.deepEqual(short.segments.map(segment => segment.text), ['crates', 'rovai-core', 'src', 'acp.rs'])
+    assert.ok(short.segments.every(segment => !segment.truncated), 'The short acp.rs path fits without any ellipses')
+    await capture('preview-path-acp-day')
+
+    await run('window.previewTest.openPath(1)')
+    const wide = await run('window.previewTest.pathSnapshot()')
+    assert.ok(wide.segments.every(segment => !segment.truncated), 'Directory character limits cannot truncate a path that fits')
+    assert.equal(wide.pathOverflow, false)
+
+    await viewport(1_111)
+    const narrow = await run('window.previewTest.pathSnapshot()')
+    assert.equal(narrow.pathOverflow, false)
+    assert.equal(narrow.segments[1].truncated, true, 'An overlong middle directory yields space')
+    assert.equal(narrow.segments.at(-1).truncated, false, 'The filename stays readable')
+    assert.ok(narrow.segments.at(-1).right <= narrow.partsRight + 1, 'The filename remains inside the path row')
+    await run('window.previewTest.setTheme("night")')
+    await snapshot()
+    await capture('preview-path-narrow-night')
+
+    await viewport(2_560, 1_440)
+    const expanded = await run('window.previewTest.pathSnapshot()')
+    assert.ok(expanded.segments.every(segment => !segment.truncated), 'Widening the pane restores the complete path')
+    await capture('preview-path-wide-night')
+    await run('window.previewTest.setTheme("day"); window.previewTest.closeExtraTabs()')
+    await viewport(1_440)
+    await open()
+  })
+
   await check('filename-only files remove the complete path row and return its height to the viewer', async () => {
     const projectFile = await run('window.previewTest.pathSnapshot()')
     assert.equal(projectFile.pathVisible, true)

--- a/scripts/fixtures/file-preview-layout/renderer.tsx
+++ b/scripts/fixtures/file-preview-layout/renderer.tsx
@@ -51,6 +51,10 @@ const markdownSource = [
 const tabFiles = ['src/app.ts', 'src/layout.tsx', 'src/theme.ts', 'src/routes.ts', 'src/search.ts',
   'src/settings.tsx', 'src/navigation.ts', 'src/very-long-file-preview-reading-anchor.tsx']
 const fileNameOnlyReference = 'external-preview.ts'
+const pathReferences = [
+  'crates/rovai-core/src/acp.rs',
+  'workspace-crates-directory/core-runtime-source-and-language-adapters/source-implementations/acp.rs'
+]
 const missingReference = 'src/missing-report.ts'
 const toolPreviewReference = 'src/tool-link-preview.ts'
 const unsupported = async (): Promise<never> => { throw new Error('Unexpected fixture API operation') }
@@ -79,7 +83,8 @@ async function resolvePreview(request: OpenFilePreviewRequest) {
     const selected = changes.files.find((entry) => entry.evidenceFileId === request.evidenceFileId)
     if (!selected) return unsupported()
     target = { ...file, previewKey: `current:${selected.path}`, displayPath: selected.path, fileName: selected.path.split('/').at(-1)! }
-  } else if (request.kind === 'message_reference' && tabFiles.includes(request.rawReference)) {
+  } else if (request.kind === 'message_reference'
+    && [...tabFiles, ...pathReferences].includes(request.rawReference)) {
     target = { ...file, previewKey: request.rawReference, displayPath: request.rawReference,
       fileName: request.rawReference.split('/').at(-1)! }
   } else if (request.kind === 'message_reference' && request.rawReference === fileNameOnlyReference) {
@@ -342,6 +347,12 @@ Object.assign(window, { previewTest: {
     })
     await settle()
   },
+  async openPath(index: number) {
+    const rawReference = pathReferences[index]
+    if (!rawReference) throw new Error('Unknown fixture path')
+    await previewController.open({ kind: 'message_reference', campId: 'camp-1', messageId: 'message-1', rawReference })
+    await settle()
+  },
   async openMarkdown() {
     await previewController.open({
       kind: 'message_reference', campId: 'camp-1', messageId: 'message-1', rawReference: markdownReference
@@ -422,7 +433,18 @@ Object.assign(window, { previewTest: {
     const content = panel.querySelector<HTMLElement>('.file-preview-content')!
     const path = panel.querySelector<HTMLElement>('.file-preview-path-row')
     const update = panel.querySelector<HTMLElement>('.file-preview-update-row')
+    const parts = path?.querySelector<HTMLElement>('.file-preview-path-parts')
     return {
+      pathTitle: parts?.title,
+      pathOverflow: Boolean(path && path.scrollWidth > path.clientWidth + 1),
+      partsRight: parts?.getBoundingClientRect().right,
+      segments: [...(parts?.querySelectorAll<HTMLElement>(
+        '.file-preview-path-leading, .file-preview-path-middle, .file-preview-path-trailing, .file-preview-path-name'
+      ) ?? [])].map((segment) => ({
+        text: segment.textContent,
+        truncated: segment.scrollWidth > segment.clientWidth + 1,
+        right: segment.getBoundingClientRect().right
+      })),
       pathVisible: Boolean(path?.getClientRects().length),
       pathHeight: path?.getBoundingClientRect().height ?? 0,
       updateVisible: Boolean(update?.getClientRects().length),


### PR DESCRIPTION
File preview breadcrumbs could display `crat… > rovai-… > s… > acp.rs` even with ample empty space. The path container now uses the available row width, and directory segments no longer have fixed character-width caps. Paths display in full when they fit; constrained panes retain the existing shrink priorities and readable filename.

The production Electron fixture covers the reported `crates/rovai-core/src/acp.rs` path, longer directory names, narrow panes, and restoration after widening in both themes. The new assertion failed with the original CSS and passes with this change.

Validation: typecheck, all Vitest tests, production desktop build, file-preview layout Electron integration, and diff checks pass. Staged Rust validation correctly skips this CSS-only production change. Full `pnpm test` also completed its other checks, with one existing script failure: `product-contract.test.mjs` expects schema 93 while the unchanged baseline declares schema 94 (219 script tests pass, one Windows-only test skips).
