### PR TITLE
fix(desktop): scope select all to active file preview content

### DIFF
--- a/apps/desktop/src/renderer/src/FileChangesPreview.tsx
+++ b/apps/desktop/src/renderer/src/FileChangesPreview.tsx
@@ -1,6 +1,7 @@
 import { FileFindChangesAdapter } from './FileFindChangesAdapter'
 import { ChangedFileSelect } from './ChangedFileSelect'
 import { fileChangeFindLineId } from './file-find-changes'
+import { selectPreviewContents } from './file-preview-selection'
 import { useEffect, useRef, useState, type JSX } from 'react'
 import type { AgentRunFileChangesDetailView, AgentRunFileChangesView } from '@contracts'
 import { useFilePreview, type FileChangesPreviewTabModel } from './FilePreviewContext'
@@ -242,6 +243,7 @@ export function AgentRunFileChangesReviewSurface({
                   className="agent-run-file-review-scroll"
                   key={selectedFile.evidenceFileId}
                   tabIndex={0}
+                  onKeyDown={(event) => selectPreviewContents(event, event.currentTarget.querySelector('.agent-run-file-review-blocks'))}
                   aria-label={`${selectedFile.path} 的文件变化内容`}
                 >
                   {detailStatus === 'loading' && (

--- a/apps/desktop/src/renderer/src/FilePreviewPane.tsx
+++ b/apps/desktop/src/renderer/src/FilePreviewPane.tsx
@@ -10,6 +10,7 @@ import { ReadonlyCodeViewer } from './ReadonlyCodeViewer'
 import { previewPathIsVisible, previewTabLabel, previewTabLabels } from './file-preview-tab-presentation'
 import { filePreviewAssetUrl } from '../../file-preview-asset-url'
 import { parseUnifiedPatch } from './file-preview-patch'
+import { selectPreviewContents } from './file-preview-selection'
 
 function FilePathButton({
   path,
@@ -295,7 +296,8 @@ function PatchViewer({ tab }: { tab: FilePreviewTabModel }): React.JSX.Element {
   }
 
   return (
-    <div className="file-preview-patch" ref={root} tabIndex={0}>
+    <div className="file-preview-patch" ref={root} tabIndex={0}
+      onKeyDown={(event) => selectPreviewContents(event, event.currentTarget.querySelector('.file-preview-patch-document'))}>
       <FileFindDomAdapter root={root} selector=".file-preview-patch-line:not(.is-metadata) code" revision={text} />
       <nav className="file-preview-patch-outline" aria-label="补丁目录">
         {patch.files.map((file) => (
@@ -367,7 +369,8 @@ function Viewer({ tab }: { tab: FilePreviewTabModel }): React.JSX.Element {
   if (!tab.content || !file) return <div className="file-preview-empty-content" />
   if (tab.content.kind === 'markdown') {
     return (
-      <div className="file-preview-markdown" ref={root} tabIndex={0}>
+      <div className="file-preview-markdown" ref={root} tabIndex={0}
+        onKeyDown={(event) => selectPreviewContents(event, event.currentTarget.querySelector('.safe-markdown'))}>
         <FileFindDomAdapter root={root} selector=".safe-markdown" revision={tab.content} />
         {linkError && <p className="file-preview-inline-error" role="alert">{linkError}</p>}
         <SafeMarkdown

--- a/apps/desktop/src/renderer/src/ReadonlyCodeViewer.tsx
+++ b/apps/desktop/src/renderer/src/ReadonlyCodeViewer.tsx
@@ -4,6 +4,7 @@ import CodeMirror from '@uiw/react-codemirror'
 import { EditorView } from '@codemirror/view'
 import { useFileFindAdapter } from './FilePreviewFind'
 import { codeFileFindAdapter } from './file-find-code'
+import { isPreviewSelectAll } from './file-preview-selection'
 import type { FileLocationTarget, ResolvedTheme } from '@contracts'
 import {
   loadSourceLanguageForFilename,
@@ -137,6 +138,14 @@ export function ReadonlyCodeViewer({
       role="region"
       aria-label={`${fileName} 内容`}
       tabIndex={0}
+      onKeyDown={(event) => {
+        const view = viewRef.current
+        if (!view || !isPreviewSelectAll(event)) return
+        event.preventDefault()
+        event.stopPropagation()
+        view.focus()
+        view.dispatch({ selection: { anchor: 0, head: view.state.doc.length }, userEvent: 'select' })
+      }}
     >
       <CodeMirror
         className="file-preview-code-mirror"

--- a/apps/desktop/src/renderer/src/file-preview-selection.ts
+++ b/apps/desktop/src/renderer/src/file-preview-selection.ts
@@ -1,0 +1,21 @@
+import type { KeyboardEvent } from 'react'
+
+export function isPreviewSelectAll(event: KeyboardEvent<HTMLElement>): boolean {
+  if (event.defaultPrevented || event.nativeEvent.isComposing || event.altKey || event.shiftKey
+    || !(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== 'a') return false
+  const target = event.target
+  return !(target instanceof HTMLElement
+    && (target.isContentEditable || target.closest('input, textarea, select')))
+}
+
+export function selectPreviewContents(event: KeyboardEvent<HTMLElement>, content: HTMLElement | null): void {
+  if (!content || !isPreviewSelectAll(event)) return
+  const selection = content.ownerDocument.getSelection()
+  if (!selection) return
+  const range = content.ownerDocument.createRange()
+  range.selectNodeContents(content)
+  event.preventDefault()
+  event.stopPropagation()
+  selection.removeAllRanges()
+  selection.addRange(range)
+}

--- a/docs/ui/components/file-preview.md
+++ b/docs/ui/components/file-preview.md
@@ -2,7 +2,7 @@
 document_type: ui-component-contract
 authority: renderer-file-preview
 status: accepted
-last_updated: 2026-09-09
+last_updated: 2026-09-12
 ---
 
 # Camp 文件预览区
@@ -211,6 +211,10 @@ Markdown document 模式保留 H1–H6 的真实语义与层级；正文为 15px
 
 Viewer 底色与会话阅读区共用语义 surface。选中文字只保留普通系统选择/复制行为，不出现“附加到会话”浮层，
 也不向 Composer 添加引用卡片；引用能力留待后续整体设计。
+
+焦点在文件正文时，`Cmd/Ctrl+A` 只全选当前阅读器的内容，不跨入会话、文件 Tabs、路径行或其他 Tab。
+Markdown 选择渲染正文；代码/文本选择已加载全文（包含未渲染的滚动区外行），分页文本只选择当前页；
+Patch 与 File Change 选择当前阅读器的差异文档。搜索输入框保留自身全选，HTML 保留 iframe 内原生选择。
 
 HTML 与 Markdown 的相对脚本、样式、图片和其他本地资源从当前文档所在目录解析，只在当前 Tab 生命周期内可用；
 HTML/Markdown 内可信点击的相对文件链接直接打开独立文件 Tab。用户不需要看到或理解资源 token、capability、

--- a/scripts/fixtures/file-preview-layout/main.cjs
+++ b/scripts/fixtures/file-preview-layout/main.cjs
@@ -98,6 +98,19 @@ app.whenReady().then(async () => {
     return snapshot()
   }
   const reviewSnapshot = async () => { await snapshot(); return run('window.previewTest.reviewSnapshot()') }
+  const assertScopedSelection = async (selector) => {
+    const result = await run(`(() => {
+      const body = document.querySelector(${JSON.stringify(selector)})
+      const selection = window.getSelection()
+      return { text: selection.toString(),
+        contained: body.contains(selection.anchorNode) && body.contains(selection.focusNode),
+        complete: selection.containsNode(body, true) }
+    })()`)
+    assert.equal(result.contained, true, 'Select all stays in the active file body')
+    assert.equal(result.complete, true, 'Select all covers the complete file body')
+    assert.ok(result.text.length > 0)
+    return result.text
+  }
 
   await viewport(1440)
   await check('the persistent preview toggle opens an empty reading plane and closes without saving a new ratio', async () => {
@@ -193,6 +206,20 @@ app.whenReady().then(async () => {
     await run('window.previewTest.setTheme("day")')
   })
 
+  await check('source select all copies the entire loaded file beyond virtualized lines and preserves read-only content', async () => {
+    for (const selector of ['.file-preview-code', '.cm-content']) {
+      await run(`document.querySelector(${JSON.stringify(selector)}).focus()`)
+      await key('a', [process.platform === 'darwin' ? 'meta' : 'control'])
+      const selected = await run('window.previewTest.sourceSelectionSnapshot()')
+      assert.equal(selected.complete, true)
+      assert.equal(selected.copied, selected.document, 'Copy includes all source text without gutter line numbers')
+      assert.equal(selected.copied.split('\n').length, 300)
+      assert.ok(selected.renderedLines < 300, 'The fixture exercises offscreen source lines')
+      await window.webContents.insertText('must not edit the preview')
+      assert.equal((await run('window.previewTest.sourceSelectionSnapshot()')).document, selected.document)
+    }
+  })
+
   await check('Markdown document mode preserves hierarchy and uses static shared syntax highlighting', async () => {
     await run('window.previewTest.openMarkdown()')
     const day = await run('window.previewTest.markdownSnapshot()')
@@ -207,6 +234,29 @@ app.whenReady().then(async () => {
     assert.equal(day.tableScrolls, true)
     assert.ok(day.documentWidth <= 780 && day.documentWidth < day.paneWidth)
     assert.equal(day.pageOverflow, false)
+
+    await click('.file-preview-tab-panel:not([hidden]) .safe-markdown h1')
+    for (const modifier of process.platform === 'darwin' ? ['meta', 'control'] : ['control']) {
+      await key('a', [modifier])
+      const text = await assertScopedSelection('.file-preview-tab-panel:not([hidden]) .safe-markdown')
+      assert.ok(text.includes('文件预览') && text.includes('滚轮经过宽表格'),
+        'Select all includes the complete active Markdown document')
+      await run('window.getSelection().removeAllRanges()')
+    }
+    await key('f', [process.platform === 'darwin' ? 'meta' : 'control'])
+    await run('window.previewTest.setSourceSearch("文件预览")')
+    await run(`window.addEventListener('keydown', event => { window.previewSelectionKey = event }, { capture: true, once: true })`)
+    await key('a', [process.platform === 'darwin' ? 'meta' : 'control'])
+    assert.equal(await run('window.previewSelectionKey.defaultPrevented'), false,
+      'A focused find input keeps its native select-all behavior')
+    window.webContents.selectAll()
+    await snapshot()
+    assert.equal(await run(`(() => {
+      const input = document.activeElement
+      return input.tagName === 'INPUT' && input.selectionStart === 0 && input.selectionEnd === input.value.length
+    })()`), true, 'Native select all selects only the find query')
+    await run('delete window.previewSelectionKey')
+    await key('Escape')
 
     const reader = await run(`(() => {
       const reader = document.querySelector('.file-preview-tab-panel:not([hidden]) .file-preview-markdown')
@@ -968,6 +1018,10 @@ app.whenReady().then(async () => {
     await drag(420)
     await release()
     const before = await reviewSnapshot()
+    await click('.file-preview-tab-panel:not([hidden]) .agent-run-file-review-diff-line.is-addition code')
+    await key('a', [process.platform === 'darwin' ? 'meta' : 'control'])
+    await assertScopedSelection('.file-preview-tab-panel:not([hidden]) .agent-run-file-review-blocks')
+    await run('window.getSelection().removeAllRanges()')
     const typography = () => run(`(() => {
       const row = document.querySelector('.file-preview-tab-panel:not([hidden]) .agent-run-file-review-diff-line.is-addition');
       const code = row.querySelector('code');
@@ -1099,6 +1153,10 @@ app.whenReady().then(async () => {
   })
   await check('patch metadata, page boundaries and image surfaces respect their search scope', async () => {
     await run('window.previewTest.openFindFixture("find.patch")')
+    await click('.file-preview-tab-panel:not([hidden]) .file-preview-patch-line code')
+    await key('a', [process.platform === 'darwin' ? 'meta' : 'control'])
+    await assertScopedSelection('.file-preview-tab-panel:not([hidden]) .file-preview-patch-document')
+    await run('window.getSelection().removeAllRanges()')
     await click('.file-preview-find-trigger')
     await run('window.previewTest.setSourceSearch("patch")')
     assert.equal((await run('window.previewTest.findSnapshot()')).count, '1 / 2')
@@ -1114,6 +1172,11 @@ app.whenReady().then(async () => {
     await click('.file-preview-find-trigger')
     await run('window.previewTest.setSourceSearch("second-page")')
     assert.equal((await run('window.previewTest.findSnapshot()')).count, '1 / 1')
+    await key('Escape')
+    await key('a', [process.platform === 'darwin' ? 'meta' : 'control'])
+    const pageSelection = await run('window.previewTest.sourceSelectionSnapshot()')
+    assert.equal(pageSelection.complete, true)
+    assert.equal(pageSelection.copied, 'second-page needle', 'Paged text selects only the loaded page')
     await run('window.previewTest.openFindFixture("find.svg")')
     assert.equal(await run('document.querySelector(".file-preview-find-trigger").disabled'), true)
     await run('document.querySelector(".file-preview-tab-panel:not([hidden])").focus()')

--- a/scripts/fixtures/file-preview-layout/renderer.tsx
+++ b/scripts/fixtures/file-preview-layout/renderer.tsx
@@ -1,5 +1,6 @@
 import { searchFileDocuments } from '../../../apps/desktop/src/renderer/src/file-find-client'
 import { EMPTY_FILE_FIND } from '../../../apps/desktop/src/renderer/src/file-find'
+import { EditorView } from '@codemirror/view'
 import { isFileFindTarget } from '../../../apps/desktop/src/renderer/src/FilePreviewFind'
 import { StrictMode, useEffect, useRef, useState } from 'react'
 import { createRoot } from 'react-dom/client'
@@ -663,6 +664,18 @@ Object.assign(window, { previewTest: {
     const scroller = element('.file-preview-tab-panel:not([hidden]) .cm-scroller')
     if (scroller) scroller.scrollTop = 480
     await settle()
+  },
+  sourceSelectionSnapshot() {
+    const content = element('.file-preview-tab-panel:not([hidden]) .cm-content')!
+    const view = EditorView.findFromDOM(content)!
+    const clipboard = new DataTransfer()
+    content.dispatchEvent(new ClipboardEvent('copy', { bubbles: true, cancelable: true, clipboardData: clipboard }))
+    return {
+      complete: view.state.selection.main.from === 0 && view.state.selection.main.to === view.state.doc.length,
+      copied: clipboard.getData('text/plain'),
+      document: view.state.doc.toString(),
+      renderedLines: content.querySelectorAll('.cm-line').length
+    }
   },
   async sourceSnapshot(requireTarget = false) {
     const deadline = performance.now() + 3_000


### PR DESCRIPTION
文件预览正文获得焦点后，Cmd/Ctrl+A 现在只全选当前阅读器内容，避免把会话、路径行和其他 Tab 一并选中。代码阅读器通过 CodeMirror 文档选择已加载全文，复制包含屏幕外行且不带行号；Markdown、Patch 和 File Change 限定 DOM 选区，分页文本只选择当前页，搜索输入框保留原生全选。

已同步最新 main 的预览加载修复。新增真实 Electron 键盘回归，覆盖 Markdown 的 Command/Ctrl+A、300 行代码完整复制和只读保护、分页、差异阅读器及搜索输入框。

验证：
- pnpm typecheck
- pnpm test
- pnpm test:file-preview-layout
- 同步 main 后的文件分类、预览服务和 ImageGallery 定向测试（61 项）
- pnpm test:rust:pr
- cargo clippy --workspace --all-targets -- -D warnings
- pnpm build:desktop
- DOCS_BASE_REF=9475856b8a642e8f5d7cd4fdd4236ce1edd0f07c pnpm docs:check:ci
