### PR TITLE
test: 同步成品工具步骤断言与定向验收

### DIFF
--- a/docs/development/ui-acceptance.md
+++ b/docs/development/ui-acceptance.md
@@ -230,6 +230,10 @@ pnpm package:mac
 pnpm accept:runtime-activity-ui
 ```
 
+只核对共享工具详情时，可补充运行 `ROVAI_RUNTIME_ACTIVITY_ACCEPT_TOOL_DETAILS_ONLY=1 pnpm accept:runtime-activity-ui`。
+它在同一隔离夹具验证 Web 的 Canonical 步骤数、查询原文、类型图标与展开结果，以及无输出 Shell 命令的结果展开；
+报告和截图与全量结果分开保存。此定向检查不能替代完整交互矩阵或把全量失败改报为通过。
+
 需要把生产 App 留给人工检查时，可运行
 `node scripts/accept-runtime-activity-ui.mjs "dist/mac-arm64/Rovai AI.app" --preview`。
 它创建同样的隔离 fixture、打开明确标注“模拟数据”的执行 Camp 并等待用户关闭 App；不调用真实模型，

--- a/docs/versions/v1.53/implementation-plan.md
+++ b/docs/versions/v1.53/implementation-plan.md
@@ -269,3 +269,9 @@ ACP 原有错误/投递测试扩展网络类别与 accepted/not-accepted 分流�
 
 验证命令：`pnpm typecheck`、`pnpm exec vitest run`、`node --test scripts/lib/single-chat-panel.test.mjs`、
 `pnpm build:desktop`、`pnpm docs:test`、`pnpm docs:check` 与 `DOCS_BASE_REF=<PR base> pnpm docs:check:ci`。
+
+成品补充验证：`pnpm package:mac:daily` 的 arm64/ad-hoc App、Core、CLI 校验通过。带隔离 userData 和
+Skill Library 的工具详情定向验收通过，验证“完成了 1 个步骤”、Web 查询全文和 Shell 无输出结果展开。
+全量 `accept:runtime-activity-ui` 本轮未通过：消息操作栏现有 `margin-left: -5px` 与旧脚本要求的零偏移不符；
+该偏移在 PR #255 的基线已存在，本轮不修改消息操作栏或放宽全量断言。定向脚本的旧“已执行 1 项操作”
+断言已同步当前工具组合同；该补充只改变验收脚本和记录，已打包的生产代码不变。

--- a/scripts/accept-runtime-activity-ui.mjs
+++ b/scripts/accept-runtime-activity-ui.mjs
@@ -30,6 +30,7 @@ const conversationDropZoneOnly = process.env.ROVAI_RUNTIME_ACTIVITY_ACCEPT_DROP_
 const worldMapOnly = process.env.ROVAI_RUNTIME_ACTIVITY_ACCEPT_WORLD_MAP_ONLY === '1'
 const runtimeModelOnly = process.env.ROVAI_RUNTIME_ACTIVITY_ACCEPT_MODEL_ONLY === '1'
 const webSearchOnly = process.env.ROVAI_RUNTIME_ACTIVITY_ACCEPT_WEB_SEARCH_ONLY === '1'
+const toolDetailsOnly = process.env.ROVAI_RUNTIME_ACTIVITY_ACCEPT_TOOL_DETAILS_ONLY === '1'
 const databasePath = join(dataDir, 'rovai.sqlite')
 const debugPort = process.env.ROVAI_RUNTIME_ACTIVITY_ACCEPT_DEBUG_PORT
   ? Number(process.env.ROVAI_RUNTIME_ACTIVITY_ACCEPT_DEBUG_PORT)
@@ -192,25 +193,28 @@ try {
   await waitForExpression(app.cdp, `document.querySelector('.camp-detail-popover')?.hidden === false`)
   await mouseClickSelector(app.cdp, '.run-pulse-inspector .execution-placement-button')
   await waitForExpression(app.cdp, `document.querySelector('.execution-drawer')?.dataset.placement === 'bottom'`)
-  if (!webSearchOnly) {
+  if (!webSearchOnly && !toolDetailsOnly) {
     await evaluate(app.cdp,
       `document.querySelector('.execution-drawer [aria-label="收起执行详情"]')?.click()`)
     await waitForExpression(app.cdp, `!document.querySelector('.execution-drawer')`)
   }
 
-  if (webSearchOnly) {
+  if (webSearchOnly || toolDetailsOnly) {
     const webSearchPresentation = await verifyWebSearchPresentation(app.cdp)
     const webSearchCapture = join(outputDir, 'runtime-activity-web-search.png')
     await capture(app.cdp, webSearchCapture)
-    const reportPath = join(outputDir, 'runtime-search-acceptance.json')
+    const shellPresentation = toolDetailsOnly ? await verifyClaudeCommandDisclosure(app.cdp) : null
+    const shellCapture = toolDetailsOnly ? join(outputDir, 'runtime-activity-shell-command.png') : null
+    if (shellCapture) await capture(app.cdp, shellCapture)
+    const reportPath = join(outputDir, toolDetailsOnly ? 'runtime-tool-details-acceptance.json' : 'runtime-search-acceptance.json')
     const report = {
       ok: true,
-      mode: 'controlled-runtime-web-search-fixture',
+      mode: toolDetailsOnly ? 'controlled-runtime-tool-details-fixture' : 'controlled-runtime-web-search-fixture',
       app: basename(appPath),
       fixtureRoot,
       outputDir,
-      verified: { webSearchPresentation },
-      captures: { webSearch: webSearchCapture }
+      verified: { webSearchPresentation, ...(toolDetailsOnly ? { shellPresentation } : {}) },
+      captures: { webSearch: webSearchCapture, ...(shellCapture ? { shell: shellCapture } : {}) }
     }
     await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`)
     console.log(JSON.stringify({ ...report, reportPath }, null, 2))
@@ -3099,7 +3103,7 @@ async function verifyWebSearchPresentation(cdp) {
   })()`)
   assert(opened.found
     && opened.groupFound
-    && opened.groupLabel === '已执行 1 项操作；状态：全部成功',
+    && opened.groupLabel === '完成了 1 个步骤',
   `Web search was not counted inside the Tool operation group: ${JSON.stringify(opened)}`)
   await waitForExpression(cdp, `(() => {
     const disclosure = [...document.querySelectorAll('.execution-drawer details.tool-call-disclosure')]


### PR DESCRIPTION
成品工具验收仍断言旧的“已执行 1 项操作；状态：全部成功”，与当前 Canonical 工具组合同及 PR #255 的生产呈现不符。同步为“完成了 1 个步骤”，并增加共享工具详情的定向入口，组合验证 Web 查询全文、步骤计数和图标，以及无输出 Shell 命令的结果展开。

已在 main f3087ea2 构建的 arm64/ad-hoc 成品中通过该定向验收；语法检查和文档治理通过。没有修改生产代码或放宽全量断言。全量交互脚本本轮仍被既有消息操作栏的 -5px 左偏移拦住，原因和验证边界已记录在当前版本验收文档中。
