### PR TITLE
chore(release): prepare v0.2.1 with Chinese release notes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "rovai-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/rovai-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rovai/desktop",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "license": "MIT",
   "type": "module"

--- a/apps/desktop/src/main/package-metadata.test.ts
+++ b/apps/desktop/src/main/package-metadata.test.ts
@@ -9,7 +9,7 @@ const packageMetadata = JSON.parse(readFileSync(
 describe('desktop package metadata', () => {
   it('keeps the visible brand separate from Electron helper bundle identity', () => {
     expect(packageMetadata.productName).toBe('Rovai AI')
-    expect(packageMetadata.version).toBe('0.2.0')
+    expect(packageMetadata.version).toBe('0.2.1')
     expect(packageMetadata.build.productName).toBe('Rovai AI')
     expect(packageMetadata.build.mac.executableName).toBeUndefined()
     expect(packageMetadata.build.win.executableName).toBe('Rovai-ai')

--- a/build/release-notes.md
+++ b/build/release-notes.md
@@ -1,21 +1,19 @@
-# Rovai AI v0.2.0
+# Rovai AI v0.2.1
 
-Rovai AI 0.2.0 makes the desktop workspace more personal, easier to configure, and clearer while agents are working.
+本次更新重点改善 MCP 与 Skills 管理、定时任务和会话阅读体验，并统一桌面各页面的视觉风格。
 
-macOS arm64 and x64 builds use the same fixed Rovai Release Signing certificate as 0.1.0. Windows x64 remains an unsigned Preview build and may show a SmartScreen warning.
+- **MCP 与 Skills 工作区升级**：采用可调整宽度的列表与详情分栏，添加、导入、配置和预览在页面内完成，保存与删除操作固定在顶部。
+- **MCP 导入更顺畅**：从本机导入时保留已有凭证与环境变量引用，减少重复填写；支持来源筛选、同名项分组和配置查看，错误与冲突提示更清楚。
+- **凭证显示更可控**：敏感字段默认隐藏，点击后查看原值；切换配置或保存后自动隐藏。
+- **Skill 文件浏览更方便**：支持导入前预览包内文件、折叠目录、搜索文件，以及 Markdown 阅读与源码切换。
+- **恢复定时任务入口**：完善总览、空白与模板创建流程，优化日期和时间选择，增加 Cron 即时校验及错误提示。
+- **会话阅读更连贯**：同一队员连续发送的公屏消息按条件分组，减少重复头像与署名，保留每条消息独立的复制和回复操作。
+- **执行操作更清晰**：Fast 移至模型配置旁，统一停止与收起按钮；收起后保留执行选择、展开内容和滚动位置。
+- **统一界面风格**：优化设置、队员、记忆、会话菜单和文件预览的控件与间距，改善宽屏、窄窗口及高倍缩放体验；运行监控支持切换折线图指标。
+- **新手引导更完整**：优化运行时配置与首次会话流程，提供三个起步示例；修复完成引导后意外返回首页的问题。
+- **修复交互问题**：解决 MCP/Skills 顶部按钮无法点击、会话加载时输入区跳动，以及单聊拖入文件时误触发公屏提示的问题。
+- **修复 Windows MCP 权限问题**：自动准备当前用户配置的私有权限，减少权限异常提示，并保留已有配置内容。
 
-## What's Changed
+内置 Skill 调整：移除 5 项旧第三方预置 Skill，保留用户手动导入的内容；`analyze-agent-codebase` 在首次安装时默认关闭，可按需启用。
 
-- Add complete appearance and reading controls for theme, conversation, document and code text sizes, reading density, application zoom, and reduced motion.
-- Redesign teammate configuration as an inline workspace with independent profile and Runtime saves, preserved drafts, clearer status, and safer conflict handling.
-- Refine the teammate roster with a resizable and collapsible rail, search for larger teams, compact grouping, and remembered layout preferences.
-- Speed up new conversations with optional saved team defaults while consistently excluding unavailable or unconfigured teammates from selection and leadership.
-- Guide users through installing and signing in to supported Agent Runtimes, with platform-aware commands, copy feedback, refresh, and recheck actions.
-- Distinguish connecting, thinking, active execution, approvals, retries, and completion without leaving stale status text after real output arrives.
-- Put Fast controls directly in execution details and simplify shared stop and collapse actions while preserving keyboard focus and per-member state.
-- Improve file activity with localized multi-file reads, wider diff click targets, direct previews for operation-only changes, canonical path display, reveal/copy actions, and safe source-attachment paths.
-- Capture verified Pi edit patches as reviewable diffs, keep missing Pi installations out of subsystem health, and finalize Pi Skill availability and delivery ordering.
-- Restore private-chat approval, completion and failure notifications while keeping the conversation currently being read quiet and preserving notification focus.
-- Keep Markdown previews vertically scrollable over wide tables and tighten long notification and file-row layouts across narrow windows.
-
-**Full changelog:** https://github.com/murray17/rovai-ai/compare/v0.1.0...v0.2.0
+**完整更新记录：** https://github.com/murray17/rovai-ai/compare/v0.2.0...v0.2.1

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rovai-ai",
   "productName": "Rovai AI",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "description": "A desktop workspace for long-lived agent teams, shared Camps, visible execution, and collaborative memory.",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rovai/contracts",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/scripts/accept-app-updates-ui.mjs
+++ b/scripts/accept-app-updates-ui.mjs
@@ -56,7 +56,7 @@ try {
     outputDir,
     verified: {
       isolatedPackagedApplication: true,
-      packagedVersion: '0.2.0',
+      packagedVersion: '0.2.1',
       typedIdleUpdaterSnapshot: true,
       productAndBundleName: 'Rovai AI',
       existingSettingsVisualWorld: true,
@@ -93,12 +93,12 @@ async function openAboutUpdates(cdp) {
   assert(selected, 'About & Updates Settings entry was unavailable')
   await waitForSelector(cdp, '.about-updates-settings')
   await waitForExpression(cdp,
-    `document.querySelector('.about-identity p > span:first-child')?.textContent === '版本 v0.2.0'`)
+    `document.querySelector('.about-identity p > span:first-child')?.textContent === '版本 v0.2.1'`)
 }
 
 async function assertAboutUpdates(cdp, context) {
   const updaterSnapshot = await evaluate(cdp, 'window.rovai.appUpdates.get()', true)
-  assert(updaterSnapshot?.currentVersion === '0.2.0'
+  assert(updaterSnapshot?.currentVersion === '0.2.1'
     && updaterSnapshot.status === 'idle'
     && updaterSnapshot.availableRelease === null
     && updaterSnapshot.lastCheckSource === null
@@ -136,7 +136,7 @@ async function assertAboutUpdates(cdp, context) {
   assert(state.heading === '关于与更新', `${context} omitted the page heading`)
   assert(state.description === '自动检查新版本，下载与安装由你决定。',
     `${context} used the wrong description`)
-  assert(state.product === 'Rovai AI' && state.version === '版本 v0.2.0',
+  assert(state.product === 'Rovai AI' && state.version === '版本 v0.2.1',
     `${context} used the wrong product/version: ${JSON.stringify(state)}`)
   assert(state.action === '检查更新' && state.actionTag === 'BUTTON' && state.actionFocused,
     `${context} did not expose a keyboard-focusable check action`)


### PR DESCRIPTION
将应用、桌面包、Contracts 与 Core 的产品版本统一更新至 0.2.1，并同步已有版本断言。发布说明采用已确认的中文内容，涵盖 MCP/Skills、定时任务、会话阅读、界面统一及 Windows MCP 权限修复，供 GitHub Release 和应用内更新共用。

本次共修改 8 个文件：版本元数据、版本断言和发布说明。

验证：`pnpm install --frozen-lockfile`、`pnpm typecheck`、`pnpm test`、`pnpm build:desktop`、`pnpm test:rust:pr`、`cargo fmt --all --check`、`cargo clippy --workspace --all-targets -- -D warnings`、`git diff --check`。
