### PR TITLE
fix(desktop): 隐藏三平台 DSH 并收敛运行时状态文案

### DIFF
--- a/apps/desktop/.impeccable/surfaces/settings-workspace.md
+++ b/apps/desktop/.impeccable/surfaces/settings-workspace.md
@@ -1,5 +1,5 @@
 ---
-version: 8
+version: 9
 slug: "settings-workspace"
 primary_target: "apps/desktop/src/renderer/src/SettingsPageHeader.tsx"
 related_targets:
@@ -162,7 +162,12 @@ availability probe, install, rescan, selection or execution action. They must no
 installed, unavailable, a red health failure or synthetic checking. Diagnostics may show the platform row
 and evidence revision without starting that Adapter.
 
-`preview` remains an admitted Product Runtime state, distinct from the Renderer-only `待支持` row below. It enters
+The catalog heading shows the Core-reported host platform once. Qualified rows show only a reported version as
+supporting copy; no version means no subtitle element or placeholder. Never fall back to static “稳定 / 测试 / 实验性”
+labels. Keep the 68px minimum row and vertically center either the name alone or the name/version block with the
+logo, machine-state badge and action. Expanded guides and failure details may grow the row.
+
+`preview` remains an admitted Product Runtime state, distinct from a Renderer-only `待支持` preview. It enters
 normal availability checks, selection, diagnostics and execution while supporting copy says “实验性开放”; its
 machine-state badge remains the real checking/available/login/install/error result. Pi no longer uses this state: its
 three shipped platforms are qualified by platform-specific immutable evidence and follow the ordinary machine flow
@@ -196,11 +201,10 @@ unable to complete. Show the safe summary and optional detail with wrapping; nev
 logs or a digest. Only `origin=rovai` may use the user-facing phrase “Rovai 内部错误”. Startup shallow version
 failures without a public failure keep the existing state copy and last-known-good behavior.
 
-The Runtime settings list may append a separately typed presentation-only preview row after supported
-products. A preview must say `待支持` and `尚未接入 AgentRun`, expose no health/configuration action and
-remain absent from member selection, diagnostics and every execution surface. It is not a Product Runtime
-state or count; logo treatment must not imply readiness. Promotion removes the preview and follows normal
-Adapter admission instead of reinterpreting preview data.
+DeepSeek Harness is hidden on macOS arm64, macOS x64 and Windows x64. The Runtime settings list currently
+contains no presentation-only pending preview rows. DSH remains an unimplemented candidate, absent from
+member selection, diagnostics and every execution surface; restoring an entry requires an explicit product
+decision and normal Adapter admission before it can become executable.
 
 Diagnostics full check is read-only. Summary counts partition all checks into normal, needs attention
 and temporarily unknown. There is no “repair all”; each issue has one bounded next step and is

--- a/apps/desktop/src/renderer/src/App.test.ts
+++ b/apps/desktop/src/renderer/src/App.test.ts
@@ -7287,14 +7287,18 @@ describe('task event projections', () => {
     expect(markup).not.toContain('<option value="pi" disabled="">')
   })
 
-  it('keeps all product checks visible without discovery diagnostics', () => {
+  it.each([
+    ['macos-arm64', 'macOS Apple Silicon'],
+    ['macos-x64', 'macOS Intel'],
+    ['windows-x64', 'Windows x64']
+  ] as const)('renders platform-aware product copy and checks on %s', (hostPlatform, platformLabel) => {
     const health: HealthStatus = {
       core: { ok: true, version: '0.0.1', dataDir: '/tmp/rovai' },
       database: { ok: true, path: '/tmp/rovai/rovai.db' },
       git: { installed: true, version: 'git version 2.0' },
-      hostPlatform: 'macos-arm64',
+      hostPlatform,
       runtimeCatalog: [],
-      runtimePlatformAdmission: runtimeAdmissionRows('macos-arm64', 'qualified'),
+      runtimePlatformAdmission: runtimeAdmissionRows(hostPlatform, 'qualified'),
       runtimeAvailability: [
         productAvailability('codex-cli', 'ready'),
         productAvailability('opencode-cli', 'found_uninspected'),
@@ -7332,15 +7336,16 @@ describe('task event projections', () => {
     expect(markup).toContain('Codex CLI')
     expect(markup).toContain('<strong>PI</strong>')
     expect(markup.indexOf('<strong>PI</strong>')).toBeGreaterThan(markup.indexOf('<strong>Antigravity</strong>'))
-    expect(markup.indexOf('<strong>PI</strong>')).toBeLessThan(markup.indexOf('<strong>DeepSeek Harness</strong>'))
     expect(markup).toContain('OpenCode')
     expect(markup).toContain('GitHub Copilot')
     expect(markup).toContain('Claude Code')
     expect(markup).toContain('Antigravity')
     expect(markup).toContain('TRAE CLI')
-    expect(markup).toContain('DeepSeek Harness')
-    expect(markup).toContain('待支持')
-    expect(markup).toContain('尚未开放')
+    expect(markup).not.toContain('DeepSeek Harness')
+    expect(markup).not.toContain('Cursor Agent')
+    expect(markup).not.toContain('待支持')
+    expect(markup).not.toContain('尚未开放')
+    expect(markup).toContain(`当前平台：${platformLabel}`)
     expect(markup).toContain('可用')
     expect(markup).toContain('正在检查…')
     expect(markup).toContain('需要登录')
@@ -7352,9 +7357,9 @@ describe('task event projections', () => {
     expect(markup).not.toContain('已找到')
     expect(markup).not.toContain('尚未检查')
     expect(markup).not.toContain('已检查')
-    expect(markup).toContain('实验性')
-    expect(markup.match(/class="runtime-product-logo"/g)).toHaveLength(14)
-    expect(markup.match(/class="quiet-button runtime-product-check"/g)).toHaveLength(12)
+    expect(markup).not.toMatch(/稳定|测试|实验性/)
+    expect(markup.match(/class="runtime-product-logo"/g)).toHaveLength(13)
+    expect(markup.match(/class="quiet-button runtime-product-check"/g)).toHaveLength(11)
     expect(markup.match(/检查可用性/g)).toHaveLength(11)
     expect(markup).toContain('Claude Code 登录指南')
     expect(markup).toContain('Antigravity 安装指南')
@@ -7363,6 +7368,11 @@ describe('task event projections', () => {
     expect(markup).not.toContain('实验性开放 ·')
     expect(markup).not.toContain('重新扫描安装')
     expect(markup).toContain('codex-cli 1.0.0')
+    expect(markup).toContain('<strong>Kiro</strong></div>')
+    expect(markup).toContain('<strong>Antigravity</strong></div>')
+    expect(markup).toContain('<small title="codex-cli 1.0.0">codex-cli 1.0.0</small>')
+    expect(markup.match(/<small\b/g)).toHaveLength(4)
+    expect(markup).not.toContain('<small></small>')
     expect(markup).not.toContain('来源 inherited_path')
     expect(markup).not.toContain('Version Probe')
     expect(markup).not.toContain('九种已支持产品')
@@ -7371,6 +7381,29 @@ describe('task event projections', () => {
     expect(markup).not.toContain('安装说明')
     expect(markup).not.toContain('高级诊断与自定义启动入口')
     expect(markup).not.toContain('/opt/homebrew/bin/codex')
+
+    // Missing versions remove the subtitle; a future preview still discloses admission.
+    for (const status of ['qualified', 'preview'] as const) {
+      for (const reportedVersion of [null, '   ', 'codex-cli 1.0.0']) {
+        const versionMarkup = renderToStaticMarkup(createElement(RuntimeInstallationsPanel, {
+          health: {
+            ...health,
+            runtimePlatformAdmission: runtimeAdmissionRows(hostPlatform, status),
+            runtimeAvailability: [{ ...productAvailability('codex-cli', 'ready'), reportedVersion }]
+          },
+          installations: [],
+          onReload: async () => undefined
+        }))
+        const version = reportedVersion?.trim()
+        const subtitle = status === 'preview' ? `实验性开放${version ? ` · ${version}` : ''}` : version
+        expect(versionMarkup).toContain(subtitle
+          ? `<strong>Codex CLI</strong><small title="${subtitle}">${subtitle}</small>`
+          : '<strong>Codex CLI</strong></div>')
+        expect(versionMarkup).toContain('status-available">可用</span>')
+        expect(versionMarkup.match(/检查可用性/g)).toHaveLength(13)
+        expect(versionMarkup).not.toContain('DeepSeek Harness')
+      }
+    }
   })
 
   it('renders Windows not-qualified rows without machine checks or rescan actions', () => {

--- a/apps/desktop/src/renderer/src/MemberManagement.tsx
+++ b/apps/desktop/src/renderer/src/MemberManagement.tsx
@@ -64,7 +64,6 @@ import {
   submittedRuntimeConfigurationKey
 } from './member-runtime-conflict'
 import type { MemberWorkspaceTab } from './MemberSidebar'
-import deepSeekLogo from './assets/runtime-logos/deepseek-color.svg'
 import {
   VISIBLE_PRODUCT_RUNTIMES,
   PRODUCT_RUNTIME_LOGOS,
@@ -1030,29 +1029,11 @@ function MemberDetailHeader({
   )
 }
 
-type RuntimeCatalogEntry =
-  | { state: 'supported'; runtimeKind: AdapterKind }
-  | {
-      state: 'pending'
-      id: 'deepseek-harness'
-      label: 'DeepSeek Harness'
-      detail: '尚未接入 AgentRun'
-      logo: string
-    }
-
-const RUNTIME_CATALOG: RuntimeCatalogEntry[] = [
-  ...VISIBLE_PRODUCT_RUNTIMES.map((runtimeKind) => ({
-    state: 'supported' as const,
-    runtimeKind
-  })),
-  {
-    state: 'pending',
-    id: 'deepseek-harness',
-    label: 'DeepSeek Harness',
-    detail: '尚未接入 AgentRun',
-    logo: deepSeekLogo
-  }
-]
+const HOST_PLATFORM_LABELS: Record<HostPlatformKey, string> = {
+  'macos-arm64': 'macOS Apple Silicon',
+  'macos-x64': 'macOS Intel',
+  'windows-x64': 'Windows x64'
+}
 
 export type MemberRuntimeFormHandle = {
   discard(): void
@@ -1504,34 +1485,11 @@ export function RuntimeInstallationsPanel({
           <div>
             <h2>Agent 运行时目录</h2>
           </div>
+          {health && <span className="runtime-catalog-platform">当前平台：{HOST_PLATFORM_LABELS[health.hostPlatform]}</span>}
         </div>
 
         <div className="runtime-product-list">
-          {RUNTIME_CATALOG.map((entry) => {
-            if (entry.state === 'pending') {
-              return (
-                <article key={entry.id} className="runtime-product-row">
-                  <span className="runtime-product-logo" aria-hidden="true">
-                    <img src={entry.logo} alt="" />
-                  </span>
-                  <div className="runtime-product-copy">
-                    <strong>{entry.label}</strong>
-                    <small>{entry.detail}</small>
-                  </div>
-                  <span className="runtime-snapshot-badge runtime-product-status status-unknown">
-                    待支持
-                  </span>
-                  <button
-                    className="quiet-button runtime-product-check"
-                    type="button"
-                    disabled
-                  >
-                    尚未开放
-                  </button>
-                </article>
-              )
-            }
-            const runtimeKind = entry.runtimeKind
+          {VISIBLE_PRODUCT_RUNTIMES.map((runtimeKind) => {
             const item = availability.find(
               (candidate) => candidate.runtimeKind === runtimeKind
             )
@@ -1545,6 +1503,10 @@ export function RuntimeInstallationsPanel({
               item ?? null,
               health === null
             )
+            const version = item?.reportedVersion?.trim() || null
+            const subtitle = admission?.status === 'preview'
+              ? `实验性开放${version ? ` · ${version}` : ''}`
+              : admission?.status === 'qualified' ? version : presentation.detail
             const allowed = runtimePlatformAdmissionAllowsUse(admission)
             const guide = allowed ? runtimeInstallGuide(runtimeKind, health?.hostPlatform ?? null) : null
             const mode = presentation.status === 'not_installed' ? 'install'
@@ -1567,14 +1529,7 @@ export function RuntimeInstallationsPanel({
                 </span>
                 <div className="runtime-product-copy">
                   <strong>{adapterLabel(runtimeKind)}</strong>
-                  <small>
-                    {admission?.status === 'preview'
-                      ? `实验性开放 · ${item?.reportedVersion ?? adapterMaturityLabel(runtimeKind)}`
-                      : admission?.status !== 'qualified'
-                        ? presentation.detail
-                        : (item?.reportedVersion ??
-                          adapterMaturityLabel(runtimeKind))}
-                  </small>
+                  {subtitle && <small title={subtitle}>{subtitle}</small>}
                 </div>
                 <span
                   className={`runtime-snapshot-badge runtime-product-status status-${presentation.status}`}
@@ -1639,25 +1594,6 @@ function commandCodeLabel(code: string): string {
       } as Record<string, string>
     )[code] ?? `操作未完成：${code}`
   )
-}
-
-function adapterMaturityLabel(kind: AdapterKind): string {
-  return {
-    'codex-cli': '稳定',
-    pi: '稳定',
-    'opencode-cli': '测试',
-    'copilot-cli': '测试',
-    'claude-code-cli': '测试',
-    'kiro-cli': '实验性',
-    'qoder-cli': '实验性',
-    'codebuddy-cli': '实验性',
-    'qwen-code': '实验性',
-    'trae-cn-cli': '实验性',
-    'cursor-agent': '实验性',
-    'kimi-code-cli': '实验性',
-    'grok-build': '实验性',
-    'antigravity-app': '实验性'
-  }[kind]
 }
 
 function memberPresenceLabel(presence: AgentProfile['presence']): string {

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -7820,7 +7820,8 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
   margin-top: 8px;
   padding: 0 0 34px;
 }
-.settings-panel-runtime > .runtime-installations > .section-heading { align-items: flex-start; margin: 0; }
+.settings-panel-runtime > .runtime-installations > .section-heading { align-items: center; flex-wrap: wrap; margin: 0; }
+.runtime-catalog-platform { color: var(--workspace-faint); font-size: 11px; }
 .settings-panel-runtime > .runtime-installations > .section-heading h2 {
   margin: 0;
   color: var(--ink);

--- a/crates/rovai-core/src/runtime_platform_admission.rs
+++ b/crates/rovai-core/src/runtime_platform_admission.rs
@@ -8,7 +8,7 @@ use crate::{agent_profile::AdapterKind, platform::HostPlatformKey};
 /// that evidence even when their Adapter identity exists in the Product Catalog.
 /// Every register revision receives a new digest.
 pub const MACOS_RUNTIME_COMPATIBILITY_EVIDENCE_REVISION: &str =
-    "sha256:2139e79dcbf5c3a94323635f34c7d30634fa0a38327941401a837ab17b7f3032";
+    "sha256:901e3d112853b61310f1b960756ab822de535daa199e3975ebaff35e2d388fb2";
 
 /// Immutable digest of the sanitized, adapter-scoped Windows x64 evidence.
 /// The source qualifies only the Runtime rows named in that evidence; shared

--- a/docs/architecture/runtime-catalog-boundaries.md
+++ b/docs/architecture/runtime-catalog-boundaries.md
@@ -3,7 +3,7 @@ document_type: architecture
 architecture: runtime-catalog-boundaries
 authority: runtime-catalog-and-preview-boundaries
 status: accepted
-last_updated: 2026-09-05
+last_updated: 2026-09-08
 ---
 
 # Runtime Catalog Boundaries
@@ -27,12 +27,15 @@ last_updated: 2026-09-05
 | Settings Runtime Preview Catalog | Renderer 内受审查的静态 presentation rows | Runtime 设置页中的名称、图标、`待支持`文案和 disabled 状态 | Contracts、Core request、数据库、成员选择、诊断、Probe、AgentRun 或支持数量 |
 
 Product Runtime Catalog 当前包含十四种已实现 Adapter。Preview 与它不是“同一目录的另一种状态”；
-Renderer 只在绘制 Runtime 设置列表时组合两种 row。产品目录的机器可判数量、全量检查、诊断分母和
+Renderer 当前不展示 Settings Preview row；DeepSeek Harness 在三个目标平台均隐藏，仍是未接入候选。
+产品目录的机器可判数量、全量检查、诊断分母和
 普通执行仍只来自逐平台 Admission。Cursor 虽保留 closed identity 和历史 reader，但未完成产品资格前不进入
 Settings Runtime Preview Catalog；隐藏该 row 不删除持久 identity，也不改变未准入状态。普通成员 Runtime
 selector 同样不展示 Cursor；其他成员选项来自 `AdapterKind`，并在当前主机上继续经过 Runtime Platform Admission。
 
-`qualified` 与 `preview` 可以进入 Product Runtime Availability；`preview` 必须标明实验性并保留缺失资格证据，
+`qualified` 与 `preview` 可以进入 Product Runtime Availability；`preview` 必须标明实验性并保留缺失资格证据。
+`qualified` 行只在有实际 reported version 时显示版本副文案，否则仅显示居中的产品名，不再回退到静态
+“稳定 / 测试 / 实验性”标签。当前主机平台在目录标题旁统一显示，机器状态徽标继续来自 Availability。
 `not_qualified` 按目标平台显示“Windows 尚未验证”或“当前平台尚未验证”，`unsupported` 显示平台不支持。
 后两者不产生 discovery、Installation、Probe 或普通机器状态。既有未准入配置
 可以原样读取并在修改无关队员字段时原样保留，但不能修改 Runtime 子对象、重新保存默认值或执行。
@@ -436,7 +439,8 @@ Client FS 是否可执行。
 ## Preview 呈现与晋升
 
 Preview row 必须同时满足：明确“待支持/尚未接入 AgentRun”、无可点击检查或配置入口、不会进入成员页
-或诊断，并在键盘和辅助技术中表现为不可执行状态。DeepSeek Harness 是当前唯一 preview。
+或诊断，并在键盘和辅助技术中表现为不可执行状态。当前没有可见 Preview；DeepSeek Harness 在
+macOS arm64、macOS x64 与 Windows x64 全部隐藏，不保留“待支持”占位入口。
 
 未来接入时不得把 preview identity 写入 Migration 或原地解释为 Installation。实现必须删除 preview row，
 再按完整可执行准入增加新的 AdapterKind 和逐平台 Admission；用户从未保存过 preview 选择，因此没有 preview-to-product

--- a/docs/runtime-compatibility.md
+++ b/docs/runtime-compatibility.md
@@ -1,7 +1,7 @@
 ---
 document_type: runtime-compatibility-register
 authority: runtime-validation-evidence
-last_updated: 2026-09-07
+last_updated: 2026-09-08
 ---
 
 # Agent Runtime 兼容性清单
@@ -29,9 +29,9 @@ Kimi 或 Grok 的平台结论。
 Grok Build 在 adapter-scoped 证据分别覆盖的 macOS arm64、macOS x64 与 Windows x64 均为 `qualified`；
 三个宿主平台各自绑定独立 evidence digest，不互相外推。
 Cursor identity 仅保留内部兼容与历史读取，默认不进入 discovery/check/AgentRun；Settings 的 Agent Runtime
-目录不展示该项。设置页的
-DeepSeek Harness “待支持”行是 Renderer-only Preview，不在这个目录中，也没有 Installation、
-Probe、成员选择、诊断或 AgentRun 语义。
+目录不展示该项。DeepSeek Harness 在 macOS arm64、macOS x64 与 Windows x64 的设置页均隐藏，
+不保留“待支持”占位行；它仍是未实现候选，不在这个目录中，也没有 Installation、Probe、成员选择、
+诊断或 AgentRun 语义。本次显示范围调整不改变任何 Runtime 的平台资格或实测证据。
 
 ### 2026-09-07 Pi 0.84.4 edit patch 文件变化证据
 
@@ -1034,7 +1034,7 @@ ADR-0189 只允许 Runtime 设置页追加严格 presentation-only 的 Preview�
 | Runtime | 调研版本 / 状态 | 观察结果 | 当前边界 / 未接入原因 | 复核条件 |
 |---|---:|---|---|---|
 | Cursor Agent | 2025.09.18-7ae6800 | 支持 headless 与 resume；已验证入口会读取项目 `.cursor/mcp.json` | 尚无稳定的逐 Run additive channel 与同名证据 | 上游提供动态追加入口并完成 native preservation、同名与恢复复核 |
-| DeepSeek Harness | Settings Preview；未实现 | 仅显示名称、图标、`待支持` 与 disabled 状态；没有 executable、Adapter、Probe 或 capability 结论 | Renderer-only preview，不属于 Product Runtime Catalog | 取得明确入口和协议后，完成 Adapter、认证、Session、终态、取消、Approval、Tool ID、MCP、Activity、Migration 与真实 AgentRun 准入 |
+| DeepSeek Harness | 未实现；三平台隐藏 | 设置页不展示；没有 executable、Adapter、Probe 或 capability 结论 | 未接入候选，不属于 Product Runtime Catalog，也不保留 Preview 占位行 | 取得明确入口和协议后，完成 Adapter、认证、Session、终态、取消、Approval、Tool ID、MCP、Activity、Migration 与真实 AgentRun 准入 |
 
 ## 后续准入规则
 

--- a/scripts/accept-member-lifecycle-ui.mjs
+++ b/scripts/accept-member-lifecycle-ui.mjs
@@ -508,9 +508,6 @@ try {
       rowCount: productRows?.length ?? 0,
       labels,
       pendingCount: pendingRows.length,
-      pendingActionsDisabled: pendingRows.every(
-        (row) => row.querySelector('button')?.disabled === true
-      ),
       hasAdvancedDiagnostics: Boolean(advanced),
       explainsShell: panel?.textContent?.includes('交互式登录 Shell 初始化'),
       exposesMemberPathPicker: Boolean(
@@ -519,25 +516,24 @@ try {
     }
   })()`)
   assert(
-    runtimeSettingsState.rowCount === 14
+    runtimeSettingsState.rowCount === 13
       && runtimeSettingsState.labels.includes('Codex CLI')
-      && runtimeSettingsState.labels.includes('Pi Coding Agent')
+      && runtimeSettingsState.labels.includes('PI')
       && runtimeSettingsState.labels.includes('Antigravity')
       && runtimeSettingsState.labels.includes('TRAE CLI')
-      && runtimeSettingsState.labels.includes('DeepSeek Harness')
-      && runtimeSettingsState.pendingCount === 1
-      && runtimeSettingsState.pendingActionsDisabled
+      && !runtimeSettingsState.labels.includes('DeepSeek Harness')
+      && runtimeSettingsState.pendingCount === 0
       && !runtimeSettingsState.hasAdvancedDiagnostics
       && !runtimeSettingsState.explainsShell
       && !runtimeSettingsState.exposesMemberPathPicker,
-    `Runtime settings did not preserve thirteen managed products plus one pending preview: ${JSON.stringify(runtimeSettingsState)}`
+    `Runtime settings did not preserve thirteen managed products without pending previews: ${JSON.stringify(runtimeSettingsState)}`
   )
   await setViewport(running.cdp, 1040, 700)
   await setTheme(running.cdp, 'night')
   await assertNoHorizontalOverflow(running.cdp, 'Runtime settings at 1040×700 Night')
   captures.runtimeSettings = join(
     outputDir,
-    'runtime-settings-thirteen-products-one-preview-night-1040x700.png'
+    'runtime-settings-thirteen-products-night-1040x700.png'
   )
   await capture(running.cdp, captures.runtimeSettings)
   const discoveredCodex = (await request(running.cdp, 'runtime.installations.list'))

--- a/scripts/fixtures/runtime-install-guide/README.md
+++ b/scripts/fixtures/runtime-install-guide/README.md
@@ -2,7 +2,8 @@
 
 挂载生产 `RuntimeInstallationsPanel`、安装引导组件和共享主题样式。使用内存 RPC 与明确标记的
 平台资格数据，不启动 Electron、Core、真实 Runtime，不读取或写入日常用户目录，不执行安装命令。
-夹具中的 Windows 已准入选项仅用于证明平台分支，不代表真实 Windows Runtime 资格。
+夹具中的三平台资格选项仅用于证明 Renderer 分支，不代表真实 Runtime 资格；其中 Windows 未验证和
+实验性选项是边界场景，不是当前正式平台结论。
 
 ```bash
 node scripts/fixtures/runtime-install-guide/serve.mjs
@@ -25,3 +26,14 @@ pnpm exec tsc -p scripts/fixtures/runtime-install-guide/tsconfig.json
 
 ![Day，1280×720](screenshots/day.png)
 ![Night，720×700](screenshots/night-narrow.png)
+
+2026-09-08 Runtime 目录文案回归（生产组件＋浏览器内存夹具）：
+
+- macOS Apple Silicon、macOS Intel、Windows x64 均显示 13 行，无 DSH、Cursor 或待支持占位。
+- Qualified 行只显示实际版本；无版本时没有副文案元素，也不出现静态成熟度标签。
+- 收起且无反馈的行高均为 68px，单行名称或名称＋版本块的垂直中心偏差为 0。
+- 日夜主题、1440×920、1040×700、720×460 放大等效视口与 2560×1440 均无横向溢出。
+- 模拟检测可从无版本的“未安装”变为带版本的“可用”，指南与检测反馈仍保留；展开内容可增加行高。
+- 模拟 Preview 保留“实验性开放”与真实机器状态；未验证场景的 13 个检查按钮全部禁用、无安装指南。
+
+以上是 Renderer 验收，不是 macOS Intel / Windows 真机运行证据。

--- a/scripts/fixtures/runtime-install-guide/renderer.tsx
+++ b/scripts/fixtures/runtime-install-guide/renderer.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { createRoot } from 'react-dom/client'
-import type { AdapterKind, HealthStatus, ProductRuntimeAvailability } from '@contracts'
+import type { AdapterKind, HealthStatus, ProductRuntimeAvailability, RuntimePlatformAdmissionStatus } from '@contracts'
 import { RuntimeInstallationsPanel } from '../../../apps/desktop/src/renderer/src/MemberManagement'
 import '../../../apps/desktop/src/renderer/src/styles.css'
 
@@ -8,7 +8,7 @@ const kinds: AdapterKind[] = ['claude-code-cli', 'codex-cli', 'opencode-cli', 'c
 const calls: string[] = []
 let nextResult = 'missing'
 let platform: HealthStatus['hostPlatform'] = 'macos-arm64'
-let admitted = true
+let admissionStatus: RuntimePlatformAdmissionStatus = 'qualified'
 const availability = new Map(kinds.map(kind => [kind, snapshot(kind, kind === 'copilot-cli' ? 'ready' : 'missing')]))
 
 function snapshot(runtimeKind: AdapterKind, status: ProductRuntimeAvailability['status']): ProductRuntimeAvailability {
@@ -26,7 +26,7 @@ function health(): HealthStatus {
     core: { ok: true, version: 'fixture', dataDir: '/tmp/rovai-runtime-install-guide-fixture' },
     database: { ok: true, path: '/tmp/rovai-runtime-install-guide-fixture/unused.db' },
     git: { installed: true, version: 'fixture' }, hostPlatform: platform, runtimeCatalog: [],
-    runtimePlatformAdmission: kinds.map(runtimeKind => ({ runtimeKind, platform, status: admitted ? 'qualified' : 'not_qualified', reasonCode: admitted ? null : 'runtime_platform.qualification_evidence_missing', evidenceRevision: admitted ? 'fixture' : null })),
+    runtimePlatformAdmission: kinds.map(runtimeKind => ({ runtimeKind, platform, status: admissionStatus, reasonCode: admissionStatus === 'qualified' ? null : 'runtime_platform.qualification_evidence_missing', evidenceRevision: admissionStatus === 'qualified' ? 'fixture' : null })),
     runtimeAvailability: [...availability.values()],
     searchEnvironment: { generation: 1, createdAt: '2026-09-07T00:00:00Z', pathEntryCount: 0,
       shell: { status: 'captured', interactive: true, shellName: 'fixture', entryCount: 0, elapsedMillis: 0 } }
@@ -63,8 +63,8 @@ function Fixture(): React.JSX.Element {
       <label>检测结果 <select aria-label="检测结果" onChange={event => { nextResult = event.target.value }}>
         <option value="missing">仍未安装</option><option value="authentication_required">需要登录</option><option value="ready">可用</option><option value="needs_attention">运行环境错误</option><option value="rpc-error">请求失败</option>
       </select></label>
-      <label>平台 <select aria-label="平台" onChange={event => { platform = event.target.value === 'mac' ? 'macos-arm64' : 'windows-x64'; admitted = event.target.value !== 'windows-blocked'; setCurrent(health()); setGeneration(value => value + 1) }}>
-        <option value="mac">macOS</option><option value="windows-blocked">Windows 未验证</option><option value="windows-admitted">Windows 已准入夹具</option>
+      <label>平台 <select aria-label="平台" onChange={event => { platform = event.target.value === 'mac' ? 'macos-arm64' : event.target.value === 'mac-intel' ? 'macos-x64' : 'windows-x64'; admissionStatus = event.target.value === 'windows-blocked' ? 'not_qualified' : event.target.value === 'windows-preview' ? 'preview' : 'qualified'; setCurrent(health()); setGeneration(value => value + 1) }}>
+        <option value="mac">macOS Apple Silicon</option><option value="mac-intel">macOS Intel</option><option value="windows-admitted">Windows 已准入夹具</option><option value="windows-blocked">Windows 未验证夹具</option><option value="windows-preview">Windows 实验性夹具</option>
       </select></label>
       <button className="quiet-button" onClick={() => { document.documentElement.dataset.theme = document.documentElement.dataset.theme === 'night' ? 'day' : 'night' }}>切换主题</button>
       <button className="quiet-button" onClick={() => setLog(calls.join('\n'))}>验收记录</button>


### PR DESCRIPTION
## 改动

- 移除 DeepSeek Harness 的 Renderer-only 待支持行，macOS Apple Silicon、macOS Intel、Windows x64 均不显示；Cursor 继续隐藏，目录保留 13 个现有产品。
- 去掉静态「稳定 / 测试 / 实验性」兜底标签。Qualified 行有真实版本才显示副文案，否则仅显示垂直居中的名称，沿用 68px 最小行高。
- 目录标题旁统一显示 Core 报告的当前平台；保留真实机器状态、安装/登录指南，以及未来 preview 的实验性披露和未验证平台禁用行为。
- 同步当前架构、兼容性说明和 UI brief。Rust 仅刷新兼容性文档摘要，不改任何平台资格或执行准入。

## 验证

- pnpm typecheck
- pnpm test：165 个 Vitest 文件、1688 项测试全部通过，文档、Skill 及其余 Node 测试通过
- pnpm build:desktop
- DOCS_BASE_REF=a30926077809df14cabc27911a4bd0c11b549db6 pnpm docs:check:ci
- pnpm test:rust:pr：541 library + 33 CLI + 308 slow tests 通过
- pnpm test:rust:staged、cargo fmt --all --check、cargo clippy --workspace --all-targets -- -D warnings
- Runtime 安装引导夹具 TypeScript 检查、生命周期验收脚本语法检查
- 生产 Renderer 组件浏览器验收：三平台均 13 行、无 DSH/旧标签/空副文案；无反馈时行高 68px、名称块中心偏差 0；Day/Night、1440×920、1040×700、720×460 放大等效视口、2560×1440 无横向溢出；检测后版本出现、preview 和未验证边界符合预期

## 验收边界

Renderer 验收使用内存 API 和模拟平台资格，不启动 Core 或真实 Runtime，不访问日常 App 数据。它不代表 Windows 或 Intel Mac 真机 Runtime 验收；未重新运行整个打包版成员生命周期脚本。