### PR TITLE
perf: speed up new conversation creation

### DIFF
--- a/crates/rovai-core/src/git.rs
+++ b/crates/rovai-core/src/git.rs
@@ -195,11 +195,10 @@ pub async fn observe_git(path: &Path) -> GitObservation {
         };
     }
 
-    let (root, common, object_format, status, head_commit, branch) = tokio::join!(
+    let (root, common, object_format, head_commit, branch) = tokio::join!(
         required_git_text(path, &["rev-parse", "--show-toplevel"]),
         required_git_text(path, &["rev-parse", "--git-common-dir"]),
         required_git_text(path, &["rev-parse", "--show-object-format"]),
-        git_output(path, &["status", "--porcelain=v1", "-z"]),
         optional_git_text(path, &["rev-parse", "--verify", "HEAD^{commit}"]),
         optional_git_text(path, &["symbolic-ref", "--quiet", "--short", "HEAD"]),
     );
@@ -244,13 +243,6 @@ pub async fn observe_git(path: &Path) -> GitObservation {
         }
         Err(error) => return invalid_observation(observed_at, format!("{error:#}")),
     };
-    let status = match status {
-        Ok(output) if output.status.success() => output,
-        Ok(output) => {
-            return invalid_observation(observed_at, output_error(&output, "Git status failed"));
-        }
-        Err(error) => return invalid_observation(observed_at, format!("{error:#}")),
-    };
     GitObservation {
         state: GitCapabilityState::GitValid,
         repository_root: Some(repository_root.to_string_lossy().to_string()),
@@ -258,7 +250,10 @@ pub async fn observe_git(path: &Path) -> GitObservation {
         object_format: Some(object_format),
         head_commit,
         branch,
-        dirty: Some(!status.stdout.is_empty()),
+        // Working-tree state is intentionally not scanned. Runtime file-change
+        // evidence owns changed-file attribution, while `git status` can make
+        // workspace inspection and Camp creation scale with untracked content.
+        dirty: None,
         observed_at,
         diagnostic: None,
     }
@@ -425,13 +420,13 @@ mod tests {
             GitCapabilityState::GitValid
         );
         assert_eq!(empty_inspection.git_observation.head_commit, None);
-        assert_eq!(empty_inspection.git_observation.dirty, Some(false));
+        assert_eq!(empty_inspection.git_observation.dirty, None);
 
         fs::remove_dir_all(root).unwrap();
     }
 
     #[tokio::test]
-    async fn git_observation_tracks_head_branch_and_dirty_state() {
+    async fn git_observation_tracks_head_and_branch_without_claiming_dirty_state() {
         let root = test_root("observation");
         let data_dir = root.join("data");
         let project = root.join("project");
@@ -448,11 +443,13 @@ mod tests {
         assert_eq!(clean.state, GitCapabilityState::GitValid);
         assert!(clean.head_commit.is_some());
         assert!(clean.branch.is_some());
-        assert_eq!(clean.dirty, Some(false));
+        assert_eq!(clean.dirty, None);
 
         fs::write(project.join("README.md"), "changed\n").unwrap();
-        let dirty = observe_git(&project).await;
-        assert_eq!(dirty.dirty, Some(true));
+        let changed = observe_git(&project).await;
+        assert_eq!(changed.head_commit, clean.head_commit);
+        assert_eq!(changed.branch, clean.branch);
+        assert_eq!(changed.dirty, None);
 
         fs::remove_dir_all(root).unwrap();
     }

--- a/crates/rovai-core/src/main.rs
+++ b/crates/rovai-core/src/main.rs
@@ -6775,16 +6775,15 @@ impl Core {
                         )
                     })?;
                 }
-                let inspection = git::inspect_workspace(
+                let selection = git::select_workspace(
                     Path::new(&requested_path),
                     &self.data_dir,
                     project_binding_kind == ProjectBindingKind::QuickChat,
-                )
-                .await?;
+                )?;
                 let command = CreateCampCommand {
                     name: params.name,
                     project_binding_kind,
-                    project_path: inspection.project_path,
+                    project_path: selection.project_path,
                     member_agent_ids: params.member_agent_ids,
                     default_lead_agent_id: params.default_lead_agent_id,
                     collaboration_mode: params.collaboration_mode,

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 ---
 document_type: documentation-index
 authority: documentation-routing
-last_updated: 2026-09-06
+last_updated: 2026-09-07
 ---
 
 # Rovai-ai 文档导航
@@ -41,7 +41,7 @@ last_updated: 2026-09-06
 | 修改渠道 Camp 自动命名、来源前缀或手动重命名展示 | [Channel Camp Naming v1](contracts/channel-camp-naming-v1.md)、[Camp 命名不变量](architecture/foundational-invariants.md#camp-lifecycle)、[App Shell 与统一侧栏](ui/components/app-shell-navigation.md) |
 | 新增或修改 Runtime Activity 映射规则 | [Runtime Activity Mapping 维护指南](runtime-activity/README.md)及[Registry](runtime-activity/registry.md) |
 | 修改内置 Agent CLI、IPC、Envelope、receipt、Projection、Gather、Single Chat history、队员创建、纯附件 Agent Send 或幂等合同 | [Built-in Tool Transport v22 合同](contracts/builtin-tool-transport-v22.md)、[Built-in 运输不变量](architecture/foundational-invariants.md#skills-builtin-transport)、[Gather v5](contracts/gather-v5.md)、[Skill Library 与投影不变量](architecture/foundational-invariants.md#skills-library-projection)、[Camp Message Send v19](contracts/camp-message-send-v19.md)及[Current User Attention v4](contracts/current-user-attention-v4.md) |
-| 修改普通用户 `rovai app`、User Automation IPC/credential、Camp/Run 终端自动化、Diagnostic Trial、双 cursor 或诊断 bundle | [User Automation v1](contracts/user-automation-v1.md)、[User Automation Architecture](architecture/user-automation.md)、[User Automation 不变量](architecture/foundational-invariants.md#user-automation-trial)及[v1.21 交付版本](versions/v1.21/README.md) |
+| 修改普通用户 `rovai app`、Workspace inspection、Camp/Run 终端自动化、Diagnostic Trial、双 cursor 或诊断 bundle | [User Automation v2](contracts/user-automation-v2.md)、[User Automation Architecture](architecture/user-automation.md)、[Workspace 与动态 Git 不变量](architecture/foundational-invariants.md#camp-workspace)及[当前版本](versions/v1.53/README.md) |
 | 修改 `camp.search`、`camp.read`、`history.search`、Agent/Human Principal message projection、跨 Camp Manifest/live authorization、Public A2A 历史可见性、Camp message publication fence 或 Agent read 附件输出 | [Camp History Retrieval v4](contracts/camp-history-v4.md)、[公共上下文不变量](architecture/foundational-invariants.md#context-public-history)、[History 与寻址不变量](architecture/foundational-invariants.md#collaboration-history-addressing)、[Message Delivery 不变量](architecture/foundational-invariants.md#collaboration-delivery)、[Built-in Tool Runtime](architecture/builtin-tool-runtime.md)及[Public A2A Message Delivery](architecture/public-a2a-message-delivery.md) |
 | 修改 Memory 在线捕获、complete exact-Scope View、Agent mutation、copyable target、Hearth Review、active body quota、clean break、候选清除、Forget 闭包或审核并发 | [Online Memory Capture 架构](architecture/online-memory-capture.md)、[Memory Capture v3](contracts/memory-capture-v3.md)、[Memory 写入与存储不变量](architecture/foundational-invariants.md#memory-write-store)及[Memory 读取与投影不变量](architecture/foundational-invariants.md#memory-read-projection) |
 | 修改通知来源、Episode 聚合、未读/清除、会话可见确认、增量、浮层设置或类型化导航 | [Notification Episode v5](contracts/notification-episode-v5.md)、[Current User Attention v4](contracts/current-user-attention-v4.md)、[通知事实与投影](architecture/foundational-invariants.md#core-notifications)及[Notification Episode 架构](architecture/notification-episodes.md) |

--- a/docs/architecture/foundational-invariants.md
+++ b/docs/architecture/foundational-invariants.md
@@ -1,7 +1,7 @@
 ---
 document_type: architecture
 authority: current-foundational-invariants
-last_updated: 2026-09-06
+last_updated: 2026-09-07
 ---
 
 # 当前基础架构不变量
@@ -95,7 +95,7 @@ last_updated: 2026-09-06
 ### Workspace 与动态 Git 能力
 
 - 每个 Camp 的持久 Workspace Binding 由 `projectBindingKind: quick_chat | directory` 和绝对、规范化、可遍历且安全的 `projectPath` 组成。`quick_chat` 指向应用受管的 Quick Chat 目录，`directory` 指向用户明确选择的安全目录。Core 拒绝文件系统根、产品私有数据树、直接 Git 元数据目录和 bare repository；Runtime 权限仍独立决定 Agent 实际可做什么。
-- Git 是对当前目录的动态能力，而不是 Camp 身份。Core 在创建、Run 启动、Git 专用操作和 Run 终止等边界重新观测 `not_git | git_valid | git_invalid`；Git 失效只关闭 Git 专用行为，不废止安全目录、协作历史或普通文件工作。
+- Git 是对当前目录的动态能力，而不是 Camp 身份。Camp 创建只重新执行 Core-owned 目录准入，不运行 Git 子进程；显式 Workspace inspection、Run 启动、Git 专用操作和 Run 终止等边界重新观测 `not_git | git_valid | git_invalid`、HEAD 与 branch。Git observation 不扫描 tracked/untracked 工作树，新 observation 的 nullable `dirty` 固定为 unavailable；Git 失效只关闭 Git 专用行为，不废止安全目录、协作历史或普通文件工作。
 - AgentRun 文件变化只来自 Runtime 在该 `agentRunId + executionEpoch` 内明确报告并已落库的可靠终态 Evidence。
   Core 不通过 Git tree、baseline/final、checkpoint ref、目录扫描或当前文件读取补充结果，也不跨 Run 合并；因此
   Git 与非 Git workspace 使用相同观测能力，并行 Run 分别形成自己的结果。
@@ -103,7 +103,7 @@ last_updated: 2026-09-06
   root 内的相对路径或 root 外的规范化绝对路径。当前 Built-in Tool Process 的精确 `ROVAI_RUN_TMP` 及后代必须在
   durable Evidence ingress 前排除；该边界不扩大到应用 data dir、其他进程临时目录、同名前缀目录或普通 root 外
   用户文件，也不打开文件、不改变 ACP Client FS/Terminal 的 Runtime-owned 权限模型。
-- AgentRun 仍冻结 workspace 路径及起止 Git observation 作为既有终态审计事实；这些 per-Run audit facts 不参与
+- AgentRun 仍冻结 workspace 路径及起止 Git capability、HEAD 与 branch observation 作为既有终态审计事实；历史 boolean dirty 保留读取，新 observation 不采集 dirty。这些 per-Run audit facts 不参与
   文件变化卡片归约，也不成为 Project/导航身份。导航继续按规范目录路径分组，不引入 Project 表或 Repository
   Scope。
 - **Quick Chat / 快速对话** 是应用受管 workspace 的规范领域与产品分组术语，不是 Camp 或 Project。Rust variant 使用 `QuickChat`，存储与 IPC 值使用 `quick_chat`，JavaScript/TypeScript property 使用 `quickChat`，CSS/test identifier 与受管目录名使用 `quick-chat`。旧称只允许存在于历史快照和迁移证据；当前代码、合同与投影不保留 alias、deprecated field、dual read 或旧 wire value 翻译。
@@ -181,7 +181,7 @@ last_updated: 2026-09-06
 - CampMember 只表达 Camp 内关系，不复制全局 Presence。成员顺序使用稳定、不复用的关系序列；Default Lead 必须是当前有效关系且符合领导资格，Camp 至少保留一位 active member。动态关系命令使用 generation/version CAS，Lead successor 与影响预览由 Core 验证，不由 Renderer 自选替代。
 - Camp 只冻结 workspace binding 和成员关系，Git/Project 是可重观测投影而不是新聚合。新 Camp 不预创建 Conversation 或 Run；原子 Execution Admission 为精确目标惰性创建 Conversation、公共消息、Turn 与 queued Run，多目标保持 all-or-none。Workspace、Git、Runtime 与可执行文件检查属于后续 Scheduler dispatch 边界。永久删除默认要求 quiescent，force 只能在用户明确确认和持久停止/隔离边界后执行。
 - 外部渠道不得直接写 CampMessage、CampTurn 或 AgentRun；完成 transport dedup/聚合和 live binding recheck 后，必须复用同一原子 Execution Admission。尚未绑定或仍在渠道 FIFO 中的消息不是公共消息，也不进入 History、Context 或执行。`ExternalPrincipal` 只表达作者、上下文来源和回复目标，不继承 `local_user` 的项目、绑定或本机管理能力。
-- Renderer 可以先本地显示待确认的用户消息，但不得把它当成 CampMessage。Core 接受发送时原子持久公共消息、Turn、目标 Run 和冻结配置；Scheduler 在执行边界完成 workspace、Runtime、Git、当前 exact membership lifetime/permission/fence 检查。所有 Agent 业务工具也必须匹配 Run 冻结的 membership version；再次添加同一 Agent 不恢复旧 Run 权限。失败产生诚实 Run 终态，不撤销已接受消息；per-Run ending Git observation 属于终态审计，Runtime 文件变化属于 terminal 后的附加 Evidence projection，二者都不是发送准入。
+- Renderer 可以先本地显示待确认的用户消息，但不得把它当成 CampMessage。Core 接受发送时原子持久公共消息、Turn、目标 Run 和冻结配置；Scheduler 在执行边界完成 workspace、Runtime、Git、当前 exact membership lifetime/permission/fence 检查。所有 Agent 业务工具也必须匹配 Run 冻结的 membership version；再次添加同一 Agent 不恢复旧 Run 权限。失败产生诚实 Run 终态，不撤销已接受消息；per-Run ending Git metadata observation 属于终态审计，Runtime 文件变化属于 terminal 后的附加 Evidence projection，二者都不是发送准入。
 - 一次 CampTurn 的 root Run 与 A2A 后代共享冻结 execution budget。Core 以一个事务检查与消费总 AgentRun、accepted A2A、depth、fanout 和相关 allowance，并对重放返回同一结果；客户端、Runtime 或多条 Delivery 不能拆分请求绕过预算。
 - CampMessage/CampTurn/AgentRun/Conversation 与 Domain Event 的创建、开始、更新和结束字段使用调用时 UTC wall clock；`AgentRun.created_at` 属于输入接受边界，`started_at` 属于实际 claim 边界。Execution Budget 另用非倒退 observation，取 wall clock、进程 awake elapsed anchor 和上次 observation 的最大值，使系统休眠计入 deadline、wall clock 回拨不延长预算；Budget observation 不得写入业务审计时间。
 - Composer Stop 作用于整个 CampTurn；共享 ExecutionDrawer 的 Run Stop 只作用于当前 Run，不取消兄弟 Run 或关闭整轮渠道输出。两者都在 Core 事务提交 cancelled 业务终态，IPC 返回后结束等待；Runtime 后台清理不影响业务终态。发送与效果不确定性继续保存在 Input/Action 审计中，但取消不产生公共 hasUnsettledExternalEffects 提示，也不允许自动重发。待发送队列按业务 Turn 完成推进，同 Conversation 的新执行仍须通过旧 Runtime 清理隔离。

--- a/docs/architecture/user-automation.md
+++ b/docs/architecture/user-automation.md
@@ -3,13 +3,13 @@ document_type: architecture
 architecture: user-automation
 authority: desktop-user-automation-component-boundaries
 status: accepted
-last_updated: 2026-08-23
+last_updated: 2026-09-07
 ---
 
 # User Automation Architecture
 
 本文说明普通用户终端自动化与 Runtime Diagnostic Trial 的长期组件边界。字段、命令、错误和 bundle 以
-[User Automation v1](../contracts/user-automation-v1.md)为准；决定理由见
+[User Automation v2](../contracts/user-automation-v2.md)为准；决定理由见
 [v1.21 决策](../versions/v1.21/decisions.md)。
 
 ## 进程结构
@@ -70,6 +70,10 @@ Diagnostic Trial 只回答“这个已配置成员 Runtime 能否在当前产品
 Core 的安全诊断投影把 frozen facts、公开输出与派生摘要组合成 allowlist view。Main 和 CLI 不读取 raw Runtime
 payload 后再做黑名单脱敏；这样新私有字段不会因调用方忘记删除而进入终端或 bundle。公共结果必须来自
 CampMessage publication seam，Evidence 只说明观察事实，不替代消息、Task outcome 或 terminal authority。
+
+Workspace inspection 只读取目录身份和轻量 Git metadata；Camp 创建重新执行目录准入，但不重复 inspection。
+Run 起止 observation 同样不扫描 tracked/untracked 工作树，新 `dirty` 为 unavailable。历史 dirty boolean 只作为
+既有诊断事实继续读取；Files Changed Card 仍完全来自 Runtime Evidence。
 
 ## Desktop 生命周期
 

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -1,7 +1,7 @@
 ---
 document_type: contracts-index
 authority: protocol-contract-routing
-last_updated: 2026-09-06
+last_updated: 2026-09-07
 ---
 
 # 长期接口合同
@@ -168,7 +168,8 @@ Architecture 解释组件如何组成，Version 概览记录交付范围；它�
 | [Runtime Usage Monitoring v2（历史）](runtime-usage-monitoring-v2.md) | 五表 clean break、内存 Usage 合并、稀疏 Token/Cache/Cost、Coverage、单 Snapshot 与有界刷新 |
 | [Runtime Monitoring v1（历史）](runtime-monitoring-v1.md) | Clean-break collection/enrollment、稀疏 Usage Observation、Native Session fact、三类查询、Coverage、Tool Duration 与 Cost layer |
 | [Diagnostics Center v1（当前）](diagnostics-center-v1.md) | `diagnostics.check` typed read model、三态分类、显式单项修复映射、Recovery 与集中脱敏的 `rovai-diagnostics-v5` |
-| [User Automation v1（当前）](user-automation-v1.md) | 普通用户 `rovai app` 的独立本机 IPC、Runtime OS 隔离、原子 Camp/Run 自动化、真实 shell exit、双 cursor Diagnostic Trial、安全投影与私有 bundle |
+| [User Automation v2（当前）](user-automation-v2.md) | v1 transport、Trial 与安全投影不变；Camp 创建只做目录准入，Git observation 不扫描工作树且新 dirty 为 null |
+| [User Automation v1（历史）](user-automation-v1.md) | 普通用户 `rovai app` 的独立本机 IPC、Runtime OS 隔离、原子 Camp/Run 自动化、真实 shell exit、双 cursor Diagnostic Trial、安全投影与私有 bundle |
 | [Network Interruption Recovery v1（当前）](network-interruption-recovery-v1.md) | App/Core 持续运行期间的严格网络分类、Core 内存固定退避、Input Delivery 安全门禁、ACP terminal 接管、online/resume wake 与三态投影 |
 | [Accepted Input Recovery v5（当前）](accepted-input-recovery-v5.md) | v4 发送边界不变；普通恢复失败与业务取消终态分离 |
 | [Accepted Input Recovery v4（历史）](accepted-input-recovery-v4.md) | 新增 `dispatch_started_at`；发送/取消事务排序，迟到回执只补证据 |

--- a/docs/contracts/user-automation-v2.md
+++ b/docs/contracts/user-automation-v2.md
@@ -1,0 +1,50 @@
+---
+document_type: interface-contract
+contract: user-automation
+version: 2
+authority: desktop-user-automation-transport-and-diagnostic-trial
+status: accepted
+source_version: v1.53
+last_updated: 2026-09-07
+---
+
+# User Automation v2
+
+## 1. 继承范围
+
+v2 完整继承 [User Automation v1](user-automation-v1.md) 的本机 IPC、鉴权、封闭命令、幂等、
+Diagnostic Trial、双 cursor、退出码、安全投影与私有 bundle 边界，只收敛 Workspace 创建和 Git
+observation 的工作树扫描语义。
+
+## 2. Workspace 创建与检查
+
+`camps.create` 只重新执行 Core-owned 目录准入：绝对路径、存在性、规范化、可读目录、文件系统根、
+应用私有数据和 Git metadata/bare repository 边界。创建命令不执行 Git 子进程，不采集 Git
+observation，也不依赖 Renderer 或 CLI 之前返回的 inspection 才能安全提交。
+
+`workspaces.inspect` 保留动态 Git capability、repository root、common dir、object format、HEAD、branch
+和 observation time，用于目录选择展示与 Diagnostic Trial baseline。该读取不得执行 `git status`、扫描
+tracked/untracked 文件或把工作区内容规模带入创建延迟。
+
+## 3. Git observation 兼容语义
+
+`GitObservation.dirty` 保持 `boolean | null` wire shape。v2 新 observation 固定返回 `null`，表示未采集，
+不能用 `false` 表示 clean。历史 AgentRun 已保存的 `true | false` 原样读取，不迁移、不重写。
+
+AgentRun 启动与终止仍冻结当时可读的 Git capability、HEAD 和 branch，供诊断还原执行版本背景；它们不
+扫描工作树。`agentRuns.diagnostic.get` schema 保持 1，baseline/final 的 `dirty` 因而可以同时包含历史
+boolean 与新 `null`。Trial 的 `workspace-baseline.json` 使用相同语义。
+
+## 4. 文件变化边界
+
+Git observation 不参与 AgentRun 文件变化归约。Files Changed Card 只使用 Runtime 在精确
+`agentRunId + executionEpoch` 内明确报告并已落库的可靠终态 Evidence；移除工作树扫描不得增加 Git diff、
+目录扫描或当前文件读取作为替代来源。
+
+## 5. 验收
+
+- Git 与非 Git 目录仍可创建 Camp，持久化规范化目录身份；创建路径不启动 Git 子进程。
+- Git inspection 和 Run 起止 observation 仍返回 capability、HEAD、branch；新 `dirty` 为 `null`。
+- 大量未跟踪文件不再增加创建、inspection 或 Run observation 的 Git 工作树扫描成本。
+- 既有历史 boolean dirty 值可继续通过 AgentRun 与 Diagnostic 投影读取。
+- Files Changed Card 的内容、顺序和来源不变。

--- a/docs/decisions/CURRENT.md
+++ b/docs/decisions/CURRENT.md
@@ -1,7 +1,7 @@
 ---
 document_type: current-decision-navigation
 authority: current-authority-and-rationale-routing
-last_updated: 2026-09-06
+last_updated: 2026-09-07
 ---
 
 # 当前规范与决定理由导航
@@ -100,8 +100,8 @@ last_updated: 2026-09-06
 
 ## User Automation 与 Diagnostic Trial
 
-- 当前规范：[User Automation 不变量](../architecture/foundational-invariants.md#user-automation-trial)、[User Automation Architecture](../architecture/user-automation.md)和[User Automation v1](../contracts/user-automation-v1.md)。
-- 理由来源：[V1.21-D01](../versions/v1.21/decisions.md#v1-21-d01)、[V1.21-D02](../versions/v1.21/decisions.md#v1-21-d02)、[V1.21-D03](../versions/v1.21/decisions.md#v1-21-d03)、[V1.21-D04](../versions/v1.21/decisions.md#v1-21-d04)。
+- 当前规范：[User Automation 不变量](../architecture/foundational-invariants.md#user-automation-trial)、[Workspace 与动态 Git 不变量](../architecture/foundational-invariants.md#camp-workspace)、[User Automation Architecture](../architecture/user-automation.md)和[User Automation v2](../contracts/user-automation-v2.md)。
+- 理由来源：[V1.21-D01](../versions/v1.21/decisions.md#v1-21-d01)、[V1.21-D02](../versions/v1.21/decisions.md#v1-21-d02)、[V1.21-D03](../versions/v1.21/decisions.md#v1-21-d03)、[V1.21-D04](../versions/v1.21/decisions.md#v1-21-d04)及[V1.53-D05](../versions/v1.53/decisions.md#v1-53-d05)。
 
 ## Evidence、Runtime Activity 与 Usage
 

--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -4,7 +4,7 @@ authority: renderer-ui-routing
 status: accepted
 design_direction: porcelain-day-steel-night
 target_version: cross-version
-last_updated: 2026-09-06
+last_updated: 2026-09-07
 ---
 
 # Rovai AI UI 规范
@@ -54,7 +54,7 @@ Runtime 终态文件行与会话中的每 Run 文件变化卡片由
 
 普通用户通过 `rovai app camp open` 请求导航时，Desktop Main 必须先验证 Camp，再复用现有 window 恢复与
 Camp activation 路径；Renderer 不接收 automation credential、socket、任意 route 或本地路径，也不建立第二套
-视觉 surface。字段和错误由 [User Automation v1](../contracts/user-automation-v1.md)拥有。
+视觉 surface。字段和错误由 [User Automation v2](../contracts/user-automation-v2.md)拥有。
 
 ## 页面局部 Brief
 

--- a/docs/versions/v1.53/README.md
+++ b/docs/versions/v1.53/README.md
@@ -9,7 +9,7 @@ model_context_change: false
 last_updated: 2026-09-07
 ---
 
-# Rovai-ai v1.53：Runtime 图片来源、工具一致性、正文块持久化与网络恢复
+# Rovai-ai v1.53：Runtime 图片来源、工具一致性、正文块持久化、网络恢复与创建性能
 
 前置：[v1.52](../v1.52/README.md)。本版本保留 Runtime 结构化图片观察、混合存储、按需读取和既有图片
 Gallery，只收紧 Runtime 图片自动进入 Camp 公屏的来源准入。
@@ -71,19 +71,31 @@ Gallery，只收紧 Runtime 图片自动进入 Camp 公屏的来源准入。
 命令图标、精确结果和步骤计数。保留审批、重试、网络恢复、停止和失败事实，以及已展开结果状态。
 这是已确认界面的局部修复，不新增 Runtime、数据库或投递合同；验证记录见[实施与验收](implementation-plan.md#单聊与执行台反馈补充)。
 
+## 新对话创建性能补充
+
+- `camps.create` 只重新执行 Core directory admission 与路径规范化，不运行 Git 子进程；Camp 持久化不再被
+  工作树大小或未跟踪文件数量阻塞。
+- 显式 Workspace inspection 与 AgentRun 起止 observation 保留 capability、HEAD、branch 等轻量 metadata，
+  但不执行 `git status` 或扫描工作树。新 observation 的 `dirty` 为 `null`，历史布尔值继续兼容读取。
+- Files Changed / Diff Card 的权威不变，继续只来自当前 AgentRun 与 execution epoch 的 Runtime evidence；
+  本次优化不改变 Renderer 布局、文件变化归约或 Git 专用操作。
+
+边界与理由见 [V1.53-D05](decisions.md#v1-53-d05)、[User Automation v2](../../contracts/user-automation-v2.md)
+及[实施与验收](implementation-plan.md#新对话创建性能补充)。
+
 ## 跨版本文档影响
 
 | 范围 | 结论 | 证据或理由 |
 | --- | --- | --- |
-| Version lifecycle | 已更新 | v1.52 冻结为 historical；本概览、[实施计划](implementation-plan.md)、版本索引与前后链接建立唯一 current v1.53 |
-| Decisions | 已更新 | [V1.53-D01](decisions.md#v1-53-d01)拥有图片准入理由，[D02](decisions.md#v1-53-d02)拥有正文块与维护调用理由，[D03](decisions.md#v1-53-d03)拥有部署迁移汇合理由，[D04](decisions.md#v1-53-d04)拥有网络安全续接理由；CURRENT 已纳入导航 |
-| Contracts | 已更新 | [Runtime Images v5](../../contracts/runtime-images-v5.md)、[Camp Open Projection v16](../../contracts/camp-open-projection-v16.md)、[Runtime File Change Observation v3](../../contracts/runtime-file-change-observation-v3.md)与 [Run Process Detail Surface v31](../../contracts/run-process-detail-surface-v31.md)分别拥有图片、读取、typed 操作与工具呈现；[Network Interruption Recovery v1](../../contracts/network-interruption-recovery-v1.md)拥有网络分类、固定退避与 Input 安全门禁 |
-| Architecture | 已更新 | [Runtime 图片](../../architecture/runtime-images.md)、[文件操作](../../architecture/runtime-file-change-observation.md)、[Availability-first Runtime](../../architecture/availability-first-runtime.md#migration-switch)同步保留式投影与精确升级源汇合；[AgentRun Recovery](../../architecture/agent-run-recovery.md)同步进程内恢复协调与生命周期 |
-| UI | 已更新 | [Camp 会话工作区](../../ui/components/conversation-workspace.md)与 [File Preview](../../ui/components/file-preview.md)保留合入分支的工具一致性和文件阅读语义；正文优化不增加界面设计改动；网络恢复补充等待、恢复与需处理状态及 Stop 保留规则 |
+| Version lifecycle | 已更新 | v1.52 冻结为 historical；本概览、[实施计划](implementation-plan.md)、版本索引与前后链接建立唯一 current v1.53，并记录创建性能补充 |
+| Decisions | 已更新 | [V1.53-D01](decisions.md#v1-53-d01)拥有图片准入理由，[D02](decisions.md#v1-53-d02)拥有正文块与维护调用理由，[D03](decisions.md#v1-53-d03)拥有部署迁移汇合理由，[D04](decisions.md#v1-53-d04)拥有网络安全续接理由，[D05](decisions.md#v1-53-d05)拥有 Camp 创建与 Git observation 的性能边界；CURRENT 已纳入导航 |
+| Contracts | 已更新 | [Runtime Images v5](../../contracts/runtime-images-v5.md)、[Camp Open Projection v16](../../contracts/camp-open-projection-v16.md)、[Runtime File Change Observation v3](../../contracts/runtime-file-change-observation-v3.md)与 [Run Process Detail Surface v31](../../contracts/run-process-detail-surface-v31.md)分别拥有图片、读取、typed 操作与工具呈现；[Network Interruption Recovery v1](../../contracts/network-interruption-recovery-v1.md)拥有网络分类、固定退避与 Input 安全门禁；[User Automation v2](../../contracts/user-automation-v2.md)拥有创建和轻量 Git observation 边界 |
+| Architecture | 已更新 | [Runtime 图片](../../architecture/runtime-images.md)、[文件操作](../../architecture/runtime-file-change-observation.md)、[Availability-first Runtime](../../architecture/availability-first-runtime.md#migration-switch)同步保留式投影与精确升级源汇合；[AgentRun Recovery](../../architecture/agent-run-recovery.md)同步进程内恢复协调与生命周期；[Workspace 不变量](../../architecture/foundational-invariants.md#camp-workspace)与 [User Automation](../../architecture/user-automation.md)同步无工作树扫描边界 |
+| UI | 已更新 | [Camp 会话工作区](../../ui/components/conversation-workspace.md)与 [File Preview](../../ui/components/file-preview.md)保留合入分支的工具一致性和文件阅读语义；正文优化不增加界面设计改动；网络恢复补充等待、恢复与需处理状态及 Stop 保留规则；创建性能补充不改变界面 |
 | Runtime Activity | 已更新 | [Registry](../../runtime-activity/registry.md)记录 activity-v3、可靠 typed read/write、历史 classifier 冻结和两种部署源兼容 |
-| Runtime compatibility | 确认无需更新 | 不改变 Runtime 启动、协议能力或平台资格；只使用已经适配并验证的原生事件字段 |
-| Documentation routing | 已更新 | 文档任务导航、Contracts/Architecture 索引、版本指针和当前决定导航均指向 Runtime Images v5、Camp Open v16 与 Network Interruption Recovery v1 |
-| Root README | 确认无需更新 | 项目定位、安装方法与公开 Runtime 支持范围不因本地公屏图片集合收紧而变化 |
+| Runtime compatibility | 确认无需更新 | 不改变 Runtime 启动、协议能力或平台资格；创建性能补充也不改变 Runtime 文件变化 Evidence |
+| Documentation routing | 已更新 | 文档任务导航、Contracts/Architecture 索引、版本指针和当前决定导航已包含 User Automation v2 与 Workspace inspection 边界 |
+| Root README | 确认无需更新 | 项目定位、安装方法与公开 Runtime 支持范围不因本地公屏图片集合或创建路径内部优化而变化 |
 
 ## References
 
@@ -91,5 +103,6 @@ Gallery，只收紧 Runtime 图片自动进入 Camp 公屏的来源准入。
 - [版本决定](decisions.md)
 - [Runtime Images v5](../../contracts/runtime-images-v5.md)
 - [Camp Open Projection v16](../../contracts/camp-open-projection-v16.md)
+- [User Automation v2](../../contracts/user-automation-v2.md)
 - [Runtime 图片架构](../../architecture/runtime-images.md)
 - [Camp 会话工作区](../../ui/components/conversation-workspace.md#runtime-图片与消息图片)

--- a/docs/versions/v1.53/decisions.md
+++ b/docs/versions/v1.53/decisions.md
@@ -2,7 +2,7 @@
 document_type: version-decisions
 version: v1.53
 lifecycle: current
-last_updated: 2026-09-06
+last_updated: 2026-09-07
 ---
 
 # v1.53 决定
@@ -117,3 +117,38 @@ Delivery 都 fail closed。Claude Code 明确仍在原生 API retry 时不登记
 当前规范见 [Network Interruption Recovery v1](../../contracts/network-interruption-recovery-v1.md)、
 [AgentRun Recovery](../../architecture/agent-run-recovery.md)与
 [Camp 会话工作区](../../ui/components/conversation-workspace.md)。
+
+<a id="v1-53-d05"></a>
+## V1.53-D05：Camp 创建只做目录准入，Git observation 不扫描工作树
+
+### 背景
+
+标准新建对话流程会先调用 `workspaces.inspect` 展示工作区信息，随后 `camps.create` 又执行一次完整 Git
+inspection。后者实际只消费规范化项目路径，却连带运行 `git status --porcelain=v1 -z`；该命令的成本会随
+工作树和未跟踪内容增长，在较大仓库中可把本应为毫秒级的 Camp 持久化放大到数秒。
+
+Files Changed / Diff Card 已由 Runtime execution evidence 及其文件变更投影拥有，不读取 Git dirty。
+`GitObservation.dirty` 只进入诊断和历史导出，未参与 Camp 准入、调度、AgentRun 生命周期判断或 Renderer
+产品展示，因此不能用创建路径的同步延迟换取这一弱观测。
+
+### 决定
+
+`camps.create` 只通过 Core directory admission 完成目录存在性、类型、受管目录排除和规范化校验，不执行
+任何 Git 子进程。显式 `workspaces.inspect` 以及 AgentRun 开始／结束 observation 继续读取 Git capability、
+repository root、common directory、object format、HEAD 和 branch，但不运行 `git status`，也不扫描工作树；
+新 observation 的 `dirty` 写为 `null`。
+
+保留 nullable `dirty` 字段与历史布尔值的读取兼容，不修改诊断 schema。仓库测试、发布脚本或开发门禁中
+有明确目的的 `git status` 不属于产品运行路径，继续保留。
+
+### 后果与被拒绝方案
+
+- 新建对话的后端路径不再随仓库未跟踪文件数量增长；标准对话框仍可显示 branch 等轻量 Git metadata。
+- 新产生的诊断记录不再声称掌握运行前后工作树 dirty；历史 `true` / `false` 仍可原样读取。
+- 拒绝缓存或复用一次完整 `git status`：它既保留首次延迟，也会快速失效，且创建流程不消费其结果。
+- 拒绝 `--untracked-files=no`：它仍扫描索引和已跟踪文件，同时把不完整结果包装成 dirty 事实。
+- 拒绝改用 Git diff 驱动 Files Changed：它会丢失 Runtime owner、epoch、工具证据和实时投影语义。
+
+当前规范见 [Workspace / Git 不变量](../../architecture/foundational-invariants.md#camp-workspace)、
+[User Automation v2](../../contracts/user-automation-v2.md)与
+[Runtime 文件变更架构](../../architecture/runtime-file-change-observation.md)。

--- a/docs/versions/v1.53/implementation-plan.md
+++ b/docs/versions/v1.53/implementation-plan.md
@@ -275,3 +275,55 @@ Skill Library 的工具详情定向验收通过，验证“完成了 1 个步骤
 全量 `accept:runtime-activity-ui` 本轮未通过：消息操作栏现有 `margin-left: -5px` 与旧脚本要求的零偏移不符；
 该偏移在 PR #255 的基线已存在，本轮不修改消息操作栏或放宽全量断言。定向脚本的旧“已执行 1 项操作”
 断言已同步当前工具组合同；该补充只改变验收脚本和记录，已打包的生产代码不变。
+
+## 新对话创建性能补充
+
+- [x] `camps.create` 改为只执行 `select_workspace` 的目录准入与规范化，不调用 Git inspection。
+- [x] `observe_git` 移除 `git status` 工作树扫描，保留 capability、root/common directory、object format、
+  HEAD 与 branch；新 observation 的 `dirty` 为 `None`。
+- [x] 保留 `GitObservation.dirty` 的 nullable wire、数据库与历史读取兼容，不伪造 clean 状态，不修改诊断 schema。
+- [x] 扩展既有 `git::tests` owner，证明 clean 与 modified 工作树都只返回相同 HEAD/branch 且 dirty unavailable；
+  Files Changed / Diff Card 仍完全由 Runtime evidence 投影拥有。
+- [x] 更新 Workspace / User Automation 权威、v2 合同、版本决定与导航。
+- [x] 执行 Core、Desktop、文档治理与合入前门禁，并在下方记录结果及已确认的主线 Clippy 基线。
+
+本轮不新增平行测试夹具：既有 `git::tests` 已拥有 Git metadata observation，直接扩展它即可捕捉重新引入
+dirty scan 的行为合同；`smoke:core` 继续拥有临时数据目录与 Git / 非 Git Camp 创建的端到端 seam。性能边界
+由调用图保证：Camp 创建路径不再包含 Git 子进程，Git observation 也不再包含工作树命令；不设置依赖机器负载的
+毫秒阈值。
+
+### 必跑命令
+
+```bash
+cargo fmt --all -- --check
+cargo test -p rovai-core --lib git::tests::
+cargo test -p rovai-core --bin rovai-core
+pnpm smoke:core
+pnpm typecheck
+pnpm test
+pnpm build:desktop
+pnpm test:rust:pr
+cargo clippy --workspace --all-targets -- -D warnings
+pnpm docs:test
+pnpm docs:check
+DOCS_BASE_REF=<merge-base-with-main> pnpm docs:check:ci
+git diff --check
+```
+
+### 验证记录
+
+- Git observation 定向 4 个用例通过；Core binary 230 个用例通过，5 个手工真实 Runtime smoke 按设计忽略。
+- `TMPDIR=/private/tmp pnpm smoke:core` 通过，覆盖 fresh Core、Git / 非 Git Camp 创建、重启读取与删除；默认
+  macOS `tmpdir()` 返回的 `/var` 别名会被既有 Runtime Files Root symlink 门禁拒绝，因此使用规范临时目录，
+  未修改 smoke 脚本或产品门禁。
+- `pnpm test:rust:pr` 通过：Library 524、CLI 33、slow integration 306 个用例全部通过。
+- `pnpm typecheck`、`pnpm test` 与 `pnpm build:desktop` 通过；整合最新主线后的全量前端为 159 个 Vitest 文件／1,616 个用例，
+  最终 Node 批次 222 个通过／1 个 Windows-only 跳过。
+- `pnpm docs:test`（9 个用例）、`pnpm docs:check`、
+  `DOCS_BASE_REF=c1582f4b6987b37979ca1b01fc7c639b5b800614 pnpm docs:check:ci`、Rust format 与 diff 检查通过。
+- `cargo clippy --workspace --all-targets -- -D warnings` 仍只在未修改的
+  `record_available_runtime_model` 报既有 `too_many_arguments`；该函数与本分支基线一致，本次不扩大范围修改。
+- 当前工作树重复三次完整 `git status --porcelain=v1 -z` 分别耗时 1.69s、1.62s、1.39s；新的
+  `camps.create` 调用图不含 Git 子进程，因而直接移除该段随工作树增长的创建等待。
+
+真实 Runtime、日常 Electron userData 与用户工作区未参与本轮自动验收。


### PR DESCRIPTION
## Summary
- make `camps.create` perform only Core-owned directory admission and canonicalization, with no Git subprocess
- remove `git status` worktree scans from Git observations while preserving capability, HEAD, branch, nullable wire compatibility, and historical dirty values
- document the new User Automation v2 boundary and v1.53 decision; keep Files Changed / Diff Card on Runtime evidence

## Performance
The removed `git status --porcelain=v1 -z` call took 1.39s–1.69s across three runs in this worktree. The new Camp creation call graph contains no Git subprocess, so that worktree-size-dependent delay is removed from creation.

## Validation
- `cargo test -p rovai-core --lib git::tests::` (4 passed)
- `cargo test -p rovai-core --bin rovai-core` (230 passed, 5 manual ignored)
- `TMPDIR=/private/tmp pnpm smoke:core`
- `pnpm test:rust:pr` (Library 524, CLI 33, slow 306)
- `pnpm typecheck`
- `pnpm test` (159 Vitest files / 1616 tests; Node 222 passed / 1 Windows-only skipped)
- `pnpm build:desktop`
- documentation governance, Rust format, and diff checks

`cargo clippy --workspace --all-targets -- -D warnings` still reports only the pre-existing `record_available_runtime_model` `too_many_arguments` warning; that function is unchanged by this PR.