### PR TITLE
fix(monitoring): prevent horizontal overflow for 30-day usage

### DIFF
--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -4683,6 +4683,10 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
 /* Runtime monitoring */
 .runtime-monitoring { display: grid; width: min(1040px, 100%); max-width: 1040px; padding-bottom: 20px; }
 .runtime-monitoring-body { display: grid; gap: 22px; padding-top: 18px; }
+.runtime-monitoring,
+.runtime-monitoring-body,
+.monitoring-view,
+.monitoring-section { grid-template-columns: minmax(0, 1fr); }
 .monitoring-toolbar { display: flex; align-items: flex-end; justify-content: space-between; gap: 18px; padding-bottom: 13px; border-bottom: 1px solid var(--line); }
 .monitoring-filters { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 8px; }
 .monitoring-filters label { display: grid; gap: 4px; }
@@ -4785,8 +4789,8 @@ button.attachment-open:disabled { cursor: wait; opacity: .76; }
 .monitoring-usage-legend { display: flex; flex-wrap: wrap; justify-content: center; gap: 10px; }
 .monitoring-usage-legend span { display: inline-flex; align-items: center; gap: 5px; }
 .monitoring-usage-legend span::before { width: 6px; height: 6px; border-radius: 2px; content: ""; }
-.monitoring-trend-cost { display: flex; gap: 14px; overflow-x: auto; padding: 0 13px 9px; color: var(--muted); font-size: 9px; font-variant-numeric: tabular-nums; }
-.monitoring-trend-cost > span { white-space: nowrap; }
+.monitoring-trend-cost { display: flex; flex-wrap: wrap; gap: 8px 14px; padding: 0 13px 9px; color: var(--muted); font-size: 9px; font-variant-numeric: tabular-nums; }
+.monitoring-trend-cost > span { min-width: 0; max-width: 100%; overflow-wrap: anywhere; }
 .monitoring-trend-cost > span:first-child { color: var(--faint); font-weight: 670; }
 .monitoring-table-wrap table { min-width: 890px; }
 .monitoring-reconciliation { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); overflow: hidden; margin: 0; border-radius: 11px; background: var(--workspace-surface-subtle); }

--- a/scripts/fixtures/settings-workspace/data.js
+++ b/scripts/fixtures/settings-workspace/data.js
@@ -44,10 +44,16 @@ export function monitoringSnapshot(filter = {}, scenario = 'normal') {
     const sum = key => rows.length ? rows.reduce((n, r) => n + (r[key] ?? 0), 0) : null;
     const coverage = Object.fromEntries(metricKeys.map(k => [k, { eligibleRuns: eligible, observedRuns: scenario === 'partial' && ['cacheReadTokens', 'cacheWriteTokens', 'reasoningOutputTokens', 'cost'].includes(k) ? 0 : observed }]));
     const summary = { promptInputTotalTokens: sum('promptInputTotalTokens'), uncachedInputTokens: sum('uncachedInputTokens'), cacheReadTokens: sum('cacheReadTokens'), cacheWriteTokens: sum('cacheWriteTokens'), outputTokens: sum('outputTokens'), reasoningOutputTokens: sum('reasoningOutputTokens'), cacheReadShare: rows.length ? sum('cacheReadTokens') / sum('promptInputTotalTokens') : null, requestCacheHitRate: rows.length ? 0.62 : null, cost: { run: rows.length && (!filter.costKind || filter.costKind === 'run') ? [{ amount: rows.reduce((s, r) => s + Number(r.cost[0]?.amount ?? 0), 0).toFixed(2), currency: 'USD', kind: 'run', source: 'runtime_reported' }] : [], reconciliation: [], latestReconciledAt: null, difference: [] } };
-    const weights = [2, 1, 1, 1, 1, 2, 4, 8, 11, 7, 6, 9, 13, 11, 8, 6, 10, 9, 7, 5, 4, 3, 2, 1], total = weights.reduce((a, b) => a + b, 0);
+    const hourlyWeights = [2, 1, 1, 1, 1, 2, 4, 8, 11, 7, 6, 9, 13, 11, 8, 6, 10, 9, 7, 5, 4, 3, 2, 1];
+    const bucketCount = filter.range === '30d' ? 30 : filter.range === '7d' ? 7 : 24;
+    const weights = Array.from({ length: bucketCount }, (_, i) => hourlyWeights[i % hourlyWeights.length]);
+    const total = weights.reduce((a, b) => a + b, 0);
     const hours = filter.range === '30d' ? 30 * 24 : filter.range === '7d' ? 7 * 24 : 24;
     const start = Date.parse(now) - hours * 3600000;
-    const trend = rows.length ? weights.map((w, i) => ({ bucketStartAt: new Date(start + i * hours / 24 * 3600000).toISOString(), promptInputTotalTokens: Math.round(summary.promptInputTotalTokens * w / total), uncachedInputTokens: Math.round(summary.uncachedInputTokens * w / total), cacheReadTokens: Math.round(summary.cacheReadTokens * w / total), cacheWriteTokens: Math.round(summary.cacheWriteTokens * w / total), outputTokens: Math.round(summary.outputTokens * w / total), reasoningOutputTokens: Math.round(summary.reasoningOutputTokens * w / total), cacheReadShare: summary.cacheReadShare, requestCacheHitRate: summary.requestCacheHitRate, cost: null })) : [];
+    const trend = rows.length ? weights.map((w, i) => ({ bucketStartAt: new Date(start + i * hours / bucketCount * 3600000).toISOString(), promptInputTotalTokens: Math.round(summary.promptInputTotalTokens * w / total), uncachedInputTokens: Math.round(summary.uncachedInputTokens * w / total), cacheReadTokens: Math.round(summary.cacheReadTokens * w / total), cacheWriteTokens: Math.round(summary.cacheWriteTokens * w / total), outputTokens: Math.round(summary.outputTokens * w / total), reasoningOutputTokens: Math.round(summary.reasoningOutputTokens * w / total), cacheReadShare: summary.cacheReadShare, requestCacheHitRate: summary.requestCacheHitRate, cost: filter.range === '30d' ? [
+        { amount: '88.7653316', currency: 'USD', kind: 'run', source: 'price_catalog' },
+        { amount: '1.44650899999999996', currency: 'USD', kind: 'run', source: 'runtime_reported' }
+    ] : null })) : [];
     if (scenario === 'partial') {
         for (const k of ['cacheReadTokens', 'cacheWriteTokens', 'cacheReadShare', 'reasoningOutputTokens'])
             summary[k] = null;

--- a/scripts/fixtures/settings-workspace/main.cjs
+++ b/scripts/fixtures/settings-workspace/main.cjs
@@ -55,6 +55,28 @@ app.whenReady().then(async () => {
       return overflow
     })()`), false, label + ' must contain horizontal overflow')
   }
+  const selectMonitoringRange = async range => {
+    await run(`(() => {
+      const select = document.querySelector('.monitoring-filters select')
+      select.value = ${JSON.stringify(range)}
+      select.dispatchEvent(new Event('change', { bubbles: true }))
+    })()`)
+    await settle()
+    await waitFor(`!document.querySelector('.monitoring-filters select').disabled && window.settingsTest.requests.some(r => r.method === 'monitoring.snapshot' && r.params.range === ${JSON.stringify(range)})`)
+  }
+  const costHistoryFits = async label => {
+    const bounds = await run(`(() => {
+      const page = document.querySelector('.runtime-monitoring')
+      const cost = document.querySelector('.monitoring-trend-cost')
+      return { pageWidth: page.clientWidth, pageScrollWidth: page.scrollWidth,
+        costWidth: cost.clientWidth, costScrollWidth: cost.scrollWidth,
+        dates: cost.querySelectorAll('time').length }
+    })()`)
+    assert.equal(bounds.dates, 30, label + ' retains every daily cost')
+    assert.ok(bounds.pageScrollWidth <= bounds.pageWidth + 1, label + ' page must fit: ' + JSON.stringify(bounds))
+    assert.ok(bounds.costScrollWidth <= bounds.costWidth + 1, label + ' costs must fit without horizontal scrolling: ' + JSON.stringify(bounds))
+    await noOverflow(label)
+  }
   try {
     await window.loadFile(renderer); await settle()
     assert.equal(await run("document.querySelectorAll('.general-save-row .dialog-glyph').length"), 1)
@@ -112,6 +134,11 @@ app.whenReady().then(async () => {
     await navigate('monitoring', 'empty')
     assert.equal(await run("document.querySelectorAll('.monitoring-chart-svg').length"), 0)
 
+    await navigate('monitoring')
+    await selectMonitoringRange('30d')
+    await costHistoryFits('monitoring/30d/1440')
+    await capture('monitoring-30d-day-1440')
+
     await navigate('diagnostics')
     await run("window.settingsTest.fail('mcp.config.repairPermissions')")
     await click('.diagnostics-issue-action button')
@@ -136,11 +163,16 @@ app.whenReady().then(async () => {
       window.setContentSize(1040, 700); window.webContents.setZoomFactor(1)
       for (const page of ['general','appearance','notifications','runtime','channels','monitoring','diagnostics','about']) {
         await navigate(page); await noOverflow(`${page}/${theme}/1040`); await capture(`${page}-${theme}-1040`)
+        if (page === 'monitoring') {
+          await selectMonitoringRange('30d'); await costHistoryFits(`${page}/30d/${theme}/1040`)
+          await capture(`${page}-30d-${theme}-1040`)
+        }
       }
       for (const page of ['general','monitoring','diagnostics','about']) {
         window.webContents.setZoomFactor(2); await navigate(page)
         await noOverflow(`${page}/${theme}/200%`)
         if(page === 'monitoring') {
+          await selectMonitoringRange('30d'); await costHistoryFits(`${page}/30d/${theme}/200%`)
           assert.equal(await run("getComputedStyle(document.querySelector('.monitoring-keyline')).gridTemplateColumns.split(' ').length"), 1)
           await run("document.querySelector('.monitoring-keyline').scrollIntoView()"); await settle()
         }


### PR DESCRIPTION
选择运行监控的“过去 30 天”后，每日成本明细被强制排在同一行，并通过网格的内容最小宽度撑开筛选器、图表和表格，导致整页出现横向滚动条。

成本明细现在自动换行，监控网格允许随容器收缩；保留所有日期、金额和原有页面宽度。设置页集成夹具补充 30 天每日成本及长精度金额，检查桌面、窄窗口和 200% 缩放下的页面与成本区不横向溢出。

验证：
- 浏览器复现修复前 1040px 页面被撑至 8449px；修复后浅色/深色主题在 1440、1040、520px 下均无页面或成本区横向溢出，30 天日期全部保留。
- 177 项相关 Renderer 测试、类型检查及桌面构建通过；必需 CI gate 通过。
- [额外 Full Check](https://github.com/murray17/rovai-ai/actions/runs/34463716301) 的完整 Node 检查通过。本机首次全量 Vitest 有 1 项 Supervisor 等待超时；该文件单独复跑 20/20 通过。Node 脚本检查 223 通过、1 跳过。
- 本机 Rust 默认库测试 544 通过，1 项 macOS sandbox probe 因宿主限制失败（exit 71）。本机 workspace/all-targets Clippy 与远端 all-features Clippy 已通过。
- 额外 Electron 全套停在未修改的 Composer continuation 用例（late-response 断言及 pendingInputIsDirty 读取 undefined.map）；尚未执行到 settings-workspace。Windows 检查停在未修改的 MCP 文件所有者权限用例。未将该全套检查记为通过。
- macOS arm64 daily 构建及 App/Core/CLI ad-hoc 签名门通过。原生 Electron 夹具与 packaged App 隔离启动均受当前宿主嵌套沙箱限制，无法完成原生 UI 验收；浏览器布局验证不替代该验收。
