### PR TITLE
fix(cli): admit ZCode in User Automation commands

### DIFF
--- a/crates/rovai-core/src/bin/rovai/app_cli.rs
+++ b/crates/rovai-core/src/bin/rovai/app_cli.rs
@@ -23,7 +23,7 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 const POLL_INTERVAL: Duration = Duration::from_millis(300);
 const SETTLEMENT_GRACE: Duration = Duration::from_secs(5);
 const CONTEXT_ENV: &str = "ROVAI_APP_AUTOMATION_CONTEXT";
-const ADAPTER_KINDS: [&str; 13] = [
+const ADAPTER_KINDS: [&str; 14] = [
     "codex-cli",
     "opencode-cli",
     "copilot-cli",
@@ -36,6 +36,7 @@ const ADAPTER_KINDS: [&str; 13] = [
     "cursor-agent",
     "kimi-code-cli",
     "grok-build",
+    "zcode-app",
     "antigravity-app",
 ];
 
@@ -1838,30 +1839,34 @@ mod tests {
     }
 
     #[test]
-    fn member_runtime_configuration_admits_grok_build() {
-        let flags = Flags::parse(&[
-            "--agent-id".into(),
-            "agent_13".into(),
-            "--expected-version".into(),
-            "1".into(),
-            "--adapter".into(),
-            "grok-build".into(),
-            "--runtime-default".into(),
-            "--permission-schema-version".into(),
-            "1".into(),
-            "--permissions-json".into(),
-            r#"{"permission_mode":"bypassPermissions"}"#.into(),
-        ])
-        .unwrap();
-        let params = member_runtime_set_params(&flags).unwrap();
+    fn member_runtime_configuration_admits_native_runtime_defaults() {
+        for (adapter, permission_mode) in
+            [("grok-build", "bypassPermissions"), ("zcode-app", "yolo")]
+        {
+            let flags = Flags::parse(&[
+                "--agent-id".into(),
+                "agent_13".into(),
+                "--expected-version".into(),
+                "1".into(),
+                "--adapter".into(),
+                adapter.into(),
+                "--runtime-default".into(),
+                "--permission-schema-version".into(),
+                "1".into(),
+                "--permissions-json".into(),
+                json!({ "permission_mode": permission_mode }).to_string(),
+            ])
+            .unwrap();
+            let params = member_runtime_set_params(&flags).unwrap();
 
-        assert_eq!(params["adapterKind"], "grok-build");
-        assert_eq!(params["model"]["mode"], "runtime_default");
-        assert_eq!(params["permissions"]["adapterKind"], "grok-build");
-        assert_eq!(
-            params["permissions"]["values"]["permission_mode"],
-            "bypassPermissions"
-        );
+            assert_eq!(params["adapterKind"], adapter);
+            assert_eq!(params["model"]["mode"], "runtime_default");
+            assert_eq!(params["permissions"]["adapterKind"], adapter);
+            assert_eq!(
+                params["permissions"]["values"]["permission_mode"],
+                permission_mode
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
`rovai app runtime check --adapter zcode-app` rejected ZCode before contacting the running Desktop, even though Main and Core already supported it. Add the missing ZCode entry to the CLI adapter allowlist so availability checks, model catalog queries and member configuration use the existing User Automation flow.

Extend the existing native-default configuration test with a ZCode case, preserving its Grok coverage and keeping the test count unchanged.

Validation: Rust PR suite (551 library, 33 CLI, 309 slow tests), Clippy with warnings denied, formatting, and 8 Main User Automation tests passed. A local official ZCode 0.16.5 / MiniMax-M3 run exercised readiness, catalog, member binding, Read/Edit/Write/Bash and public message publication through the running Desktop; its persisted file-change projection contains 6 files and 7 operations. UI interaction remains unverified because the computer-use connection was unavailable.
