### PR TITLE
fix(windows): secure MCP configuration permissions by default

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -159,3 +159,9 @@ jobs:
           cargo test -p rovai-core --lib
           --target x86_64-pc-windows-msvc
           private_json_replacement
+
+      - name: Exercise Windows MCP configuration permissions
+        run: >-
+          cargo test -p rovai-core --features slow-tests --lib
+          --target x86_64-pc-windows-msvc
+          mcp::slow_tests::

--- a/crates/rovai-core/src/mcp.rs
+++ b/crates/rovai-core/src/mcp.rs
@@ -24,6 +24,7 @@ use uuid::Uuid;
 #[cfg(windows)]
 use crate::platform::private_storage::{
     atomic_write_private_bytes, create_private_bytes, open_private_read_file,
+    private_directory_permissions_need_repair, private_file_permissions_need_repair,
     repair_private_directory, repair_private_file,
 };
 
@@ -1039,7 +1040,15 @@ impl McpConfigStore {
         if !self.path.exists() {
             self.write_new(&McpConfigFile::empty())?;
         }
-        self.load()
+        let loaded = self.load()?;
+        #[cfg(windows)]
+        if loaded.config.is_some() && loaded.permission_issue {
+            // Management initialization admits a valid, current-user-owned
+            // config by tightening ACLs only. `inspect` stays strictly read-only.
+            self.repair_permissions()?;
+            return self.load();
+        }
+        Ok(loaded)
     }
 
     fn load(&self) -> Result<LoadedConfig> {
@@ -1209,6 +1218,15 @@ impl McpConfigStore {
 
     #[cfg(windows)]
     fn write_new(&self, config: &McpConfigFile) -> Result<()> {
+        let parent = self
+            .path
+            .parent()
+            .context("MCP configuration path has no parent directory")?;
+        if parent.exists() && private_directory_permissions_need_repair(parent)? {
+            // The user-owned MCP directory can predate the first config (for
+            // example, an existing Skill Library). Secure it before writing bytes.
+            repair_private_directory(parent)?;
+        }
         let bytes = canonical_bytes(config)?;
         match create_private_bytes(&self.path, &bytes) {
             Ok(()) => Ok(()),
@@ -1290,7 +1308,7 @@ fn private_permission_issue(_path: &Path, metadata: &fs::Metadata) -> Result<boo
 
 #[cfg(windows)]
 fn private_permission_issue(path: &Path, _metadata: &fs::Metadata) -> Result<bool> {
-    Ok(open_private_read_file(path).is_err())
+    private_file_permissions_need_repair(path)
 }
 
 #[cfg(not(any(unix, windows)))]
@@ -1950,30 +1968,36 @@ mod slow_tests {
 
     #[test]
     fn missing_file_atomically_materializes_an_exact_empty_library() {
-        let (root, store) = temporary_store("empty-default");
-        assert_eq!(
-            store.migrate_pre_release_config().unwrap(),
-            McpConfigMigrationOutcome::Missing
-        );
-        assert!(!store.path().exists());
-        let view = store.get(&agents()).unwrap();
-        assert!(view.exists);
-        assert!(view.servers.is_empty());
-        assert_eq!(view.public_config_json, "{\n  \"mcpServers\": {}\n}\n");
-        assert!(!view.public_config_json.contains("_rovai"));
-        let raw = fs::read_to_string(store.path()).unwrap();
-        assert_eq!(
-            raw,
-            "{\n  \"mcpServers\": {},\n  \"_rovai\": {\n    \"schemaVersion\": 2,\n    \"servers\": {},\n    \"assignments\": []\n  }\n}\n"
-        );
-        #[cfg(unix)]
-        assert_eq!(
-            fs::metadata(store.path()).unwrap().permissions().mode() & 0o777,
-            0o600
-        );
-        #[cfg(windows)]
-        assert!(open_private_read_file(store.path()).is_ok());
-        let _ = fs::remove_dir_all(root);
+        for existing_parent in [false, true] {
+            let (root, store) = temporary_store("empty-default");
+            if existing_parent {
+                fs::create_dir_all(store.path().parent().unwrap()).unwrap();
+            }
+            assert_eq!(
+                store.migrate_pre_release_config().unwrap(),
+                McpConfigMigrationOutcome::Missing
+            );
+            assert!(!store.path().exists());
+            let view = store.get(&agents()).unwrap();
+            assert!(view.exists);
+            assert!(!view.permission_issue);
+            assert!(view.servers.is_empty());
+            assert_eq!(view.public_config_json, "{\n  \"mcpServers\": {}\n}\n");
+            assert!(!view.public_config_json.contains("_rovai"));
+            let raw = fs::read_to_string(store.path()).unwrap();
+            assert_eq!(
+                raw,
+                "{\n  \"mcpServers\": {},\n  \"_rovai\": {\n    \"schemaVersion\": 2,\n    \"servers\": {},\n    \"assignments\": []\n  }\n}\n"
+            );
+            #[cfg(unix)]
+            assert_eq!(
+                fs::metadata(store.path()).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+            #[cfg(windows)]
+            assert!(open_private_read_file(store.path()).is_ok());
+            let _ = fs::remove_dir_all(root);
+        }
     }
 
     #[test]
@@ -2134,6 +2158,7 @@ mod slow_tests {
         let McpMutationResult::Ok { config, .. } = created else {
             panic!("create should succeed");
         };
+        assert!(!config.permission_issue);
         let server = config
             .servers
             .iter()
@@ -2168,6 +2193,7 @@ mod slow_tests {
         let McpMutationResult::Ok { config, .. } = renamed else {
             panic!("rename should succeed");
         };
+        assert!(!config.permission_issue);
         let server = config
             .servers
             .iter()
@@ -2542,19 +2568,89 @@ mod slow_tests {
     #[cfg(windows)]
     #[test]
     fn windows_permission_repair_restricts_an_owned_inherited_config() {
-        let (root, store) = temporary_store("windows-permission-repair");
-        fs::create_dir_all(store.path().parent().unwrap()).unwrap();
-        fs::write(
-            store.path(),
-            canonical_bytes(&McpConfigFile::empty()).unwrap(),
-        )
-        .unwrap();
-        assert!(store.inspect(&agents()).unwrap().permission_issue);
+        // Keep explicit repair, first management access and invalid-file
+        // preservation together as the owner of existing-config ACL admission.
+        for (automatic, valid_config) in [(false, true), (true, true), (true, false)] {
+            let (root, store) = temporary_store("windows-permission-repair");
+            fs::create_dir_all(store.path().parent().unwrap()).unwrap();
+            let bytes = if valid_config {
+                canonical_bytes(&McpConfigFile::empty()).unwrap()
+            } else {
+                b"{broken".to_vec()
+            };
+            fs::write(store.path(), &bytes).unwrap();
+            assert!(store.inspect(&agents()).unwrap().permission_issue);
+            // Inspection must not repair either the directory or the file.
+            assert!(
+                private_directory_permissions_need_repair(store.path().parent().unwrap()).unwrap()
+            );
 
-        store.repair_permissions().unwrap();
+            if automatic {
+                let view = store.get(&agents()).unwrap();
+                assert_eq!(view.permission_issue, !valid_config);
+                assert_eq!(view.file_issue.is_none(), valid_config);
+            } else {
+                store.repair_permissions().unwrap();
+            }
 
-        assert!(!store.inspect(&agents()).unwrap().permission_issue);
-        assert!(open_private_read_file(store.path()).is_ok());
+            assert_eq!(
+                store.inspect(&agents()).unwrap().permission_issue,
+                !valid_config
+            );
+            assert_eq!(
+                private_directory_permissions_need_repair(store.path().parent().unwrap()).unwrap(),
+                !valid_config
+            );
+            assert_eq!(open_private_read_file(store.path()).is_ok(), valid_config);
+            assert_eq!(fs::read(store.path()).unwrap(), bytes);
+            let _ = fs::remove_dir_all(root);
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_permission_inspection_does_not_require_write_access() {
+        use std::os::windows::fs::OpenOptionsExt;
+        use windows_sys::Win32::Storage::FileSystem::FILE_SHARE_READ;
+
+        // Unlike the repair cases, this owns the false-warning regression:
+        // healthy ACLs with a concurrent reader or a read-only file attribute.
+        let (root, store) = temporary_store("windows-permission-inspection");
+        let initial = store.get(&agents()).unwrap();
+        let original_metadata = fs::metadata(store.path()).unwrap();
+        let bytes = fs::read(store.path()).unwrap();
+        for read_only in [false, true] {
+            let mut permissions = original_metadata.permissions();
+            permissions.set_readonly(read_only);
+            fs::set_permissions(store.path(), permissions).unwrap();
+            // Exercise the sharing conflict and read-only attribute separately.
+            let reader = (!read_only).then(|| {
+                fs::OpenOptions::new()
+                    .read(true)
+                    .share_mode(FILE_SHARE_READ)
+                    .open(store.path())
+                    .unwrap()
+            });
+
+            let view = store.inspect(&agents()).unwrap();
+            assert!(!view.permission_issue);
+            assert!(view.file_issue.is_none());
+            assert_eq!(view.config_digest, initial.config_digest);
+            assert!(!store.get(&agents()).unwrap().permission_issue);
+            assert!(open_private_read_file(store.path()).is_ok());
+            assert_eq!(
+                fs::metadata(store.path()).unwrap().permissions().readonly(),
+                read_only
+            );
+            assert_eq!(fs::read(store.path()).unwrap(), bytes);
+            drop(reader);
+        }
+        fs::set_permissions(store.path(), original_metadata.permissions()).unwrap();
+        fs::remove_file(store.path()).unwrap();
+        // A disappearance between stat and ACL observation is an inspection
+        // failure, not evidence that permissions need repair; no file is created.
+        assert!(private_permission_issue(store.path(), &original_metadata).is_err());
+        assert!(!store.path().exists());
         let _ = fs::remove_dir_all(root);
     }
 }

--- a/crates/rovai-core/src/platform/private_storage.rs
+++ b/crates/rovai-core/src/platform/private_storage.rs
@@ -176,6 +176,18 @@ pub(crate) fn open_private_read_file(path: &Path) -> Result<File> {
     open_private_read_file_platform(path)
 }
 
+/// Inspects an existing file and its parent through metadata-only handles.
+/// Read/open failures remain errors; only a verified DACL mismatch returns true.
+#[cfg(windows)]
+pub(crate) fn private_file_permissions_need_repair(path: &Path) -> Result<bool> {
+    windows::private_file_permissions_need_repair(path)
+}
+
+#[cfg(windows)]
+pub(crate) fn private_directory_permissions_need_repair(path: &Path) -> Result<bool> {
+    windows::private_directory_permissions_need_repair(path)
+}
+
 /// Creates a new private, non-inheritable file and rejects an existing leaf.
 pub(crate) fn create_private_new_file(path: &Path) -> Result<File> {
     create_private_new_file_platform(path)
@@ -512,15 +524,17 @@ mod windows {
                 Some(ERROR_FILE_EXISTS) | Some(ERROR_ALREADY_EXISTS)
             ) {
                 created = false;
-                open_existing_private_file(path).map_err(|open_error| {
-                    blocker(
-                        PRIVATE_ACL_INVALID,
-                        format!(
-                            "failed to open existing private file {}: {open_error:#}",
-                            path.display()
-                        ),
-                    )
-                })?
+                open_existing_private_file(path, GENERIC_READ | GENERIC_WRITE).map_err(
+                    |open_error| {
+                        blocker(
+                            PRIVATE_ACL_INVALID,
+                            format!(
+                                "failed to open existing private file {}: {open_error:#}",
+                                path.display()
+                            ),
+                        )
+                    },
+                )?
             } else {
                 return Err(error)
                     .with_context(|| format!("failed to create private file {}", path.display()));
@@ -561,7 +575,7 @@ mod windows {
         let admitted_parent = admit_private_directory(parent)?;
         let parent_handle = open_path(&admitted_parent, ExpectedObjectKind::Directory)?;
         let parent_identity = file_identity(&parent_handle)?;
-        let handle = open_existing_private_file(path)?;
+        let handle = open_existing_private_file(path, GENERIC_READ)?;
         let identity = inspect_handle(&handle, ExpectedObjectKind::File)?;
         if identity.volume_serial_number != parent_identity.volume_serial_number {
             bail!(
@@ -579,6 +593,32 @@ mod windows {
             )
         })?;
         Ok(File::from(handle))
+    }
+
+    pub(super) fn private_file_permissions_need_repair(path: &Path) -> Result<bool> {
+        validate_native_absolute_path(path)?;
+        let parent = path.parent().context("private file path has no parent")?;
+        admit_volume(parent)?;
+        let parent_handle = open_path(parent, ExpectedObjectKind::Directory)?;
+        let handle = open_path(path, ExpectedObjectKind::File)?;
+        if file_identity(&handle)?.volume_serial_number
+            != file_identity(&parent_handle)?.volume_serial_number
+        {
+            bail!("{IDENTITY_UNAVAILABLE}: private file and parent resolved to different volumes");
+        }
+        let parent_issue = PrivateSecurityDescriptor::new(PrivateObjectKind::Directory)?
+            .file_permissions_need_repair(parent_handle.as_raw_handle() as HANDLE)?;
+        let file_issue = PrivateSecurityDescriptor::new(PrivateObjectKind::File)?
+            .file_permissions_need_repair(handle.as_raw_handle() as HANDLE)?;
+        Ok(parent_issue || file_issue)
+    }
+
+    pub(super) fn private_directory_permissions_need_repair(path: &Path) -> Result<bool> {
+        validate_native_absolute_path(path)?;
+        admit_volume(path)?;
+        let handle = open_path(path, ExpectedObjectKind::Directory)?;
+        PrivateSecurityDescriptor::new(PrivateObjectKind::Directory)?
+            .file_permissions_need_repair(handle.as_raw_handle() as HANDLE)
     }
 
     pub(super) fn create_private_new_file(path: &Path) -> Result<File> {
@@ -843,14 +883,14 @@ mod windows {
         Ok(handle)
     }
 
-    fn open_existing_private_file(path: &Path) -> Result<OwnedHandle> {
+    fn open_existing_private_file(path: &Path, access: u32) -> Result<OwnedHandle> {
         let wide_path = wide_path(path)?;
         let raw = unsafe {
             // SAFETY: wide_path is NUL-terminated. Null security attributes make
             // the existing handle non-inheritable and OPEN_EXISTING never creates.
             CreateFileW(
                 wide_path.as_ptr(),
-                GENERIC_READ | GENERIC_WRITE | READ_CONTROL,
+                access | READ_CONTROL,
                 FILE_SHARE_READ | FILE_SHARE_WRITE,
                 null(),
                 OPEN_EXISTING,

--- a/crates/rovai-core/src/platform/windows_security.rs
+++ b/crates/rovai-core/src/platform/windows_security.rs
@@ -27,6 +27,17 @@ use windows_sys::Win32::{
 const ACCESS_ALLOWED_ACE_TYPE_VALUE: u8 = 0;
 const LOCAL_SYSTEM_SID: &str = "S-1-5-18";
 
+#[derive(Debug)]
+struct PrivateDaclMismatch(String);
+
+impl std::fmt::Display for PrivateDaclMismatch {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for PrivateDaclMismatch {}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum PrivateObjectKind {
     Directory,
@@ -102,10 +113,21 @@ impl PrivateSecurityDescriptor {
         security.verify_private_policy(self.kind, &self.principal_sid)
     }
 
+    /// Only an observed DACL mismatch is repairable. Failed reads and unknown
+    /// owners must not become a permission warning or authorize an ACL rewrite.
+    pub(crate) fn file_permissions_need_repair(&self, handle: HANDLE) -> Result<bool> {
+        match self.verify_file_handle(handle) {
+            Ok(()) => Ok(false),
+            Err(error) if error.is::<PrivateDaclMismatch>() => Ok(true),
+            Err(error) => Err(error),
+        }
+    }
+
     pub(crate) fn apply_file_dacl(&self, handle: HANDLE) -> Result<()> {
         if self.kind == PrivateObjectKind::NamedPipe {
             bail!("named-pipe descriptors cannot repair filesystem objects");
         }
+        SecurityInfo::from_file_handle(handle)?.verify_file_owner(&self.principal_sid)?;
         let mut present = 0;
         let mut defaulted = 0;
         let mut dacl = null_mut();
@@ -217,11 +239,16 @@ impl SecurityInfo {
         })
     }
 
-    fn verify_private_policy(&self, kind: PrivateObjectKind, current_user_sid: &str) -> Result<()> {
-        if kind != PrivateObjectKind::NamedPipe
-            && (self.owner.is_null() || sid_to_string(self.owner)? != current_user_sid)
-        {
+    fn verify_file_owner(&self, current_user_sid: &str) -> Result<()> {
+        if self.owner.is_null() || sid_to_string(self.owner)? != current_user_sid {
             bail!("filesystem object owner is not the current Windows user");
+        }
+        Ok(())
+    }
+
+    fn verify_private_policy(&self, kind: PrivateObjectKind, current_user_sid: &str) -> Result<()> {
+        if kind != PrivateObjectKind::NamedPipe {
+            self.verify_file_owner(current_user_sid)?;
         }
 
         let mut control = 0_u16;
@@ -236,10 +263,15 @@ impl SecurityInfo {
                 .context("failed to inspect Windows security descriptor control flags");
         }
         if control & SE_DACL_PROTECTED == 0 {
-            bail!("filesystem object DACL is not protected from inheritance");
+            return Err(PrivateDaclMismatch(
+                "filesystem object DACL is not protected from inheritance".to_string(),
+            )
+            .into());
         }
         if self.dacl.is_null() {
-            bail!("filesystem object has no explicit DACL");
+            return Err(
+                PrivateDaclMismatch("filesystem object has no explicit DACL".to_string()).into(),
+            );
         }
 
         let mut acl_info = ACL_SIZE_INFORMATION::default();
@@ -258,10 +290,11 @@ impl SecurityInfo {
                 .context("failed to inspect Windows DACL entries");
         }
         if acl_info.AceCount != 2 {
-            bail!(
+            return Err(PrivateDaclMismatch(format!(
                 "filesystem object DACL has {} entries; expected exactly 2",
                 acl_info.AceCount
-            );
+            ))
+            .into());
         }
 
         let expected_flags = match kind {
@@ -296,7 +329,7 @@ impl SecurityInfo {
                 || ace.Header.AceFlags != expected_flags
                 || ace.Mask != expected_mask
             {
-                bail!(
+                return Err(PrivateDaclMismatch(format!(
                     "private object DACL contains an unexpected access entry: type={}, flags={:#04x}, mask={:#010x}; expected type={}, flags={:#04x}, mask={:#010x}",
                     ace.Header.AceType,
                     ace.Header.AceFlags,
@@ -304,7 +337,8 @@ impl SecurityInfo {
                     ACCESS_ALLOWED_ACE_TYPE_VALUE,
                     expected_flags,
                     expected_mask
-                );
+                ))
+                .into());
             }
             let sid = std::ptr::addr_of!(ace.SidStart).cast_mut().cast();
             entries.push(sid_to_string(sid)?);
@@ -313,7 +347,11 @@ impl SecurityInfo {
         let mut expected = [LOCAL_SYSTEM_SID.to_string(), current_user_sid.to_string()];
         expected.sort();
         if entries != expected {
-            bail!("private object DACL is not limited to SYSTEM and the admitted principal");
+            return Err(PrivateDaclMismatch(
+                "private object DACL is not limited to SYSTEM and the admitted principal"
+                    .to_string(),
+            )
+            .into());
         }
         Ok(())
     }

--- a/docs/architecture/foundational-invariants.md
+++ b/docs/architecture/foundational-invariants.md
@@ -438,6 +438,7 @@ last_updated: 2026-09-08
 ### 外部 MCP 配置与投影
 
 - `~/.rovai/mcp.json` 是用户管理外部 MCP Server、immutable server identity、enablement 和 Assignment 的唯一配置真源；SQLite 不复制 Server/Assignment 真源。已有 env/Header 明文凭证可在本机导入时迁移至既有私有配置存储；Unix 为文件 `0600`、目录 `0700` 的明文，Windows 复用私有 ACL，并不承诺落盘加密或新增密钥库。
+- Windows 的 MCP 管理初始化默认准备私有权限：新建前收紧已存在且属于当前用户的配置父目录；已有配置只有通过完整格式校验、当前用户所有权、普通文件/目录、local NTFS 与非 reparse 检查后，才自动把父目录和文件收紧到当前用户/SYSTEM 的 protected DACL，保持 JSON 字节与 digest 不变。后续保存继续使用创建时私有的临时文件原子替换。损坏配置、未知所有者或检查失败不触发自动修复；`inspect` 与诊断自检保持严格只读。Windows 权限观察只请求元数据与 ACL 读取，只有明确的 DACL 不匹配才产生权限提示，不能把占用、只读属性或 I/O 失败当作权限过宽。
 - 文件是一个封闭、版本化 canonical JSON envelope；Core 在完整校验、规范化和精确 compare-and-swap 后原子替换。管理用 identity/revision/provenance 元数据不投影给 Runtime，Server identity 不因显示名、参数或 secret 变化而改变，删除后不复用。默认前端预览、命令回执、事件、诊断和日志不得暴露完整凭证；后端从选定来源重新读取并校验后完成隐藏值迁移，未修改的掩码不得作为凭证落盘。用户在详情显式点击“显示”时，独立只读 `mcp.servers.reveal` 以所选 Server ID 和预期 digest 读取单项原值，只进入当前编辑会话，不经过通用命令回执或事件，不写入前端持久存储。保存或离开后重新隐藏；日常落盘仍为既有权限收紧的私有配置文件，并非加密存储。Runtime 接收值仍沿用既有 Core-owned 私有投影边界。
 - 本机导入保留 env/Header 的原始值语义（含空值、空白和鉴权前缀），不生成新变量名或强制重复填写。引用按来源语义无损转换，并以 Core 实际启动环境判定缺项；不兼容语法明确拒绝该候选，不影响其他候选。新增仍默认停用且不分配队员；替换保留 identity、启停和分配，失败不破坏旧配置。历史生成的占位符不推测恢复，只有显式重新选取原始来源执行替换才迁移来源值。
 - 新配置从空 `mcpServers`、空管理元数据和无 Assignment 开始；产品不内置、恢复、广告或自动创建第三方 preset/受审定义。所有外部 Server 都来自用户显式创建/导入。

--- a/docs/architecture/windows-desktop-platform.md
+++ b/docs/architecture/windows-desktop-platform.md
@@ -3,7 +3,7 @@ document_type: architecture
 architecture: windows-desktop-platform
 authority: windows-desktop-platform-composition
 status: accepted
-last_updated: 2026-09-04
+last_updated: 2026-09-08
 ---
 
 # Windows Desktop Platform
@@ -71,6 +71,11 @@ transport-independent.
 [Windows Private Storage v2](../contracts/windows-private-storage-v2.md) places Core and Electron state under separate
 `%LOCALAPPDATA%\Rovai AI` children. Private objects are created with a protected DACL before becoming visible. Opened
 handle identity, verified ancestry and reparse policy—not lowercase strings—own security and deduplication.
+
+MCP 管理初始化按[外部 MCP 配置边界](foundational-invariants.md#skills-external-mcp)默认准备权限：首次创建前
+收紧当前用户拥有的既有父目录；加载格式有效的既有配置时可仅修复其父目录与文件 DACL，随后重新检查，
+不改写 JSON。通用私有存储准入仍拒绝未知对象。权限审计使用元数据句柄，读取失败保留为检查失败；
+诊断自检不调用初始化或修复。
 
 The derived legacy Camp Published Attachment View is the explicit `<data_dir>\runtime-files` private child; Windows never
 uses the macOS Home-based instance directory. Root/managed containers use native private-directory admission, and Runtime


### PR DESCRIPTION
Windows MCP settings could immediately show a permission warning for an existing user-owned directory or configuration. The permission probe also requested write access and treated any open failure as an ACL problem.

Prepare private permissions during MCP management initialization: tighten an existing current-user-owned directory before creating the configuration, and tighten an existing valid configuration without changing its JSON bytes or digest. Inspect ACLs through metadata-only handles, retain I/O/ownership failures as errors, and check the owner before applying a DACL. Diagnostics inspection remains read-only, and atomic saves retain the existing private-at-creation policy.

Extend the existing MCP initialization and inherited-ACL repair tests for automatic preparation and malformed-file preservation. Add one Windows regression test at the MCP store boundary for concurrent readers, read-only attributes, and a file disappearing during inspection; those failures are separate from the existing actual-ACL-repair cases. Run the MCP suite in the Windows Full check job.

Validation completed:
- Rust library: 543 passed.
- Rust CLI: 33 passed.
- TypeScript and Vitest: 166 files / 1,701 tests passed.
- Targeted MCP suite: 11 passed.
- Rust compile and format checks, plus a scoped Windows MSVC cross-compilation check, passed.

The repository owner requested stopping additional testing and merging directly. The remaining local slow-tests were stopped; no Windows native or manual Full check run was started. Local documentation checks encounter three pre-existing broken links in ignored prototype documents; those local documents are not part of this PR.
