### PR TITLE
fix(desktop): isolate single-chat file drag feedback

### DIFF
--- a/apps/desktop/src/renderer/src/SingleChatPanel.tsx
+++ b/apps/desktop/src/renderer/src/SingleChatPanel.tsx
@@ -1361,8 +1361,10 @@ export function SingleChatPanel({
 
   const enterAttachmentDropSurface = (event: ReactDragEvent<HTMLElement>): void => {
     const kind = attachmentDragKind(event.dataTransfer)
-    if (!kind || attachmentDropBlocked) {
-      if (kind) event.dataTransfer.dropEffect = 'none'
+    if (!kind) return
+    event.stopPropagation()
+    if (attachmentDropBlocked) {
+      event.dataTransfer.dropEffect = 'none'
       return
     }
     event.preventDefault()
@@ -1377,6 +1379,7 @@ export function SingleChatPanel({
   const continueAttachmentDrop = (event: ReactDragEvent<HTMLElement>): void => {
     const kind = attachmentDragKind(event.dataTransfer)
     if (!kind) return
+    event.stopPropagation()
     if (attachmentDropBlocked) {
       event.dataTransfer.dropEffect = 'none'
       clearAttachmentDragState()
@@ -1394,6 +1397,7 @@ export function SingleChatPanel({
 
   const leaveAttachmentDropSurface = (event: ReactDragEvent<HTMLElement>): void => {
     if (!dataTransferContainsFiles(event.dataTransfer)) return
+    event.stopPropagation()
     event.preventDefault()
     if (dragLeaveTimer.current !== null) window.clearTimeout(dragLeaveTimer.current)
     dragLeaveTimer.current = window.setTimeout(() => {

--- a/scripts/fixtures/single-chat-panel/main.cjs
+++ b/scripts/fixtures/single-chat-panel/main.cjs
@@ -81,6 +81,17 @@ app.whenReady().then(async () => {
     writeFileSync(path, (await window.webContents.capturePage()).toPNG())
     return path
   }
+  const drag = async (type, selector = '.single-chat-composer textarea', files = true) => {
+    const result = await run(`(() => {
+      const dataTransfer = new DataTransfer()
+      if (${files}) dataTransfer.items.add(new File(['private'], 'private.txt', { type: 'text/plain' }))
+      else dataTransfer.setData('text/plain', 'text drag')
+      const event = new DragEvent(${JSON.stringify(type)}, { dataTransfer, bubbles: true, cancelable: true })
+      document.querySelector(${JSON.stringify(selector)}).dispatchEvent(event)
+      return { defaultPrevented: event.defaultPrevented }
+    })()`)
+    return { ...result, state: await settle() }
+  }
 
   try {
     await waitFor("Boolean(document.querySelector('.single-chat-final'))")
@@ -105,6 +116,36 @@ app.whenReady().then(async () => {
     assert.match(state.body, /工作了 39 分 17 秒/)
     assert.match(state.body, /你在 5 分 38 秒后停止了运行/)
     assert.doesNotMatch(state.body, /Working for|You stopped after/)
+
+    // The panel is nested in the Camp drop surface in production. Its file events must stay private.
+    let dragged = await drag('dragenter')
+    assert.equal(dragged.state.attachmentDropVisible, true)
+    assert.deepEqual(dragged.state.bubbledDragEvents, [])
+    dragged = await drag('dragover', '.single-chat-transcript')
+    assert.equal(dragged.defaultPrevented, true)
+    assert.equal(dragged.state.attachmentDropVisible, true)
+    assert.deepEqual(dragged.state.bubbledDragEvents, [])
+    const dayDrop = await capture('single-chat-day-private-drop-1180x800')
+    dragged = await drag('dragleave')
+    assert.equal(dragged.state.attachmentDropVisible, false)
+    assert.deepEqual(dragged.state.bubbledDragEvents, [])
+    await drag('dragenter')
+    dragged = await drag('drop')
+    assert.equal(dragged.defaultPrevented, true)
+    assert.equal(dragged.state.attachmentDropVisible, false)
+    assert.deepEqual(dragged.state.bubbledDragEvents, [])
+
+    // Public-surface and ordinary text drags still propagate normally.
+    for (const type of ['dragenter', 'dragover', 'dragleave', 'drop']) {
+      await drag(type, '.public-execution-fixture')
+      dragged = await drag(type, '.single-chat-composer textarea', false)
+      assert.equal(dragged.defaultPrevented, false)
+      assert.equal(dragged.state.attachmentDropVisible, false)
+    }
+    assert.deepEqual(dragged.state.bubbledDragEvents, [
+      'dragenter', 'dragenter', 'dragover', 'dragover', 'dragleave', 'dragleave', 'drop', 'drop'
+    ])
+    await run('window.singleChatTest.resetDragEvents()')
 
     state = await click('.single-chat-run-history.is-terminal > summary')
     assert.equal(state.terminalOpen, true)
@@ -136,6 +177,11 @@ app.whenReady().then(async () => {
 
     assert.equal(composerEnter.state.sendFeedback, '连接中')
     assert.equal(composerEnter.state.composerDisabled, true)
+    for (const type of ['dragenter', 'dragover', 'dragleave', 'drop']) {
+      dragged = await drag(type, '.single-chat-transcript')
+      assert.equal(dragged.state.attachmentDropVisible, false)
+      assert.deepEqual(dragged.state.bubbledDragEvents, [])
+    }
     await run('window.singleChatTest.releaseSend()')
     await waitFor("window.singleChatTest.state().composerDisabled === false")
     state = await settle()
@@ -314,12 +360,13 @@ app.whenReady().then(async () => {
         campComposerParity: true,
         composerKeyboardSemantics: true,
         privateAttachments: true,
+        privateAttachmentDragBoundary: true,
         agentMessagesWithoutFill: true,
         runningStopAndQueueComposer: true,
         dayAndNight: true,
         compactNoOverflow: true
       },
-      captures: { dayMenu, dayDialog, dayQueued, dayTools, nightRunning, nightComplete, compact }
+      captures: { dayDrop, dayMenu, dayDialog, dayQueued, dayTools, nightRunning, nightComplete, compact }
     }))
     window.destroy()
     app.quit()

--- a/scripts/fixtures/single-chat-panel/renderer.tsx
+++ b/scripts/fixtures/single-chat-panel/renderer.tsx
@@ -342,6 +342,7 @@ Object.assign(window, {
 let locateNotification: (conversation: string) => void
 const notificationPresentations: number[] = []
 let notificationRequest = 0
+const bubbledDragEvents: string[] = []
 
 function Fixture(): React.JSX.Element {
   const [entryHost, setEntryHost] = useState<HTMLDivElement | null>(null)
@@ -362,7 +363,12 @@ function Fixture(): React.JSX.Element {
       <div className="single-chat-fixture-title"><span>rovai-ai</span><strong>单聊样式验收</strong></div>
       <div className="single-chat-fixture-entries" ref={setEntryHost} />
     </header>
-    <main className="single-chat-fixture-stage">
+    <main className="single-chat-fixture-stage"
+      onDragEnter={event => { bubbledDragEvents.push(event.type) }}
+      onDragOver={event => { bubbledDragEvents.push(event.type) }}
+      onDragLeave={event => { bubbledDragEvents.push(event.type) }}
+      onDrop={event => { bubbledDragEvents.push(event.type) }}
+    >
       <PublicExecutionFixture phase={phase} />
       <SingleChatPanel
         target={notificationTarget}
@@ -385,6 +391,7 @@ createRoot(document.getElementById('root')!).render(<Fixture />)
 
 Object.assign(window, {
   singleChatTest: {
+    resetDragEvents: () => { bubbledDragEvents.length = 0 },
     notification: (conversation: string) => locateNotification(conversation),
     settle: async () => {
       await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
@@ -405,6 +412,8 @@ Object.assign(window, {
       const composerActions = document.querySelector<HTMLElement>('.single-chat-composer .composer-actions')
       const rect = panel?.getBoundingClientRect()
       return {
+        bubbledDragEvents: [...bubbledDragEvents],
+        attachmentDropVisible: Boolean(document.querySelector('.single-chat-drop-layer')),
         body: document.body.textContent ?? '',
         liveText: document.querySelector('.single-chat-run-history.is-live')?.textContent ?? '',
         sendFeedback: document.querySelector('.single-chat-send-feedback')?.textContent ?? '',

--- a/scripts/lib/single-chat-panel.test.mjs
+++ b/scripts/lib/single-chat-panel.test.mjs
@@ -71,6 +71,7 @@ test('production Single Chat panel preserves private conversation layout and ter
       campComposerParity: true,
       composerKeyboardSemantics: true,
       privateAttachments: true,
+      privateAttachmentDragBoundary: true,
       agentMessagesWithoutFill: true,
       runningStopAndQueueComposer: true,
       dayAndNight: true,


### PR DESCRIPTION
Dragging a file into the Single Chat panel also activated the public Camp drop hint because the panel's drag events bubbled into the containing conversation surface. Stop file drag enter, over, and leave events at the panel boundary, including when attachment intake is disabled.

Extend the existing Electron fixture to verify private file drag feedback, leave/drop cleanup, blocked intake, and normal propagation for public-surface and text drags. The regression reproduced the original bubbling before the fix.

Validation:
- TypeScript check and 184 related Vitest tests passed.
- Required isolated Electron Single Chat integration passed, including the new drag boundary cases.
- Desktop production build passed.
- Documentation and Skill governance passed; 222 subsequent Node tests passed (one Windows-only test skipped on macOS).
- Full Vitest run: 1,689 passed, one existing Core startup retry test exceeded its 6-second snapshot deadline. An isolated rerun of that file passed all 20 tests without changes.
- Rust library: 543 passed; CLI: 33 passed. Slow integration: 296 passed, 13 failed in existing Skills projection expectations. No Rust, Cargo, or Skill files changed in this PR. Reproduced `context_manifest_freezes_skills_and_ignores_unrequested_historical_mcp` on clean main `efd3fd30` (expected one exposure, received zero); this is a baseline failure, not introduced by the drag fix.
- Clippy reports the existing `single_element_loop` in `crates/rovai-core/src/mcp_import.rs:1278`. The Rust/Cargo/Skills tree is identical between this branch and main; this PR leaves those unrelated baseline issues unchanged.
