### PR TITLE
chore(release): prepare v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "rovai-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/rovai-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rovai/desktop",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "license": "MIT",
   "type": "module"

--- a/apps/desktop/src/main/package-metadata.test.ts
+++ b/apps/desktop/src/main/package-metadata.test.ts
@@ -9,7 +9,7 @@ const packageMetadata = JSON.parse(readFileSync(
 describe('desktop package metadata', () => {
   it('keeps the visible brand separate from Electron helper bundle identity', () => {
     expect(packageMetadata.productName).toBe('Rovai AI')
-    expect(packageMetadata.version).toBe('0.1.0')
+    expect(packageMetadata.version).toBe('0.2.0')
     expect(packageMetadata.build.productName).toBe('Rovai AI')
     expect(packageMetadata.build.mac.executableName).toBeUndefined()
     expect(packageMetadata.build.win.executableName).toBe('Rovai-ai')

--- a/build/release-notes.md
+++ b/build/release-notes.md
@@ -1,20 +1,21 @@
-# Rovai AI v0.1.0
+# Rovai AI v0.2.0
 
-Rovai AI 0.1.0 introduces private member conversations, a substantially stronger file-preview workspace, safer Runtime recovery, and leaner durable execution storage.
+Rovai AI 0.2.0 makes the desktop workspace more personal, easier to configure, and clearer while agents are working.
 
-macOS arm64 and x64 builds use the same fixed Rovai Release Signing certificate as 0.0.7. Windows x64 remains an unsigned Preview build and may show a SmartScreen warning.
+macOS arm64 and x64 builds use the same fixed Rovai Release Signing certificate as 0.1.0. Windows x64 remains an unsigned Preview build and may show a SmartScreen warning.
 
 ## What's Changed
 
-- Add Camp-scoped private Single Chat conversations with attachments, bounded history context, conversation-local pending delivery, precise lifecycle controls, and race-safe target switching.
-- Restore file-preview tabs, order, active state, and pane visibility independently for each Camp, including safe recovery for linked project files and unavailable-file presentation.
-- Add independent Rovai file and diff search with next/previous navigation, case, whole-word and regular-expression options, bounded execution, and support for code, Markdown, HTML, patches, and historical file changes.
-- Unify Single Chat and execution feedback with shared Thinking, terminal duration, tool grouping, final-answer presentation, quieter successful completion, predictable Command/Ctrl+W preview closing, and consistent PI naming.
-- Surface sanitized Runtime failures directly on Agent Runs and safely retry only explicitly unaccepted ACP network failures with fixed backoff, cancellation fencing, and fresh admission checks.
-- Persist Runtime text and reasoning in durable blocks while retaining live deltas and partial output, reducing maintenance write amplification without changing the public timeline.
-- Correlate Claude Code streaming and completed text blocks without duplicating assistant output, while keeping file actions and long filenames readable on one stable row.
-- Store new command-result bodies once while preserving idempotent replay, legacy reads, and the existing public event payload.
-- Restrict public Runtime image galleries to confirmed native image generation while preserving explicit image attachments sent through Rovai.
-- Simplify dialogs and popovers, refine shared send/stop controls, keep pinned Camp loading markers current, restore author headers for standalone Run artifacts, and remove Git-status latency from new conversation creation.
+- Add complete appearance and reading controls for theme, conversation, document and code text sizes, reading density, application zoom, and reduced motion.
+- Redesign teammate configuration as an inline workspace with independent profile and Runtime saves, preserved drafts, clearer status, and safer conflict handling.
+- Refine the teammate roster with a resizable and collapsible rail, search for larger teams, compact grouping, and remembered layout preferences.
+- Speed up new conversations with optional saved team defaults while consistently excluding unavailable or unconfigured teammates from selection and leadership.
+- Guide users through installing and signing in to supported Agent Runtimes, with platform-aware commands, copy feedback, refresh, and recheck actions.
+- Distinguish connecting, thinking, active execution, approvals, retries, and completion without leaving stale status text after real output arrives.
+- Put Fast controls directly in execution details and simplify shared stop and collapse actions while preserving keyboard focus and per-member state.
+- Improve file activity with localized multi-file reads, wider diff click targets, direct previews for operation-only changes, canonical path display, reveal/copy actions, and safe source-attachment paths.
+- Capture verified Pi edit patches as reviewable diffs, keep missing Pi installations out of subsystem health, and finalize Pi Skill availability and delivery ordering.
+- Restore private-chat approval, completion and failure notifications while keeping the conversation currently being read quiet and preserving notification focus.
+- Keep Markdown previews vertically scrollable over wide tables and tighten long notification and file-row layouts across narrow windows.
 
-**Full changelog:** https://github.com/murray17/rovai-ai/compare/v0.0.7...v0.1.0
+**Full changelog:** https://github.com/murray17/rovai-ai/compare/v0.1.0...v0.2.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rovai-ai",
   "productName": "Rovai AI",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "description": "A desktop workspace for long-lived agent teams, shared Camps, visible execution, and collaborative memory.",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rovai/contracts",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/scripts/accept-app-updates-ui.mjs
+++ b/scripts/accept-app-updates-ui.mjs
@@ -56,7 +56,7 @@ try {
     outputDir,
     verified: {
       isolatedPackagedApplication: true,
-      packagedVersion: '0.1.0',
+      packagedVersion: '0.2.0',
       typedIdleUpdaterSnapshot: true,
       productAndBundleName: 'Rovai AI',
       existingSettingsVisualWorld: true,
@@ -93,12 +93,12 @@ async function openAboutUpdates(cdp) {
   assert(selected, 'About & Updates Settings entry was unavailable')
   await waitForSelector(cdp, '.about-updates-settings')
   await waitForExpression(cdp,
-    `document.querySelector('.about-version-value code')?.textContent === 'v0.1.0'`)
+    `document.querySelector('.about-version-value code')?.textContent === 'v0.2.0'`)
 }
 
 async function assertAboutUpdates(cdp, context) {
   const updaterSnapshot = await evaluate(cdp, 'window.rovai.appUpdates.get()', true)
-  assert(updaterSnapshot?.currentVersion === '0.1.0'
+  assert(updaterSnapshot?.currentVersion === '0.2.0'
     && updaterSnapshot.status === 'idle'
     && updaterSnapshot.availableRelease === null
     && updaterSnapshot.lastCheckSource === null
@@ -136,7 +136,7 @@ async function assertAboutUpdates(cdp, context) {
   assert(state.heading === '关于与更新', `${context} omitted the page heading`)
   assert(state.description === 'Rovai AI 会在正式打包版本中主动检查更新；下载、安装和重启始终由你确认。',
     `${context} used the wrong description`)
-  assert(state.product === 'Rovai AI' && state.version === 'v0.1.0',
+  assert(state.product === 'Rovai AI' && state.version === 'v0.2.0',
     `${context} used the wrong product/version: ${JSON.stringify(state)}`)
   assert(state.action === '检查更新' && state.actionTag === 'BUTTON' && state.actionFocused,
     `${context} did not expose a keyboard-focusable check action`)


### PR DESCRIPTION
## Summary

- bump workspace, desktop, contracts, and Core versions to 0.2.0
- update packaged-app acceptance assertions for 0.2.0
- refresh release notes for changes since v0.1.0

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm build:desktop`
- `pnpm test`
- `pnpm test:rust:pr`
- `pnpm test:rust:slow` (307 passed)
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- focused package metadata and release-note tests
- `git diff --check`