### PR TITLE
Fix Markdown preview scrolling over tables

### DIFF
--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -3307,7 +3307,7 @@ button.camp-world-map-live-caption { cursor: pointer; font: inherit; }
 .safe-markdown.is-document li + li { margin-top: 4px; }
 .safe-markdown.is-document blockquote { margin: 15px 0 17px; padding: 5px 13px; }
 .safe-markdown.is-document pre { margin: 16px 0 19px; padding: 13px 14px; font-size: 13px; line-height: 1.65; }
-.safe-markdown.is-document .markdown-table-scroll { max-width: 100%; margin: 17px 0 20px; overflow-x: auto; overscroll-behavior: contain; }
+.safe-markdown.is-document .markdown-table-scroll { max-width: 100%; margin: 17px 0 20px; overflow-x: auto; overscroll-behavior-x: contain; }
 .safe-markdown.is-document .markdown-table-scroll > table { display: table; width: max-content; min-width: 100%; margin: 0; overflow: visible; font-size: 14px; line-height: 1.55; }
 .safe-markdown.is-document th,
 .safe-markdown.is-document td { padding: 8px 10px; overflow-wrap: normal; word-break: normal; }

--- a/scripts/fixtures/file-preview-layout/main.cjs
+++ b/scripts/fixtures/file-preview-layout/main.cjs
@@ -188,6 +188,27 @@ app.whenReady().then(async () => {
     assert.equal(day.tableScrolls, true)
     assert.ok(day.documentWidth <= 780 && day.documentWidth < day.paneWidth)
     assert.equal(day.pageOverflow, false)
+
+    const reader = await run(`(() => {
+      const reader = document.querySelector('.file-preview-tab-panel:not([hidden]) .file-preview-markdown')
+      const table = document.querySelector('.file-preview-tab-panel:not([hidden]) .markdown-table-scroll')
+      reader.scrollTop = 0
+      const bounds = table.getBoundingClientRect()
+      return {
+        x: Math.round(bounds.left + bounds.width / 2),
+        y: Math.round(bounds.top + bounds.height / 2),
+        scrollHeight: reader.scrollHeight,
+        clientHeight: reader.clientHeight
+      }
+    })()`)
+    assert.ok(reader.scrollHeight > reader.clientHeight, 'The Markdown fixture has vertical reading overflow')
+    await window.webContents.debugger.sendCommand('Input.dispatchMouseEvent', {
+      type: 'mouseWheel', x: reader.x, y: reader.y, deltaX: 0, deltaY: 180
+    })
+    await snapshot()
+    assert.ok(await run(`document.querySelector(
+      '.file-preview-tab-panel:not([hidden]) .file-preview-markdown'
+    ).scrollTop > 0`), 'Vertical wheel input over a wide table continues scrolling the Markdown reader')
     await capture('markdown-reader-day')
 
     await run('window.previewTest.setTheme("night")')

--- a/scripts/fixtures/file-preview-layout/renderer.tsx
+++ b/scripts/fixtures/file-preview-layout/renderer.tsx
@@ -51,7 +51,11 @@ const markdownSource = [
   '',
   '| 项目 | 说明 |',
   '| --- | --- |',
-  `| 宽表格 | ${'wideTableColumn'.repeat(40)} |`
+  `| 宽表格 | ${'wideTableColumn'.repeat(40)} |`,
+  '',
+  '## 后续阅读',
+  '',
+  '滚轮经过宽表格后仍应继续滚动 Markdown 阅读区。'.repeat(80)
 ].join('\n')
 const tabFiles = ['src/app.ts', 'src/layout.tsx', 'src/theme.ts', 'src/routes.ts', 'src/search.ts',
   'src/settings.tsx', 'src/navigation.ts', 'src/very-long-file-preview-reading-anchor.tsx']


### PR DESCRIPTION
Markdown file previews stopped vertical scrolling whenever the pointer was over a wide table because the table's horizontal scroll container also contained vertical overscroll. The table now contains only horizontal overscroll, so vertical wheel input continues through the surrounding Markdown reader while horizontal table scrolling remains intact.

Validation:
- `pnpm test:file-preview-layout`
- `pnpm typecheck`
- `pnpm exec vitest run apps/desktop/src/renderer/src/SafeMarkdown.test.ts`
- `git diff --check`
