### PR TITLE
fix(composer): 新建对话直接呈现队长接收提示

### DIFF
--- a/apps/desktop/src/renderer/src/App.test.ts
+++ b/apps/desktop/src/renderer/src/App.test.ts
@@ -921,7 +921,7 @@ describe('task event projections', () => {
       }
     ]
     expect(composerRecipientSummary({ version: 2, segments: [] }, members))
-      .toBe('默认由 Lead · 叮叮接收')
+      .toBe('默认由队长 @叮叮 接收')
     expect(composerRecipientSummary({ version: 2, segments: [
       { kind: 'atom', atom: { type: 'member', agentId: 'agent_2' } },
       { kind: 'atom', atom: { type: 'member', agentId: 'agent_1' } }
@@ -3375,7 +3375,7 @@ describe('task event projections', () => {
     expect(markup).toContain('给 洛可 发消息')
     expect(markup).toContain('集结队伍，写下这次冒险的目标…')
     expect(markup).not.toContain('和队伍继续前行：补充线索、调整方向或布置新任务…')
-    expect(markup).not.toContain('默认由 Lead · 洛可接收')
+    expect(markup).not.toContain('默认由队长 @洛可 接收')
     expect(markup).toContain('开始这段协作')
     expect(markup).toContain('class="empty-camp-mark" data-brand-mark="horizon" data-brand-layout="separated"')
     expect(markup).not.toContain('data-brand-point="rendezvous"')

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -263,6 +263,7 @@ export const SHUTDOWN_FEEDBACK_DELAY_MS = 400
 export type View = 'compose' | 'camp' | 'members' | 'automations' | 'memory' | 'settings'
 type ActivateCampOptions = {
   reconcileDefaultLead?: boolean
+  initializeComposerDraft?: boolean
   preserveNotificationFocus?: boolean
   suppressErrors?: boolean
   anchoredMessages?: readonly CampMessageView[]
@@ -1134,7 +1135,8 @@ function AuthoritativeApp({
   const [campSnapshotState, setCampSnapshotState] = useState<{
     snapshot: CampSurfaceSnapshot | null
     entryPreview: boolean
-  }>({ snapshot: null, entryPreview: false })
+    initialComposerDraft: CampComposerDraftView | null
+  }>({ snapshot: null, entryPreview: false, initialComposerDraft: null })
   const campSnapshot = campSnapshotState.snapshot
   const [campInspectorCampId, setCampInspectorCampId] = useState<string | null>(null)
   const [campInspectorTab, setCampInspectorTab] = useState<CampInspectorTab>('tasks')
@@ -1242,11 +1244,18 @@ function AuthoritativeApp({
 
   const setCampSnapshot = useCallback((
     snapshot: CampSurfaceSnapshot | null,
-    entryPreview = false
+    entryPreview = false,
+    initialComposerDraft: CampComposerDraftView | null = null
   ): void => {
     campSnapshotRef.current = snapshot
     if (snapshot) rememberCampSnapshot(campSnapshotCache.current, snapshot)
-    setCampSnapshotState({ snapshot, entryPreview })
+    setCampSnapshotState({ snapshot, entryPreview, initialComposerDraft })
+  }, [])
+
+  const consumeInitialComposerDraft = useCallback((draft: CampComposerDraftView): void => {
+    setCampSnapshotState((current) => current.initialComposerDraft === draft
+      ? { ...current, initialComposerDraft: null }
+      : current)
   }, [])
 
   const clearCampOpenFeedback = useCallback((): void => {
@@ -1771,7 +1780,8 @@ function AuthoritativeApp({
     )
     const commitCampSurface = (
       snapshot: CampSurfaceSnapshot,
-      entryPreview = false
+      entryPreview = false,
+      initialComposerDraft: CampComposerDraftView | null = null
     ): void => {
       const snapshotProject = currentProjectForCamp(snapshot.camp)
       setCurrentProject(snapshotProject)
@@ -1788,7 +1798,7 @@ function AuthoritativeApp({
         })
       }
       setActiveCampId(campId)
-      setCampSnapshot(snapshot, entryPreview)
+      setCampSnapshot(snapshot, entryPreview, initialComposerDraft)
       lastMainView.current = 'camp'
       setView('camp')
     }
@@ -1803,15 +1813,18 @@ function AuthoritativeApp({
       }, CAMP_OPEN_FEEDBACK_DELAY_MS)
     }
     try {
-      const { snapshot, traceId, startedAt } = await requestCampProjection(
-        campId,
-        options.reconcileDefaultLead === false ? 'open' : 'enter'
-      )
+      const [{ snapshot, traceId, startedAt }, initialComposerDraft] = await Promise.all([
+        requestCampProjection(campId, options.reconcileDefaultLead === false ? 'open' : 'enter'),
+        options.initializeComposerDraft
+          ? window.rovai.request<CampComposerDraftView>('camp.composerDraft.get', { campId })
+            .catch(() => null)
+          : Promise.resolve(null)
+      ])
       if (selectionGeneration !== campSelectionGeneration.current) {
         return false
       }
       clearCampOpenFeedback()
-      commitCampSurface(snapshot)
+      commitCampSurface(snapshot, false, initialComposerDraft)
       await afterNextPaint()
       if (selectionGeneration !== campSelectionGeneration.current) return false
       console.info(
@@ -3510,7 +3523,7 @@ function AuthoritativeApp({
         }
       }
       try {
-        await activateCamp(campId, { reconcileDefaultLead: false })
+        await activateCamp(campId, { reconcileDefaultLead: false, initializeComposerDraft: true })
       } finally {
         if (preferencesSaveFailed) {
           notifyError('对话已创建，但默认队伍与一键新建设置未保存。可在「设置 → 通用」重试。')
@@ -3986,6 +3999,8 @@ function AuthoritativeApp({
           <CampWorkspace
             key={activeCampId}
             snapshot={visibleCampSnapshot}
+            initialComposerDraft={campSnapshotState.initialComposerDraft}
+            onInitialComposerDraftConsumed={consumeInitialComposerDraft}
             openCoverage={campSnapshot?.camp.id === activeCampId
               ? campSnapshot.openCoverage ?? null
               : null}

--- a/apps/desktop/src/renderer/src/CampWorkspace.tsx
+++ b/apps/desktop/src/renderer/src/CampWorkspace.tsx
@@ -475,7 +475,7 @@ export function composerRecipientSummary(
       && (segment.atom.type === 'member' || segment.atom.type === 'all_members')
   )) return null
   const defaultLead = members.find((member) => member.isDefaultLead)
-  return `默认由 Lead · ${defaultLead?.displayName ?? '当前不可用'}接收`
+  return defaultLead ? `默认由队长 @${defaultLead.displayName} 接收` : '默认队长当前不可用'
 }
 
 export function campConversationViewFromStoredValue(value: string | null): CampConversationView {
@@ -1405,6 +1405,8 @@ const EMPTY_LIVE_RUNTIME_EVENTS: LiveRuntimeEvent[] = []
 
 export function CampWorkspace({
   snapshot,
+  initialComposerDraft = null,
+  onInitialComposerDraftConsumed,
   openCoverage = null,
   messageHistory = null,
   onLoadEarlierMessages,
@@ -1457,6 +1459,8 @@ export function CampWorkspace({
   onNotifyError
 }: {
   snapshot: CampSnapshot
+  initialComposerDraft?: CampComposerDraftView | null
+  onInitialComposerDraftConsumed?(draft: CampComposerDraftView): void
   openCoverage?: CampOpenProjection['coverage'] | null
   messageHistory?: CampOpenMessageCoverage | null
   onLoadEarlierMessages?(): Promise<void>
@@ -2873,7 +2877,7 @@ export function CampWorkspace({
     })
   }
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const campId = snapshot.camp.id
     let cancelled = false
     setPendingEditing(false)
@@ -2893,15 +2897,20 @@ export function CampWorkspace({
       snapshot: null,
       error: null
     })
-    draftCoordinator.beginEpoch(campId)
-    setDraftLoadState({ state: 'loading' })
+    // New-Camp entry hands off a Core read before the first paint. Later entries
+    // still load normally; an empty timeline alone cannot establish Draft authority.
+    const entryDraft = initialComposerDraft?.campId === campId ? initialComposerDraft : null
+    draftCoordinator.beginEpoch(campId, entryDraft)
+    setDraftLoadState({ state: entryDraft ? 'ready' : 'loading' })
     setComposerPersistenceError(null)
     setComposerLocalStatus({
       hasContent: false,
       hasExplicitRecipient: false,
       hasUnavailableAtom: false
     })
-    initializedComposerRoute.current = null
+    initializedComposerRoute.current = entryDraft
+      ? { revision: entryDraft.revision, publishedMessageSequence }
+      : null
     setPreparingAttachments([])
     setFailedAttachments([])
     setAttachmentDragState(null)
@@ -2911,7 +2920,8 @@ export function CampWorkspace({
     setReplyInteractionError(null)
     autoSuppressedContinuationSourceRef.current = null
     draftCampId.current = campId
-    void draftCoordinator.load()
+    if (entryDraft) onInitialComposerDraftConsumed?.(entryDraft)
+    else void draftCoordinator.load()
       .then(() => {
         if (cancelled || draftCampId.current !== campId) return
         setDraftLoadState({ state: 'ready' })
@@ -4867,7 +4877,9 @@ export function CampWorkspace({
                           <path d="M3 3.5v3.25c0 1.8 1.45 3.25 3.25 3.25H13" />
                           <path d="m10.5 7.5 2.5 2.5-2.5 2.5" />
                         </svg>
-                        <span>{recipientSummary}</span>
+                        <span>{defaultLead
+                          ? <>默认由队长 <strong>@{defaultLead.displayName}</strong> 接收</>
+                          : recipientSummary}</span>
                       </span>
                     )}
               </div>

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -4271,7 +4271,8 @@ details summary { min-height: 28px; padding: 5px 0; color: var(--muted); font-si
 .composer-route-rail .composer-continuation { width: 100%; }
 .composer-continuation > svg { flex: 0 0 auto; width: 12px; height: 12px; fill: none; stroke: currentColor; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1.35; }
 .composer-continuation > span { min-width: 0; overflow: hidden; text-overflow: ellipsis; }
-.composer-continuation strong { color: var(--mention-ink); font-weight: 680; }
+.composer-continuation strong,
+.composer-route-rail .mention-target-summary strong { color: var(--mention-ink); font-weight: 680; }
 .composer-continuation button { display: grid; flex: 0 0 auto; width: 26px; height: 26px; margin: 0 0 0 auto; padding: 0; place-items: center; border: 0; border-radius: 5px; color: var(--faint); background: transparent; cursor: pointer; }
 .composer-continuation button svg { width: 10px; height: 10px; fill: none; stroke: currentColor; stroke-linecap: round; stroke-width: 1.35; }
 .composer-continuation button:hover:not(:disabled) { color: var(--ink); background: var(--surface-muted); }

--- a/docs/ui/components/conversation-workspace.md
+++ b/docs/ui/components/conversation-workspace.md
@@ -258,7 +258,7 @@ Agent 公共消息继续左对齐，仅正文使用与用户消息相同的雾�
 回复当前可寻址 Agent 是一次明确的用户双意图：同一 Draft revision 设置 reply target，并插入或复用
 可见 Member Mention。已有其他 Mention 时全部保留，
 `@所有队员` 已覆盖作者时不重复插入。回复当前用户自己的消息只建立引用，不从原消息的历史 recipient、
-作者或 reply relation 猜 Agent；无 Mention 时必须明确显示“默认由 Lead · {name}接收”。显式 Mention、
+作者或 reply relation 猜 Agent；无 Mention 时必须明确显示“默认由队长 @{name} 接收”。显式 Mention、
 `@所有队员`、reply 或接收者修复已经足以表达路由，不再重复显示“实际接收者”汇总。
 
 原作者已退出 Camp、变为 `away`、被移除或不可解析时，reply dock 保留引用，但不插入失效 Mention，
@@ -294,7 +294,10 @@ Mention、修复或手动接收者修改时，Composer 输入面上方的独立�
 
 标签与默认 Lead 文案占用同一行。标签出现时不显示默认文案；显式 Member Mention、多人 Mention、
 `@所有队员` 和 reply 出现时两者都隐藏。点击标签的关闭按钮只取消当前来源延续并恢复
-“默认由 Lead · {name}接收”；同一 source 在导航、重载或重新进入 Camp 后不得复现。
+“默认由队长 @{name} 接收”；同一 source 在导航、重载或重新进入 Camp 后不得复现。
+
+默认接收人与 continuation 均将 `@姓名` 用同一 `--mention-ink` 与字重突出；界面角色名称使用“队长”。
+默认接收人提示只表达当前路由，不向正文插入 Mention。
 
 reply 比 continuation 优先。回复 Agent 后取消引用，自动加入的 Mention 保留，因此延续不恢复；回复用户
 消息未产生 Mention 且用户未改址时，取消可恢复此前只被隐藏的标签。用户主动改变过接收者后，即使再删光
@@ -763,6 +766,10 @@ Composer 与消息轨道共享中心轴但拥有独立宽度；`.composer-box` �
 接收者提示始终预留一行 34px 高度及 5px 底部间距。草稿首次 loading 时显示无接收者文案、无循环动画的模糊占位；
 ready 后原位显示默认 Lead 或 continuation。显式 Mention、reply 或错误状态不显示路由时保留空白行，
 避免路由加载或显隐挤动会话内容。占位不提前声明接收者，也不提前启用编辑或发送。
+
+新建会话成功后的首次打开，将同一 Camp 的 Core Draft 读取与 Open 投影并行准备，在首次绘制前一次性交给
+Draft Coordinator，因此直接呈现已就绪的默认接收人，不重复读取或闪现模糊占位。该交接不缓存供后续导航复用；
+普通重新进入仍读取当前草稿。读取失败继续走 loading/error 与重试流程，不能用空时间线推定 revision-zero Draft。
 
 Draft 首次读取只有 loading、ready 和 error。loading 与 error 时正文、附件、Reply/Continuation 和发送不可操作；
 error 在 Composer 上方原位显示“草稿无法加载”、具体错误与“重新加载草稿”，不能渲染可编辑的 revision-zero 空

--- a/scripts/accept-structured-mentions-ui.mjs
+++ b/scripts/accept-structured-mentions-ui.mjs
@@ -604,7 +604,7 @@ try {
       const rail = document.querySelector('.composer:has(#camp-message) .composer-route-rail')
       const summary = rail?.querySelector('.mention-target-summary')
       return rail?.getAttribute('aria-label') === '接收者路由'
-        && summary?.textContent?.trim() === ${JSON.stringify(`默认由 Lead · ${targetMembers[0].displayName}接收`)}
+        && summary?.textContent?.trim() === ${JSON.stringify(`默认由队长 @${targetMembers[0].displayName} 接收`)}
     })()`)
     const defaultRouteInspection = await evaluate(running.cdp, `(() => {
       const rail = document.querySelector('.composer:has(#camp-message) .composer-route-rail')

--- a/scripts/fixtures/camp-composer-continuation/renderer.tsx
+++ b/scripts/fixtures/camp-composer-continuation/renderer.tsx
@@ -28,6 +28,7 @@ let send: (draft: CampComposerDraftView) => Promise<CampMessageSendReceipt> = ne
 const drafts = new Map<string, CampComposerDraftView>()
 let root: Root | null = null
 let snapshot: CampSnapshot
+let initialComposerDraft: CampComposerDraftView | null = null
 let queue: CampPendingInputsView
 let nextRead: { promise: Promise<CampComposerDraftView>; resolve(value: CampComposerDraftView): void } | null = null
 const agents: AgentProfile[] = ['叮叮', '芝士'].map((displayName, index) => ({
@@ -55,7 +56,7 @@ const continuation = () => document.querySelector('.composer-continuation')?.get
 const editor = () => document.getElementById('camp-message')!
 const draftReads = () => calls.filter(call => call === 'camp.composerDraft.get').length
 const emptyDraft = (id = campId): CampComposerDraftView => ({
-  campId: id, body: '', content: emptyComposerDocument(), revision: 0, attachments: [], replyIntent: null,
+  campId: id, body: '', content: emptyComposerDocument(), revision: 0, attachments: [], quotes: [], replyIntent: null,
   continuationIntent: null, updatedAt: null, expiresAt: null
 })
 const continuedDraft = (messageId: string): CampComposerDraftView => ({
@@ -86,7 +87,7 @@ Object.assign(window, { rovai: {
       if (action.type === 'save' && failPendingSave) throw new Error('保存失败，请重试')
       if (action.type === 'begin') {
         queue.editSession = { pendingInputId: item.id, editToken: 'fixture-edit-token', basePendingRevision: item.revision,
-          recoveryRequired: false, workingAttachments: structuredClone(item.attachments) }
+          recoveryRequired: false, workingQuotes: [], workingAttachments: structuredClone(item.attachments) }
       } else {
         check(command.editToken === queue.editSession?.editToken, 'Working attachments must use the edit token')
         if (action.type === 'remove_attachment') {
@@ -163,7 +164,7 @@ function message(sequence: number, agentId: string): CampMessageView {
   return { id: `message-${sequence}`, sequence, timelineGlobalSequence: sequence,
     authorType: 'user', authorId: 'local_user', sourceAgentRunId: null,
     body: `消息 ${sequence}`, content: [{ kind: 'member_mention', agentId }, { kind: 'text', text: `消息 ${sequence}` }],
-    addressMode: 'explicit', attachments: [], addressedAgentIds: [agentId], replyToCampMessageId: null,
+    addressMode: 'explicit', attachments: [], quotes: [], addressedAgentIds: [agentId], replyToCampMessageId: null,
     campTurnId: `turn-${sequence}`, presentation: null, createdAt: timestamp }
 }
 
@@ -189,6 +190,8 @@ function running(current: CampMessageView): Pick<CampSnapshot, 'turns' | 'agentR
 
 async function render() {
   flushSync(() => root!.render(<CampWorkspace snapshot={snapshot} projectName={null} agents={agents}
+    initialComposerDraft={initialComposerDraft}
+    onInitialComposerDraftConsumed={() => { initialComposerDraft = null }}
     busy={false} stopping={false} worldMapEnabled={false}
     onSend={(draft) => send(draft)} onStop={() => undefined}
     onChangeLead={async () => undefined} onTasksChanged={async () => undefined} onResolveApproval={() => undefined}
@@ -196,7 +199,7 @@ async function render() {
   await flush()
 }
 
-async function reset(draft = emptyDraft(), holdInitialRead = false) {
+async function reset(draft = emptyDraft(), holdInitialRead = false, entryDraft: CampComposerDraftView | null = null) {
   if (root) {
     flushSync(() => root!.unmount())
     await new Promise(resolve => setTimeout(resolve, 0))
@@ -211,6 +214,7 @@ async function reset(draft = emptyDraft(), holdInitialRead = false) {
   drafts.clear()
   drafts.set(campId, draft)
   nextRead = null
+  initialComposerDraft = entryDraft
   send = neverSend
   queue = { campId, executionActive: true, items: [], editSession: null }
   const first = message(1, 'agent_1')
@@ -224,6 +228,7 @@ async function reset(draft = emptyDraft(), holdInitialRead = false) {
     membershipReconciliations: [], tasks: [], messages: [first], messageDeliveries: [], ...running(first),
     executionEvidence: [], agentRunFileChanges: [], contextManifests: [], approvals: [], actions: [], timeline: [] }
   const held = holdInitialRead ? holdRead() : null
+  if (entryDraft) snapshot = { ...snapshot, messages: [], turns: [], agentRuns: [] }
   if (held) {
     snapshot = { ...snapshot, turns: [], agentRuns: [] }
     queue = { ...queue, executionActive: false }
@@ -287,10 +292,10 @@ async function setupPendingAttachments() {
   queue.items = [
     { id: 'pending-with-body', campId, enqueueSequence: 1, revision: 1, state: 'queued',
       content: composerDocumentFromText('请看这份设计说明'), body: '请看这份设计说明', attachments,
-      replyIntent: null, recipientSelectionRequired: false, lastAttemptErrorCode: null },
+      replyIntent: null, quotes: [], recipientSelectionRequired: false, lastAttemptErrorCode: null },
     { id: 'pending-attachment-only', campId, enqueueSequence: 2, revision: 1, state: 'queued',
       content: emptyComposerDocument(), body: '', attachments: [sourceAttachment(imageFile('仅附件.png'))],
-      replyIntent: null, recipientSelectionRequired: false, lastAttemptErrorCode: null }
+      replyIntent: null, quotes: [], recipientSelectionRequired: false, lastAttemptErrorCode: null }
   ]
   emit('camp.pendingInputs.changed', { campId, reason: 'enqueued' })
   await until(() => document.querySelectorAll('.pending-input-row').length === 2, 'Both queued messages must appear')
@@ -500,7 +505,7 @@ Object.assign(window, { continuationTest: { async run() {
 
   const initialReads = draftReads()
   queue.items = [{ id: 'pending-B', campId, enqueueSequence: 1, revision: 1, state: 'queued',
-    content: composerDocumentFromText('给芝士的 B'), body: '给芝士的 B', replyIntent: null,
+    content: composerDocumentFromText('给芝士的 B'), body: '给芝士的 B', replyIntent: null, quotes: [],
     recipientSelectionRequired: false, lastAttemptErrorCode: null, attachments: [] }]
   emit('camp.pendingInputs.changed', { campId, reason: 'enqueued' })
   await flush()
@@ -579,7 +584,7 @@ Object.assign(window, { continuationTest: { async run() {
     submissions += 1
     drafts.set(campId, emptyDraft())
     queue = { ...queue, items: [{ id: 'pending-send', campId, enqueueSequence: 1, revision: 1, state: 'queued',
-      content: draft.content, body: draft.body, replyIntent: null, recipientSelectionRequired: false, lastAttemptErrorCode: null, attachments: draft.attachments }] }
+      content: draft.content, body: draft.body, replyIntent: null, quotes: [], recipientSelectionRequired: false, lastAttemptErrorCode: null, attachments: draft.attachments }] }
     emit('camp.pendingInputs.changed', { campId, reason: 'enqueued' })
     return { pendingInputId: 'pending-send', agentRunIds: [], campTurnId: null, addressedAgentIds: ['agent_1'] }
   }
@@ -695,6 +700,7 @@ async routeLoading() {
   const layouts = []
   for (const theme of ['day', 'night']) {
     document.documentElement.dataset.theme = theme
+    let defaultRecipientColor: string | null = null
     for (const [name, draft] of [['default', emptyDraft()], ['continuation', continuedDraft('message-1')], ['explicit', explicit]] as const) {
       const held = await reset(draft, true)
       check(held && draftReads() === 1, 'The initial Draft read must remain pending')
@@ -711,11 +717,36 @@ async routeLoading() {
         `Route loading must not move the conversation: ${JSON.stringify({ theme, name, before, after })}`)
       check(!document.querySelector('.composer-route-placeholder'), 'Ready replaces the placeholder')
       const route = document.querySelector('.composer-route-rail')?.textContent ?? ''
-      if (name === 'default') check(route.includes('默认由 Lead · 叮叮接收'), 'Show the default recipient')
+      if (name === 'default') check(route.includes('默认由队长 @叮叮 接收'), 'Show the default recipient')
+      if (name === 'default' || name === 'continuation') {
+        const recipient = document.querySelector<HTMLElement>('.composer-route-rail strong')!
+        check(recipient.textContent?.startsWith('@'), 'Both route modes mark the recipient with @')
+        const color = getComputedStyle(recipient).color
+        if (name === 'default') defaultRecipientColor = color
+        else check(color === defaultRecipientColor, 'Both route modes use the same mention color')
+        check(color !== getComputedStyle(recipient.parentElement!).color, 'The recipient is visually distinct from route copy')
+      }
       if (name === 'continuation') check(continuation() === '继续发给 芝士', 'Show the authoritative continuation')
       if (name === 'explicit') check(!route.trim(), 'Explicit recipients hide the route')
       layouts.push({ theme, name, before, after })
     }
+    const fresh = emptyDraft()
+    await reset(fresh, false, fresh)
+    check(draftReads() === 0, 'New Camp entry must reuse its authoritative Draft without a second route read')
+    check(initialComposerDraft === null, 'Entry Draft must be consumed, not cached for later navigation')
+    check(!document.querySelector('.composer-route-placeholder'), 'New Camp entry must not flash a loading placeholder')
+    check(editor().isContentEditable && document.querySelector('.mention-target-summary')?.textContent?.includes('默认由队长 @叮叮 接收'),
+      'The first new Camp presentation must have a ready editor and default recipient')
+    editor().focus()
+    document.execCommand('insertText', false, '第一次输入')
+    await until(() => savedContinuationSources.length === 1, 'New Camp entry must support immediate editing and autosave')
+    check(drafts.get(campId)?.body === '第一次输入', 'The initial authoritative revision must support saving')
+
+    const restored = await reset(explicit, true)
+    check(document.querySelector('.composer-route-placeholder'), 'Reopening a Camp must read its current Draft')
+    restored!.resolve(explicit)
+    await until(() => editor().isContentEditable, 'Restored Draft must enable editing')
+    check(!document.querySelector('.mention-target-summary'), 'A saved explicit recipient must not show the default route')
   }
   return { ok: true, cases: ['delayed Draft retains conversation geometry'], layouts }
 } } })
@@ -725,6 +756,12 @@ async routeLoading() {
 const browserMode = new URLSearchParams(location.search)
 if (browserMode.has('browser')) {
   const runBrowserFixture = async () => {
+    if (browserMode.get('browser') === 'route-review') {
+      document.documentElement.dataset.theme = browserMode.get('theme') === 'night' ? 'night' : 'day'
+      const fresh = emptyDraft()
+      await reset(fresh, false, fresh)
+      return
+    }
     if (browserMode.get('browser') === 'review') {
       document.documentElement.dataset.theme = browserMode.get('theme') === 'night' ? 'night' : 'day'
       await setupPendingAttachments()
@@ -736,8 +773,12 @@ if (browserMode.has('browser')) {
     const report = document.createElement('pre')
     document.body.append(report)
     try {
-      const fixture = (window as unknown as { continuationTest: { run(): Promise<unknown>; pendingAttachments(): Promise<unknown> } }).continuationTest
-      const result = await (browserMode.get('browser') === 'pending' ? fixture.pendingAttachments() : fixture.run())
+      const fixture = (window as unknown as { continuationTest: {
+        run(): Promise<unknown>; pendingAttachments(): Promise<unknown>; routeLoading(): Promise<unknown>
+      } }).continuationTest
+      const result = await (browserMode.get('browser') === 'route'
+        ? fixture.routeLoading()
+        : browserMode.get('browser') === 'pending' ? fixture.pendingAttachments() : fixture.run())
       report.textContent = JSON.stringify(result, null, 2)
     } catch (error) {
       report.textContent = String(error instanceof Error ? error.stack : error)


### PR DESCRIPTION
新建对话原先先显示输入区的模糊路由占位，再显示默认接收人。现在在新建后的首次打开阶段并行准备 Open 投影和 Core Draft，在首次绘制前将 Draft 一次性交给 Coordinator；进入后可直接输入，后续导航仍重新读取当前草稿。读取失败保留原有加载、错误与重试流程。

默认路由显示为「默认由队长 @姓名 接收」，@姓名 与 continuation 使用相同主题色和字重。提示不向正文插入 Mention，不改变 Core 路由协议。

验证：
- 必需 CI / gate 通过；Full check 的完整 Node 检查通过。
- 真实 Electron 的 route-loading 回归通过，覆盖日夜主题、布局稳定、新建无加载占位、无重复 Draft 读取、立即输入保存及重新进入恢复显式接收人。Pending 附件、Pending 导航、输入组件、preload bridge、关窗保护也通过。
- Chrome 中复跑相同新建路由断言通过，并核对日夜主题截图。
- 本地类型检查、包含 fixture 的扩展类型检查、桌面构建、diff-aware 文档治理、Clippy 通过；日常 arm64 App 打包和 ad-hoc 签名门禁通过。
- 本地 Rust library 553/554 通过，唯一失败是宿主禁止嵌套 macOS sandbox；CLI 35/35、slow tests 309/309 通过。无 Rust 改动，staged Rust 路由按规则跳过。

已确认的验证限制：Full check 在既有 continuation 测试的「A late response must not change the target after typing began」断言停止；使用相同夹具、将生产 CampWorkspace 换为未修改的 main（86c7e4d9）也稳定复现相同失败。本次新增路由场景不受影响，未修改或跳过该既有断言。本地 Vitest 的唯一 evaluation-host 进程回收失败也在干净 main 复现；Linux 全量 Node 已通过。完整 CI 证据：https://github.com/murray17/rovai-ai/actions/runs/34605970927

Full check 的 Windows 专项另外有 2 项 MCP 文件属主/权限测试失败（filesystem object owner is not the current Windows user）；本次未修改 Rust、Windows 或 MCP 代码。Rust full 远端任务仍在运行，不将 Full check 描述为全部通过。

交付：已按必需 gate 合并 main（aa8a56c2），以等价代码树打包并安装到 `/Applications/Rovai AI.app`。源、暂存、最终 bundle 均通过专用安装验证，安装 ASAR 与验收包 SHA-256 一致；旧版备份保留为 `/Applications/Rovai AI.backup-before-composer-entry-20260911-215113.app`，当前 5 个旧 App/Core/Helper 进程仍存活。

清理完成：`/Users/murray.xue/VSCodeProjects/opensource/rovai-ai-composer-entry` 已正常删除；本地及远端 `rovai/composer-entry-recipient` 分支均已删除，未丢弃未提交内容。主 checkout 干净并同步 main；保留原有 `rovai-ai-unified-rust-host` worktree，清理后磁盘可用 60 GiB。
