### PR TITLE
Fix composer attachment preview clicks

### DIFF
--- a/apps/desktop/src/renderer/src/AttachmentCard.test.ts
+++ b/apps/desktop/src/renderer/src/AttachmentCard.test.ts
@@ -1,0 +1,93 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import type { CampMessageAttachmentView, LocalAttachmentOwnerLocator } from '@contracts'
+import { AttachmentCard } from './AttachmentCard'
+
+vi.mock('./FilePreviewContext', () => ({
+  useOptionalFilePreview: () => ({ open: vi.fn() })
+}))
+
+const fileAttachment: CampMessageAttachmentView = {
+  id: 'attachment-1',
+  displayName: 'report.md',
+  kind: 'file',
+  fileCount: 1,
+  mediaType: 'text/markdown',
+  byteSize: 128,
+  previewKind: 'none',
+  availability: 'available'
+}
+
+const composerLocators: Array<[string, LocalAttachmentOwnerLocator]> = [[
+  'Camp composer',
+  { owner: 'composer', campId: 'camp-1', attachmentRefId: fileAttachment.id }
+], [
+  'single-chat composer',
+  {
+    owner: 'single_chat_composer',
+    campId: 'camp-1',
+    conversationId: 'conversation-1',
+    attachmentRefId: fileAttachment.id
+  }
+]]
+
+describe('AttachmentCard composer actions', () => {
+  it.each(composerLocators)('exposes a preview button in the %s without adding a context menu', (_name, locator) => {
+    const markup = renderToStaticMarkup(createElement(AttachmentCard, {
+      attachment: fileAttachment,
+      locator,
+      presentation: 'composer'
+    }))
+
+    expect(markup).toMatch(/<button class="attachment-open(?: [^"]*)?"/)
+    expect(markup).toContain('aria-label="打开文件预览 report.md"')
+    expect(markup).not.toContain('attachment-context-anchor')
+  })
+
+  it('exposes a primary open button for a composer directory', () => {
+    const directoryAttachment: CampMessageAttachmentView = {
+      ...fileAttachment,
+      id: 'attachment-directory',
+      displayName: 'research',
+      kind: 'directory',
+      fileCount: 3,
+      mediaType: 'inode/directory'
+    }
+    const markup = renderToStaticMarkup(createElement(AttachmentCard, {
+      attachment: directoryAttachment,
+      locator: {
+        owner: 'composer',
+        campId: 'camp-1',
+        attachmentRefId: directoryAttachment.id
+      },
+      presentation: 'composer'
+    }))
+
+    expect(markup).toMatch(/<button class="attachment-open(?: [^"]*)?"/)
+    expect(markup).toContain('aria-label="打开文件夹 research"')
+    expect(markup).not.toContain('attachment-context-anchor')
+  })
+
+  it('keeps a composer image non-interactive until its thumbnail is ready', () => {
+    const imageAttachment: CampMessageAttachmentView = {
+      ...fileAttachment,
+      id: 'attachment-image',
+      displayName: 'diagram.png',
+      mediaType: 'image/png',
+      previewKind: 'image'
+    }
+    const markup = renderToStaticMarkup(createElement(AttachmentCard, {
+      attachment: imageAttachment,
+      locator: {
+        owner: 'composer',
+        campId: 'camp-1',
+        attachmentRefId: imageAttachment.id
+      },
+      presentation: 'composer'
+    }))
+
+    expect(markup).toContain('<div class="attachment-open">')
+    expect(markup).not.toMatch(/<button class="attachment-open(?: [^"]*)?"/)
+  })
+})

--- a/apps/desktop/src/renderer/src/AttachmentCard.tsx
+++ b/apps/desktop/src/renderer/src/AttachmentCard.tsx
@@ -82,7 +82,8 @@ export function AttachmentCard({
   const locatorRef = useRef(locator)
   locatorRef.current = locator
   const timeline = presentation !== 'composer'
-  const interactive = timeline || Boolean(menuItems)
+  const contextMenuAvailable = timeline || Boolean(menuItems)
+  const primaryActionAvailable = contextMenuAvailable || attachment.previewKind !== 'image'
   const agentPresentation = presentation === 'agent-timeline'
   const composerImage = presentation === 'composer' && attachment.previewKind === 'image'
   const displayClassification = classifyAttachmentDisplay(attachment)
@@ -122,7 +123,7 @@ export function AttachmentCard({
     action: 'open' | 'reveal',
     forceSystem = false
   ): Promise<void> => {
-    if (!interactive || disabled || attachmentAction) return
+    if (!primaryActionAvailable || disabled || attachmentAction) return
     setAttachmentAction(action)
     try {
       if (action === 'open') {
@@ -236,7 +237,7 @@ export function AttachmentCard({
       className={`attachment-card ${presentation === 'composer' ? 'composer-attachment-card' : presentation} ${composerImage ? 'composer-image-attachment' : ''} type-${displayClassification.agentDisplayType} ${availabilityLabel ? `attachment-availability-${availability}` : ''}`}
       aria-label={availabilityLabel ? `${attachment.displayName}：${availabilityLabel}` : undefined}
       data-context-open={contextMenuOpen ? 'true' : undefined}
-      onContextMenu={interactive && !disabled
+      onContextMenu={contextMenuAvailable && !disabled
         ? (event) => {
             event.preventDefault()
             if (event.clientX === 0 && event.clientY === 0) showAttachmentKeyboardMenu()
@@ -244,7 +245,7 @@ export function AttachmentCard({
           }
         : undefined}
     >
-      {interactive
+      {primaryActionAvailable
         ? (
             <>
               <button
@@ -263,64 +264,68 @@ export function AttachmentCard({
                   else if (hasImagePreview) setPreviewOpen(true)
                   else void runAttachmentAction('open')
                 }}
-                onKeyDown={(event) => {
-                  if (event.key !== 'ContextMenu' && !(event.shiftKey && event.key === 'F10')) return
-                  event.preventDefault()
-                  showAttachmentKeyboardMenu()
-                }}
+                onKeyDown={contextMenuAvailable
+                  ? (event) => {
+                      if (event.key !== 'ContextMenu' && !(event.shiftKey && event.key === 'F10')) return
+                      event.preventDefault()
+                      showAttachmentKeyboardMenu()
+                    }
+                  : undefined}
                 ref={attachmentButtonRef}
               >
                 {content}
                 {attachmentAction && <i className="attachment-action-loading" aria-hidden="true" />}
               </button>
-              <DropdownMenu.Root open={contextMenuOpen} onOpenChange={setContextMenuOpen}>
-                <DropdownMenu.Trigger asChild>
-                  <span
-                    className="attachment-context-anchor"
-                    style={{ left: contextAnchor.x, top: contextAnchor.y }}
-                  />
-                </DropdownMenu.Trigger>
-                <DropdownMenu.Portal>
-                  <DropdownMenu.Content
-                    className="attachment-context-menu"
-                    aria-label={`附件操作：${attachment.displayName}`}
-                    align="start"
-                    side="right"
-                    sideOffset={4}
-                    collisionPadding={8}
-                    loop
-                    onCloseAutoFocus={(event) => {
-                      event.preventDefault()
-                    }}
-                  >
-                    <DropdownMenu.Label className="attachment-context-menu-label">
-                      <strong>{attachment.displayName}</strong>
-                      <small>{attachment.kind === 'directory' ? '文件夹' : attachmentTypeLabel(attachment.mediaType)}</small>
-                    </DropdownMenu.Label>
-                    <DropdownMenu.Item
-                      className="attachment-context-menu-item"
-                      disabled={disabled || attachmentAction !== null}
-                      onSelect={() => void runAttachmentAction('open', true)}
+              {contextMenuAvailable && (
+                <DropdownMenu.Root open={contextMenuOpen} onOpenChange={setContextMenuOpen}>
+                  <DropdownMenu.Trigger asChild>
+                    <span
+                      className="attachment-context-anchor"
+                      style={{ left: contextAnchor.x, top: contextAnchor.y }}
+                    />
+                  </DropdownMenu.Trigger>
+                  <DropdownMenu.Portal>
+                    <DropdownMenu.Content
+                      className="attachment-context-menu"
+                      aria-label={`附件操作：${attachment.displayName}`}
+                      align="start"
+                      side="right"
+                      sideOffset={4}
+                      collisionPadding={8}
+                      loop
+                      onCloseAutoFocus={(event) => {
+                        event.preventDefault()
+                      }}
                     >
-                      <AttachmentOpenGlyph kind={attachment.kind} />
-                      <span>{systemOpenLabel}</span>
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Separator className="attachment-context-menu-separator" />
-                    <DropdownMenu.Item
-                      className="attachment-context-menu-item"
-                      disabled={disabled || attachmentAction !== null}
-                      onSelect={() => void runAttachmentAction('reveal')}
-                    >
-                      <AttachmentRevealGlyph />
-                      <span>{revealLabel}</span>
-                    </DropdownMenu.Item>
-                    {menuItems && <>
+                      <DropdownMenu.Label className="attachment-context-menu-label">
+                        <strong>{attachment.displayName}</strong>
+                        <small>{attachment.kind === 'directory' ? '文件夹' : attachmentTypeLabel(attachment.mediaType)}</small>
+                      </DropdownMenu.Label>
+                      <DropdownMenu.Item
+                        className="attachment-context-menu-item"
+                        disabled={disabled || attachmentAction !== null}
+                        onSelect={() => void runAttachmentAction('open', true)}
+                      >
+                        <AttachmentOpenGlyph kind={attachment.kind} />
+                        <span>{systemOpenLabel}</span>
+                      </DropdownMenu.Item>
                       <DropdownMenu.Separator className="attachment-context-menu-separator" />
-                      {menuItems}
-                    </>}
-                  </DropdownMenu.Content>
-                </DropdownMenu.Portal>
-              </DropdownMenu.Root>
+                      <DropdownMenu.Item
+                        className="attachment-context-menu-item"
+                        disabled={disabled || attachmentAction !== null}
+                        onSelect={() => void runAttachmentAction('reveal')}
+                      >
+                        <AttachmentRevealGlyph />
+                        <span>{revealLabel}</span>
+                      </DropdownMenu.Item>
+                      {menuItems && <>
+                        <DropdownMenu.Separator className="attachment-context-menu-separator" />
+                        {menuItems}
+                      </>}
+                    </DropdownMenu.Content>
+                  </DropdownMenu.Portal>
+                </DropdownMenu.Root>
+              )}
             </>
           )
         : hasImagePreview


### PR DESCRIPTION
## Summary

- make ready file and directory attachments in Camp and single-chat composers expose their primary click action
- keep context-menu availability independent, so draft attachments do not gain timeline-only actions
- preserve the existing composer image thumbnail/lightbox behavior
- add regression coverage for Camp, single-chat, directory, and image states

## Verification

- `pnpm typecheck`
- related Vitest suite: 7 files / 103 tests passed
- `pnpm build:desktop`
- Impeccable detector: 0 findings
- full Vitest phase: 173 files / 1754 tests passed; 1 unrelated `evaluation-host` descendant-cleanup assertion also fails on the clean `main` baseline in this environment
- real Electron composer/file-preview fixtures: explicitly blocked by the nested macOS sandbox (business assertions did not run)