### PR TITLE
fix(release): align Windows verification with transport v24

### DIFF
--- a/scripts/lib/sidecar-targets.test.mjs
+++ b/scripts/lib/sidecar-targets.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 import test from 'node:test'
 
 import {
@@ -7,6 +8,20 @@ import {
   sidecarTarget,
   stagedSidecarPath
 } from './sidecar-targets.mjs'
+
+test('Windows release verification matches the current Core transport versions', () => {
+  const transport = readFileSync(new URL('../../crates/rovai-core/src/builtin_tool_transport.rs', import.meta.url), 'utf8')
+  const verifier = readFileSync(new URL('../verify-windows-release.mjs', import.meta.url), 'utf8')
+  const contract = transport.match(/BUILTIN_TOOL_CONTRACT_VERSION: u32 = (\d+);/)?.[1]
+  const ipc = transport.match(/BUILTIN_TOOL_IPC_PROTOCOL_VERSION: u32 = (\d+);/)?.[1]
+  assert.ok(contract && ipc, 'Core transport version constants must be present')
+  assert.deepEqual(verifier.match(/contract-v(\d+) ipc-v(\d+)/)?.slice(1), [contract, ipc],
+    'packaged CLI verification must use current transport versions')
+  assert.equal(verifier.match(/health\.core\.builtinToolContractVersion !== (\d+)/)?.[1], contract,
+    'packaged Core health verification must use the current contract version')
+  assert.equal(verifier.match(/health\.core\.builtinToolIpcProtocolVersion !== (\d+)/)?.[1], ipc,
+    'packaged Core health verification must use the current IPC version')
+})
 
 test('maps only the three shipped sidecar targets', () => {
   assert.equal(hostSidecarTargetKey('darwin', 'arm64'), 'macos-arm64')

--- a/scripts/lib/sidecar-targets.test.mjs
+++ b/scripts/lib/sidecar-targets.test.mjs
@@ -21,6 +21,10 @@ test('Windows release verification matches the current Core transport versions',
     'packaged Core health verification must use the current contract version')
   assert.equal(verifier.match(/health\.core\.builtinToolIpcProtocolVersion !== (\d+)/)?.[1], ipc,
     'packaged Core health verification must use the current IPC version')
+  assert.equal(verifier.match(/builtinToolContractVersion: (\d+)/)?.[1], contract,
+    'release manifest must record the current contract version')
+  assert.equal(verifier.match(/builtinToolIpcProtocolVersion: (\d+)/)?.[1], ipc,
+    'release manifest must record the current IPC version')
 })
 
 test('maps only the three shipped sidecar targets', () => {

--- a/scripts/verify-windows-release.mjs
+++ b/scripts/verify-windows-release.mjs
@@ -436,7 +436,7 @@ try {
     packagedCoreSmoke: {
       isolatedDataRoot: true,
       healthCheck: true,
-      builtinToolContractVersion: 23,
+      builtinToolContractVersion: 24,
       builtinToolIpcProtocolVersion: 2
     }
   }

--- a/scripts/verify-windows-release.mjs
+++ b/scripts/verify-windows-release.mjs
@@ -380,7 +380,7 @@ try {
     cli: await verifyBinary('rovai', cliExecutable)
   }
   const cliVersion = run(cliExecutable, ['--version'])
-  if (!cliVersion.includes(`rovai ${packageMetadata.version} contract-v23 ipc-v2`)) {
+  if (!cliVersion.includes(`rovai ${packageMetadata.version} contract-v24 ipc-v2`)) {
     throw new Error(`unexpected packaged CLI version: ${cliVersion}`)
   }
   report.push(`CLI: ${cliVersion}`)
@@ -393,7 +393,7 @@ try {
   const health = await core.request('health.check')
   if (health?.core?.ok !== true
       || health.core.version !== packageMetadata.version
-      || health.core.builtinToolContractVersion !== 23
+      || health.core.builtinToolContractVersion !== 24
       || health.core.builtinToolIpcProtocolVersion !== 2) {
     throw new Error(`packaged Core health is incompatible: ${JSON.stringify(health?.core)}`)
   }


### PR DESCRIPTION
## 修正范围

v0.2.2 的 Windows 构建已生成安装包，但发布验证未通过。检查发现验证脚本仍固定要求 transport v23，而当前 Core 与 CLI 已在消息引用功能中升级到 v24。

- 把 Windows verifier 的 CLI 版本、Core health 期望与发布报告中的协议号从 23 更新到 24；IPC 仍为 2。
- 在已有 sidecar 脚本测试中增加与 Core 真源常量的一致性检查，防止后续协议升级遗漏。
- 不修改任何 Rust、Desktop 或业务代码，不放宽验证条件；中文发布说明保持用户已确认内容。

## 验证

- CLI 校验和发布报告的回归分别先失败（actual 23 / expected 24），修正后通过；覆盖 CLI、Core health 和报告的协议一致性。
- 实际 CLI 输出：`rovai 0.2.2 contract-v24 ipc-v2`。
- typecheck、完整 pnpm test、脚本语法和 diff 检查通过。
- Rust staged 路由按无 Rust 改动跳过；同一产品源码在发布 PR #321 中已通过完整 Rust（545 + 33 + 309）、fmt、严格 Clippy 和 Desktop build，本补丁未改变这些输入。

合并后重新从同一个 main 提交触发三平台构建；成功后并发下载并验证完整发布集合。
