### PR TITLE
fix(quotes): keep private source navigation inside its viewport

### DIFF
--- a/apps/desktop/src/renderer/src/MessageQuotes.tsx
+++ b/apps/desktop/src/renderer/src/MessageQuotes.tsx
@@ -178,7 +178,7 @@ export function MessageQuoteSelectionToolbar({ ownerKey, messages, disabled, onA
         if (!next || same(dismissed.current, next.range)) { setCandidate(null); return }
         const rects = [...next.range.getClientRects()]
         const rect = rects.at(-1) ?? next.range.getBoundingClientRect()
-        const viewport = next.root.closest('.conversation-timeline, .single-chat-transcript')?.getBoundingClientRect()
+        const viewport = next.root.closest('.conversation-timeline, .single-chat-viewport')?.getBoundingClientRect()
         if (!rect.width || rect.bottom < Math.max(0, viewport?.top ?? 0) || rect.top > Math.min(window.innerHeight, viewport?.bottom ?? window.innerHeight)) { setCandidate(null); return }
         setPosition({ x: Math.max(8, Math.min(window.innerWidth - 100, rect.right - 50)), y: Math.max(8, Math.min(window.innerHeight - 44, rect.bottom + 7)) })
         setCandidate(next); setError(null)

--- a/apps/desktop/src/renderer/src/message-quote-reveal.ts
+++ b/apps/desktop/src/renderer/src/message-quote-reveal.ts
@@ -113,7 +113,7 @@ export async function revealMessageQuote(quote: MessageQuoteSnapshot, root: HTML
   if (!bounds) { clear(); throw new Error('quote.selection_unavailable') }
   clearActive = clear
   root.dataset.quoteLocated = 'true'
-  const timeline = root.closest<HTMLElement>('.conversation-timeline, .single-chat-transcript')
+  const timeline = root.closest<HTMLElement>('.conversation-timeline, .single-chat-viewport')
   if (timeline) {
     const viewport = timeline.getBoundingClientRect()
     const padding = 40

--- a/scripts/fixtures/message-quotes/renderer.tsx
+++ b/scripts/fixtures/message-quotes/renderer.tsx
@@ -62,12 +62,14 @@ function Fixture() {
   }
   return <main style={{ maxWidth: 780, margin: '24px auto', padding: 20 }}>
     <div className="conversation-timeline" style={{ maxHeight: 410, overflow: 'auto' }}>
-      {messages.map((message, index) => <section key={message.id}>
-        <div className="final-copy" data-message-quote-body={message.id} data-quote-owner="camp:fixture">
-          {messageBody(index)}
-        </div>
-        {index === 0 && <div data-quote-exclude>文件卡片 <button>复制文件</button></div>}
-      </section>)}
+      <div className="single-chat-transcript" style={{ display: 'block', padding: 0 }}>
+        {messages.map((message, index) => <section key={message.id}>
+          <div className="final-copy" data-message-quote-body={message.id} data-quote-owner="camp:fixture">
+            {messageBody(index)}
+          </div>
+          {index === 0 && <div data-quote-exclude>文件卡片 <button>复制文件</button></div>}
+        </section>)}
+      </div>
     </div>
     <MessageQuoteSelectionToolbar ownerKey="camp:fixture" messages={messages} onAdd={add} disabled={false} />
     <div style={{ marginTop: 12 }}><MessageQuotes history quotes={quotes} onReveal={quote => revealMessageQuote(quote, root(Number(quote.source.messageId.split('-')[1])))} /></div>
@@ -175,6 +177,19 @@ Object.assign(window, { quoteTest: {
     await revealMessageQuote({ ...saved, locator: { ...saved.locator!, projectionDigest: 'changed' } }, root(lineSourceIndex)).then(() => { throw new Error('stale anchor must fail') }, error => check(String(error).includes('selection_unavailable'), 'stale digest'))
     check(!document.querySelector('.message-quote-line-band'), 'stale source is unhighlighted')
     trigger.scrollIntoView(); await frames()
+    // Single Chat has a scrolling viewport outside its non-scrolling transcript.
+    const viewport = document.querySelector<HTMLElement>('.conversation-timeline')!
+    viewport.className = 'single-chat-viewport'
+    viewport.scrollTop = 0
+    await revealMessageQuote(saved, root(lineSourceIndex)); await pause(400); await frames()
+    const located = root(lineSourceIndex).querySelector('.message-quote-line-band')!.getBoundingClientRect()
+    const visible = viewport.getBoundingClientRect()
+    check(viewport.scrollTop > 0 && located.top >= visible.top && located.bottom <= visible.bottom, 'private jump scrolls the actual viewport into view')
+    const clippedRange = select(lineSourceIndex, start + 1, end)
+    viewport.scrollTop += clippedRange.getBoundingClientRect().top - (visible.bottom + 20)
+    document.dispatchEvent(new Event('scroll')); await frames()
+    check(!document.querySelector('.message-quote-selection-toolbar'), 'clipped private selection has no floating toolbar outside the viewport')
+    viewport.className = 'conversation-timeline'
     trigger.click(); await frames()
     while (latest.length) {
       document.querySelector<HTMLButtonElement>('.message-quote-remove')!.click(); await frames()


### PR DESCRIPTION
Packaged App acceptance of #315 found that Single Chat quote navigation used the non-scrolling transcript as its viewport. Clicking a quoted excerpt could leave its source lines clipped beneath the private chat header, and a selection outside the actual viewport could retain its quote toolbar.

Use the outer Single Chat viewport for both source scrolling and selection clipping. Extend the Electron interaction fixture with the nested private transcript structure and verify that source lines become visible and clipped selections hide the toolbar.

Validation: `pnpm typecheck`, `ROVAI_KEEP_QUOTE_FIXTURE=1 pnpm test:message-quotes`, and `git diff --check` passed. The original quote implementation's Rust, context, persistence, real Runtime, and UI acceptance results are recorded in #315; this patch changes renderer viewport ownership only.
