### PR TITLE
test(windows): align release verifier contract

### DIFF
--- a/scripts/verify-windows-release.mjs
+++ b/scripts/verify-windows-release.mjs
@@ -393,7 +393,7 @@ try {
   const health = await core.request('health.check')
   if (health?.core?.ok !== true
       || health.core.version !== packageMetadata.version
-      || health.core.builtinToolContractVersion !== 21
+      || health.core.builtinToolContractVersion !== 22
       || health.core.builtinToolIpcProtocolVersion !== 2) {
     throw new Error(`packaged Core health is incompatible: ${JSON.stringify(health?.core)}`)
   }
@@ -436,7 +436,7 @@ try {
     packagedCoreSmoke: {
       isolatedDataRoot: true,
       healthCheck: true,
-      builtinToolContractVersion: 21,
+      builtinToolContractVersion: 22,
       builtinToolIpcProtocolVersion: 2
     }
   }


### PR DESCRIPTION
## Summary

- align the Windows packaged Core health assertion with built-in tool contract v22
- record contract v22 in the generated Windows release manifest
- leave product/runtime code unchanged

## Why

The v0.1.0 Windows package built successfully, then the release verifier rejected the packaged Core because these two test-only expectations remained at v21 while the CLI and Core now report v22.

## Validation

- `node --check scripts/verify-windows-release.mjs`
- `git diff --check`
- CI and the native Windows release verification will run after merge