### PR TITLE
fix(ui): 收紧上下文压缩提示与命令组的间距

### DIFF
--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -1679,7 +1679,7 @@ html[data-rovai-platform="win32"] .bootstrap-shell-brand { padding-left: 20px; }
 .single-chat-disclosure { display: grid; width: 24px; height: 24px; place-items: center; justify-self: end; border-radius: 5px; color: var(--faint); }
 .single-chat-disclosure svg { width: 14px; height: 14px; fill: none; stroke: currentColor; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1.55; transition: transform 130ms ease; }
 .single-chat-run-history:not([open]) > summary .single-chat-disclosure svg { transform: rotate(-90deg); }
-.single-chat-execution-content.process-content { display: grid; gap: 8px; margin: 5px 0 7px; padding: 8px 2px 2px; }
+.single-chat-execution-content.process-content { --process-item-gap: 8px; display: grid; gap: var(--process-item-gap); margin: 5px 0 7px; padding: 8px 2px 2px; }
 .single-chat-run-history.is-live .single-chat-execution-content { margin: 0; padding: 0 2px; border: 0; background: transparent; }
 .single-chat-narration { color: var(--muted); font-size: 11.5px; line-height: 1.58; }
 .single-chat-narration .safe-markdown { color: inherit; font-size: inherit; line-height: inherit; }
@@ -3761,7 +3761,10 @@ button.task-event-card:focus-visible .task-card-chevron { color: var(--brand-ink
 .execution-disclosure.worked:not([open]) .process-disclosure-slot svg { transform: rotate(-90deg); }
 .execution-disclosure.worked > summary:hover .process-disclosure-slot,
 .execution-disclosure.worked > summary:focus-visible .process-disclosure-slot { color: var(--ink); background: var(--surface-hover); }
-.process-content { display: grid; gap: 14px; padding: 13px 0 6px; }
+.process-content { --process-item-gap: 14px; display: grid; gap: var(--process-item-gap); padding: 13px 0 6px; }
+/* Keep adjacent activity rows compact within the wider narrative rhythm. */
+.process-content > .tool-activity-group + .compaction-event,
+.process-content > .compaction-event + :is(.tool-activity-group, .compaction-event) { margin-top: calc(4px - var(--process-item-gap)); }
 .run-live > .process-content { padding: 0; }
 .process-copy { margin: 0; color: var(--ink); font-size: 12.5px; line-height: 1.68; }
 .process-copy .safe-markdown { color: inherit; font-size: inherit; line-height: inherit; }

--- a/scripts/accept-runtime-activity-ui.mjs
+++ b/scripts/accept-runtime-activity-ui.mjs
@@ -1376,14 +1376,14 @@ async function seedFixture() {
       'sha256:legacy-empty-mcp-exposure', 'fixture-mcp-projection',
       '[]', 'fixture-active-tasks',
       0, ${runtimes.length}, 0,
-      4, '{"profileVersion":4,"maxPublicMessages":15,"maxPublicHistoryChars":24000,"maxMessageBodyChars":2000,"maxPublicReferenceChainMessages":3,"maxSelfActiveTasks":8}',
+      5, '{"profileVersion":5,"maxPublicMessages":15,"maxPublicHistoryChars":24000,"maxMessageBodyChars":2000,"maxPublicReferenceChainMessages":3,"maxSelfActiveTasks":8}',
       'fixture-context-profile', NULL,
-      '[]', 22,
+      '[]', 23,
       ${sqlLiteral(recoveryBlob.id)}, ${sqlLiteral(recoveryBlob.digest)}, ${sqlLiteral(now)},
       '[]', '[]', '[]', 'fixture-shared-message-evidence', '{"schemaVersion":1}',
       'agent_v1', '{"schemaVersion":1,"included":false}',
       '8f0abde6b1c7b1bf405e1efa2a2cfe82a1bd329a64003a93c3e20c84a8c26d92',
-      22, 2, 2,
+      23, 2, 2,
       ${sqlLiteral(JSON.stringify(campAttachmentViewReceipt))},
       ${sqlLiteral(campAttachmentViewReceiptDigest)}
     );


### PR DESCRIPTION
压缩上下文提示位于执行列表根层，原先继承了 14px 的段落间距，单聊为 8px，与相邻 command 组显得过于疏远。将 Compaction 与相邻 Tool 组、连续 Compaction 的间距统一为 4px，保留正文间距、28px 行高和展开交互。

同时将执行台验收夹具更新为当前要求的 Formatter 23 / ContextManifest 23 / Delivery Profile 5，修复旧夹具在数据库导入阶段被拒绝的问题。

验证：

- `pnpm typecheck`、`pnpm docs:check:ci`、CI gate 通过。
- `pnpm exec vitest run --maxWorkers=2`：174 文件、1759 项测试通过。默认并发下的 6 项超时在降低并发后通过。
- 双主题、不同窗口尺寸、200% 缩放下的 16 组生产组件布局检查通过，相邻活动间距为 4px。
- 合并后的 main `afd01d10` 已通过 `pnpm package:mac:daily`、arm64 ad-hoc 签名校验和打包 App 的工具详情定向验收，确认 Web 搜索及 Shell 展开正常。
- 全量 App 验收仍在既有消息样式断言处失败：复制按钮背景不是透明色，操作行左偏移为 -5px。该断言早于 Compaction 检查，因此全量界面矩阵未通过；保留失败记录，不计为通过。
