### PR TITLE
fix: keep Composer recipient loading layout stable

### DIFF
--- a/apps/desktop/src/renderer/src/CampWorkspace.tsx
+++ b/apps/desktop/src/renderer/src/CampWorkspace.tsx
@@ -4721,6 +4721,12 @@ export function CampWorkspace({
             if (!editing && pendingEditing) requestAnimationFrame(() => composerEditorRef.current?.focus())
           }} />
         <div hidden={pendingEditing}>
+        <div className="composer-route-slot">
+        {draftLoadState.state === 'loading' && (
+          <div className="composer-route-rail" aria-label="正在加载接收者路由" aria-busy="true">
+            <span className="composer-route-placeholder" aria-hidden="true"><span /><span /></span>
+          </div>
+        )}
         {(continuationVisible && continuationIntent) || (
           composerDraft
           && recipientSummary
@@ -4762,6 +4768,7 @@ export function CampWorkspace({
               </div>
             )
           : null}
+        </div>
         <div className="composer-box">
           {attachmentDragState && (
             <span className="composer-destination">将添加到这条消息</span>

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -4156,8 +4156,12 @@ button.task-event-card:focus-visible .task-card-chevron { color: var(--brand-ink
 
 details summary { min-height: 28px; padding: 5px 0; color: var(--muted); font-size: 11px; cursor: pointer; }
 .composer { position: relative; flex: 0 0 auto; margin: 0; padding: 0 27px 14px; background: var(--conversation-surface); }
+.composer-route-slot { display: flow-root; min-height: 39px; }
 .composer-route-rail { display: flex; width: min(var(--conversation-composer-width), 100%); min-height: 34px; margin: 0 auto 5px; align-items: center; gap: 7px; padding: 0 4px 0 2px; color: var(--faint); }
 .composer-route-rail::before { width: 2px; height: 16px; flex: 0 0 2px; border-radius: 3px; background: var(--brand); content: ""; }
+.composer-route-placeholder { display: inline-flex; align-items: center; gap: 6px; filter: blur(2px); opacity: .55; }
+.composer-route-placeholder > span { width: 12px; height: 10px; border-radius: 3px; background: var(--faint); }
+.composer-route-placeholder > span + span { width: 136px; }
 .composer-route-rail .mention-target-summary { display: inline-flex; min-width: 0; align-items: center; gap: 4px; }
 .composer-route-rail .mention-target-summary > svg { width: 12px; height: 12px; flex: 0 0 auto; fill: none; stroke: currentColor; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1.35; }
 .composer-route-rail .mention-target-summary > span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }

--- a/docs/ui/components/conversation-workspace.md
+++ b/docs/ui/components/conversation-workspace.md
@@ -730,6 +730,10 @@ Composer 与消息轨道共享中心轴但拥有独立宽度；`.composer-box` �
 都不能建立第二份草稿真源。回复条位于附件队列之上、正文编辑器之内，并与 Composer 共用开放工作面，
 不创建 focus trap。鼠标点击 Composer 任意位置都不增加编辑器内层描边；键盘进入仍保留局部焦点提示。
 
+接收者提示始终预留一行 34px 高度及 5px 底部间距。草稿首次 loading 时显示无接收者文案、无循环动画的模糊占位；
+ready 后原位显示默认 Lead 或 continuation。显式 Mention、reply 或错误状态不显示路由时保留空白行，
+避免路由加载或显隐挤动会话内容。占位不提前声明接收者，也不提前启用编辑或发送。
+
 Draft 首次读取只有 loading、ready 和 error。loading 与 error 时正文、附件、Reply/Continuation 和发送不可操作；
 error 在 Composer 上方原位显示“草稿无法加载”、具体错误与“重新加载草稿”，不能渲染可编辑的 revision-zero 空
 Draft。发送和路由 mutation 在第一个异步等待前同步禁用编辑器；Core 路由 mutation 改变正文时在解除禁用前回写

--- a/scripts/fixtures/camp-composer-continuation/main.cjs
+++ b/scripts/fixtures/camp-composer-continuation/main.cjs
@@ -20,7 +20,9 @@ app.whenReady().then(async () => {
   await window.loadFile(renderer)
   const report = await window.webContents.executeJavaScript(mode === '--pending-attachments'
     ? 'window.continuationTest.pendingAttachments()'
-    : 'window.continuationTest.run()', true)
+    : mode === '--route-loading'
+      ? 'window.continuationTest.routeLoading()'
+      : 'window.continuationTest.run()', true)
   console.log(JSON.stringify(report))
   app.exit(report.ok ? 0 : 1)
 }).catch(error => { console.error(error); app.exit(1) })

--- a/scripts/fixtures/camp-composer-continuation/renderer.tsx
+++ b/scripts/fixtures/camp-composer-continuation/renderer.tsx
@@ -72,6 +72,7 @@ Object.assign(window, { rovai: {
   async request(method: string, params: Record<string, unknown> = {}) {
     calls.push(method)
     if (method === 'skills.list' || method === 'skills.deliveryGroups.list') return []
+    if (method === 'camps.members.fast.check') return null
     if (method === 'camp.pendingInputs.get') return structuredClone({ ...queue, campId: params.campId })
     if (method === 'camp.pendingInputs.edit') {
       const command = params.command as {
@@ -191,7 +192,7 @@ async function render() {
   await flush()
 }
 
-async function reset(draft = emptyDraft()) {
+async function reset(draft = emptyDraft(), holdInitialRead = false) {
   if (root) {
     flushSync(() => root!.unmount())
     await new Promise(resolve => setTimeout(resolve, 0))
@@ -218,9 +219,15 @@ async function reset(draft = emptyDraft()) {
       profilePresence: 'present', memberOrder: index, isDefaultLead: index === 0, version: 1 })),
     membershipReconciliations: [], tasks: [], messages: [first], messageDeliveries: [], ...running(first),
     executionEvidence: [], agentRunFileChanges: [], contextManifests: [], approvals: [], actions: [], timeline: [] }
+  const held = holdInitialRead ? holdRead() : null
+  if (held) {
+    snapshot = { ...snapshot, turns: [], agentRuns: [] }
+    queue = { ...queue, executionActive: false }
+  }
   root = createRoot(document.getElementById('root')!)
   await render()
   await flush()
+  return held
 }
 
 async function publish(agentId: string, projected: CampComposerDraftView) {
@@ -572,7 +579,42 @@ Object.assign(window, { continuationTest: { async run() {
   cases.push('Markdown caching preserves fresh callbacks, image authority and changed content')
   await flush()
   return { ok: true, cases }
-}, async pendingAttachments() { return { ok: true, cases: await runPendingAttachmentCases() } } } })
+}, async pendingAttachments() { return { ok: true, cases: await runPendingAttachmentCases() } },
+async routeLoading() {
+  const layout = () => ({
+    composerTop: editor().closest('.composer-box')!.getBoundingClientRect().top,
+    timelineBottom: document.querySelector('.timeline-scroll')!.getBoundingClientRect().bottom
+  })
+  const explicit = emptyDraft()
+  explicit.content = { version: 2, segments: [{ kind: 'atom', atom: { type: 'member', agentId: 'agent_2' } }] }
+  explicit.body = '@芝士'
+  const layouts = []
+  for (const theme of ['day', 'night']) {
+    document.documentElement.dataset.theme = theme
+    for (const [name, draft] of [['default', emptyDraft()], ['continuation', continuedDraft('message-1')], ['explicit', explicit]] as const) {
+      const held = await reset(draft, true)
+      check(held && draftReads() === 1, 'The initial Draft read must remain pending')
+      const before = layout()
+      check(before.composerTop > 0 && before.timelineBottom > 0, 'Measure the visible conversation and input')
+      check(editor().getAttribute('aria-disabled') === 'true', 'Loading must keep the editor disabled')
+      check(document.querySelector('.composer-route-placeholder') && document.querySelector('.composer-route-rail')?.getAttribute('aria-busy') === 'true',
+        'Loading must present the placeholder as busy')
+      check(!document.querySelector('.composer-route-rail')?.textContent?.trim(), 'Loading must not guess the recipient')
+      held.resolve(draft)
+      await until(() => editor().getAttribute('aria-disabled') !== 'true', 'The authoritative Draft enables the editor')
+      const after = layout()
+      check(Math.abs(after.composerTop - before.composerTop) <= 1 && Math.abs(after.timelineBottom - before.timelineBottom) <= 1,
+        `Route loading must not move the conversation: ${JSON.stringify({ theme, name, before, after })}`)
+      check(!document.querySelector('.composer-route-placeholder'), 'Ready replaces the placeholder')
+      const route = document.querySelector('.composer-route-rail')?.textContent ?? ''
+      if (name === 'default') check(route.includes('默认由 Lead · 叮叮接收'), 'Show the default recipient')
+      if (name === 'continuation') check(continuation() === '继续发给 芝士', 'Show the authoritative continuation')
+      if (name === 'explicit') check(!route.trim(), 'Explicit recipients hide the route')
+      layouts.push({ theme, name, before, after })
+    }
+  }
+  return { ok: true, cases: ['delayed Draft retains conversation geometry'], layouts }
+} } })
 
 // The same isolated production-Renderer fixture can also run in a browser when
 // the host cannot initialize a nested Electron sandbox. This is not native IPC coverage.

--- a/scripts/lib/camp-composer-continuation.test.mjs
+++ b/scripts/lib/camp-composer-continuation.test.mjs
@@ -26,6 +26,7 @@ async function runFixture(t, mode, expectedCases) {
     })
     const environment = { ...process.env, ELECTRON_DISABLE_SECURITY_WARNINGS: 'true' }
     delete environment.ELECTRON_RUN_AS_NODE
+    process.stdout.write(`Automatic acceptance userData: ${join(fixture, 'user-data')}; no Core/SQLite/Skill Library/Runtime\n`)
     child = spawn(electron, [
       join(fixtureSource, 'main.cjs'), join(fixture, 'renderer/index.html'), join(fixture, 'user-data'),
       mode,
@@ -43,6 +44,7 @@ async function runFixture(t, mode, expectedCases) {
     const report = JSON.parse(stdout.split('\n').find(line => line.startsWith('{')))
     assert.equal(report.ok, true)
     assert.equal(report.cases.length, expectedCases)
+    if (report.layouts) process.stdout.write(`${JSON.stringify(report.layouts)}\n`)
   } finally {
     if (child && child.exitCode === null && child.signalCode === null) {
       child.kill('SIGKILL')
@@ -57,3 +59,6 @@ test('the production Camp Composer refreshes continuation on publication without
 
 test('Pending attachments use Composer cards, body-only queue summaries and active-editor drag routing', { timeout: 60_000 },
   t => runFixture(t, '--pending-attachments', 6))
+
+test('loading the Composer route preserves conversation and input positions', { timeout: 60_000 },
+  t => runFixture(t, '--route-loading', 1))


### PR DESCRIPTION
Entering a Camp first renders its conversation, then loads the authoritative Composer Draft. Mounting the recipient hint after that read adds 34px plus a 5px gap and pushes the conversation up by 39px.

Reserve that space from the first render and show the approved, token-based blurred placeholder until the Draft arrives. Default and continuation routes replace it in place; explicit mentions and other states without a route keep the empty space. Editing and sending still wait for the authoritative Draft. The loading state is marked busy and the placeholder contains no guessed recipient.

Validation:
- TypeScript typecheck passed.
- Full Vitest: 165 files, 1,688 tests passed.
- Documentation checks passed.
- Production Electron fixture: default, continuation and explicit recipient states in both themes retain the exact conversation/input positions; Pending attachment integration also passed.
- The same fixture failed before the fix with the expected 39px conversation shift.

Known baseline issue: the pre-existing continuation race scenario (`A late response must not change the target after typing began`) fails on the unchanged production code as well. It was reproduced before applying this fix and remains outside this presentation-only change.
