### PR TITLE
fix(ui): unify Chrome zoom presets across shortcuts and settings

### DIFF
--- a/apps/desktop/.impeccable/surfaces/settings-workspace.md
+++ b/apps/desktop/.impeccable/surfaces/settings-workspace.md
@@ -1,5 +1,5 @@
 ---
-version: 12
+version: 13
 slug: "settings-workspace"
 primary_target: "apps/desktop/src/renderer/src/SettingsPageHeader.tsx"
 related_targets:
@@ -32,8 +32,8 @@ Reviewed settings controls use the existing neutral conversation-action tokens. 
 unchanged, selection uses a neutral fill without a left stripe, and status/provider colors keep their meaning.
 Off switches have a white thumb. Inputs and buttons preserve keyboard behavior and text carets without
 decorative focus rings. Member Runtime configuration selects retain their current styles. MCP/Skills follow the capability composition below.
-Appearance keeps its real reading previews; only the motion demo is removed. Zoom presets are exactly
-80, 90, 100, 110, 125, 150, 175 and 200%; existing nonpreset values and shortcut limits remain valid.
+Appearance keeps its real reading previews; only the motion demo is removed. Its zoom selector and
+shortcuts share the Chrome desktop presets defined by the theme contract below.
 
 All categories implement Loading, Empty, Partial, Error, Disabled, Submitting and Recovery while
 retaining the header and navigation. A save, import, repair or probe failure keeps inputs, selection,
@@ -87,8 +87,9 @@ empty/intermediate input is kept while editing and normalized on blur or Enter. 
 changes prose leading and paragraph spacing. Preview tabs use ArrowLeft/Right, Home/End and roving focus.
 Preview messages and files are synthetic examples, never user or Core data.
 
-The display section offers 80–200% zoom choices and follows the existing native Electron zoom shortcuts.
-The broader 10–500% shortcut range remains available and an out-of-list current value stays representable.
+The display section uses the shared 25–500% Chrome desktop presets from
+[`themes/README.md`](../../../../docs/ui/themes/README.md#外观与阅读偏好), including its exact fractional
+factors and shortcut limits. An existing out-of-list saved value stays representable and restorable.
 Reduced motion has exactly 跟随系统 and 始终减少; it suppresses motion in CSS, programmatic scrolling
 and the world map while preserving status and progress content. Its one-shot file-tab example can replay.
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -83,7 +83,7 @@ import { parseClipboardWriteRequest } from './clipboard-write'
 import { OnboardingStore } from './onboarding-preferences'
 import { DailyAnalysisService } from './daily-analysis'
 import { EvaluationHostService } from './evaluation-host'
-import { nextPageZoomPercentage, pageZoomAction, pageZoomPercentage } from './page-zoom'
+import { nextPageZoomPercentage, pageZoomAction, pageZoomFactor, pageZoomPercentage } from './page-zoom'
 import { applyWindowChromeAppearance, windowChromeOptions } from './window-chrome'
 import {
   parseWindowsApplicationMenuPopupRequest,
@@ -667,7 +667,7 @@ async function updateAppearancePreferences(patch: Partial<AppearancePreferences>
   const preferences = await appearanceStore.update(patch)
   nativeTheme.themeSource = nativeThemeSource(preferences.preference)
   if (mainWindow && !mainWindow.isDestroyed()) {
-    mainWindow.webContents.setZoomFactor(preferences.zoomPercentage / 100)
+    mainWindow.webContents.setZoomFactor(pageZoomFactor(preferences.zoomPercentage))
     mainWindow.webContents.send('rovai:page-zoom-changed', preferences.zoomPercentage)
   }
   return publishAppearance()
@@ -717,7 +717,7 @@ function createWindow(): void {
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: true,
-      zoomFactor: appearanceSnapshot().zoomPercentage / 100
+      zoomFactor: pageZoomFactor(appearanceSnapshot().zoomPercentage)
     }
   })
   const webContentsId = window.webContents.id
@@ -754,12 +754,12 @@ function createWindow(): void {
     event.preventDefault()
     const percentage = nextPageZoomPercentage(window.webContents.getZoomFactor(), action)
     if (percentage === null) return
-    window.webContents.setZoomFactor(percentage / 100)
+    window.webContents.setZoomFactor(pageZoomFactor(percentage))
     window.webContents.send('rovai:page-zoom-changed', percentage)
     void updateAppearancePreferences({ zoomPercentage: percentage }).catch((error) => {
       console.warn('[rovai] Page zoom preference could not be saved.', error)
       if (!window.isDestroyed()) {
-        window.webContents.setZoomFactor(appearanceSnapshot().zoomPercentage / 100)
+        window.webContents.setZoomFactor(pageZoomFactor(appearanceSnapshot().zoomPercentage))
         publishPageZoom()
       }
     })

--- a/apps/desktop/src/main/page-zoom.test.ts
+++ b/apps/desktop/src/main/page-zoom.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
+import { APPEARANCE_ZOOM_OPTIONS } from '../shared/appearance'
 import {
   nextPageZoomPercentage,
   pageZoomAction,
+  pageZoomFactor,
   pageZoomPercentage,
   type PageZoomKeyboardInput
 } from './page-zoom'
@@ -55,17 +57,57 @@ describe('page zoom feedback', () => {
     expect(pageZoomPercentage(Number.NaN)).toBeNull()
   })
 
-  it('changes keyboard zoom by exactly ten percentage points', () => {
-    expect(nextPageZoomPercentage(1, 'in')).toBe(110)
-    expect(nextPageZoomPercentage(1, 'out')).toBe(90)
-    expect(nextPageZoomPercentage(0.91, 'in')).toBe(101)
-    expect(nextPageZoomPercentage(1.21, 'out')).toBe(111)
+  it('moves keyboard zoom through the same adjacent presets as Settings', () => {
+    expect(APPEARANCE_ZOOM_OPTIONS).toEqual([
+      25, 33, 50, 67, 75, 80, 90, 100, 110, 125, 150, 175, 200, 250, 300, 400, 500
+    ])
+    for (let index = 1; index < APPEARANCE_ZOOM_OPTIONS.length; index++) {
+      const previous = APPEARANCE_ZOOM_OPTIONS[index - 1]
+      const current = APPEARANCE_ZOOM_OPTIONS[index]
+      expect(nextPageZoomPercentage(pageZoomFactor(previous), 'in')).toBe(current)
+      expect(nextPageZoomPercentage(pageZoomFactor(current), 'out')).toBe(previous)
+    }
+  })
+
+  it('uses Chrome fractional factors behind the rounded percentage labels', () => {
+    expect(pageZoomFactor(33)).toBe(1 / 3)
+    expect(pageZoomFactor(67)).toBe(2 / 3)
+    expect(pageZoomPercentage(pageZoomFactor(33))).toBe(33)
+    expect(pageZoomPercentage(pageZoomFactor(67))).toBe(67)
+    expect(pageZoomFactor(121)).toBe(1.21)
+  })
+
+  it('moves existing nonpreset zoom to the next preset in the requested direction', () => {
+    expect(nextPageZoomPercentage(0.91, 'in')).toBe(100)
+    expect(nextPageZoomPercentage(0.91, 'out')).toBe(90)
+    expect(nextPageZoomPercentage(1.21, 'in')).toBe(125)
+    expect(nextPageZoomPercentage(1.21, 'out')).toBe(110)
+    expect(nextPageZoomPercentage(1.15, 'out')).toBe(110)
     expect(nextPageZoomPercentage(1.4, 'reset')).toBe(100)
   })
 
-  it('keeps custom keyboard zoom within safe valid bounds', () => {
-    expect(nextPageZoomPercentage(0.1, 'out')).toBe(10)
+  it('uses Chrome presets above and below the former common Settings range', () => {
+    expect(nextPageZoomPercentage(0.8, 'out')).toBe(75)
+    expect(nextPageZoomPercentage(0.7, 'in')).toBe(75)
+    expect(nextPageZoomPercentage(0.5, 'in')).toBe(67)
+    expect(nextPageZoomPercentage(0.75, 'in')).toBe(80)
+    expect(nextPageZoomPercentage(2, 'in')).toBe(250)
+    expect(nextPageZoomPercentage(2.1, 'out')).toBe(200)
+    expect(nextPageZoomPercentage(2.5, 'out')).toBe(200)
+    expect(nextPageZoomPercentage(2.5, 'in')).toBe(300)
+    expect(nextPageZoomPercentage(3, 'in')).toBe(400)
+    expect(nextPageZoomPercentage(4, 'in')).toBe(500)
+    expect(nextPageZoomPercentage(2.05, 'out')).toBe(200)
+  })
+
+  it('stops at the Chrome preset limits and accepts existing values below the minimum', () => {
+    expect(nextPageZoomPercentage(0.25, 'out')).toBe(25)
     expect(nextPageZoomPercentage(5, 'in')).toBe(500)
+    expect(nextPageZoomPercentage(0.1, 'out')).toBe(10)
+    expect(nextPageZoomPercentage(0.1, 'in')).toBe(25)
+    expect(nextPageZoomPercentage(0.15, 'out')).toBe(15)
+    expect(nextPageZoomPercentage(0.15, 'in')).toBe(25)
+    expect(nextPageZoomPercentage(4.95, 'in')).toBe(500)
     expect(nextPageZoomPercentage(Number.NaN, 'in')).toBeNull()
   })
 })

--- a/apps/desktop/src/main/page-zoom.ts
+++ b/apps/desktop/src/main/page-zoom.ts
@@ -1,3 +1,5 @@
+import { APPEARANCE_ZOOM_FACTORS, APPEARANCE_ZOOM_OPTIONS } from '../shared/appearance'
+
 export interface PageZoomKeyboardInput {
   type: string
   key: string
@@ -10,7 +12,7 @@ export interface PageZoomKeyboardInput {
 
 export type PageZoomAction = 'in' | 'out' | 'reset'
 
-export const PAGE_ZOOM_STEP_PERCENTAGE = 10
+// Saved preferences still accept legacy values below the first Chrome preset.
 export const MIN_PAGE_ZOOM_PERCENTAGE = 10
 export const MAX_PAGE_ZOOM_PERCENTAGE = 500
 
@@ -40,6 +42,11 @@ export function pageZoomPercentage(zoomFactor: number): number | null {
   return Math.round(zoomFactor * 100)
 }
 
+export function pageZoomFactor(percentage: number): number {
+  const index = APPEARANCE_ZOOM_OPTIONS.indexOf(percentage)
+  return index === -1 ? percentage / 100 : APPEARANCE_ZOOM_FACTORS[index]
+}
+
 export function nextPageZoomPercentage(
   currentZoomFactor: number,
   action: PageZoomAction
@@ -49,16 +56,10 @@ export function nextPageZoomPercentage(
   if (action === 'reset') return 100
 
   if (action === 'in') {
-    if (currentPercentage >= MAX_PAGE_ZOOM_PERCENTAGE) return currentPercentage
-    return Math.min(
-      currentPercentage + PAGE_ZOOM_STEP_PERCENTAGE,
-      MAX_PAGE_ZOOM_PERCENTAGE
-    )
+    return APPEARANCE_ZOOM_OPTIONS.find((percentage) => percentage > currentPercentage)
+      ?? currentPercentage
   }
 
-  if (currentPercentage <= MIN_PAGE_ZOOM_PERCENTAGE) return currentPercentage
-  return Math.max(
-    currentPercentage - PAGE_ZOOM_STEP_PERCENTAGE,
-    MIN_PAGE_ZOOM_PERCENTAGE
-  )
+  return APPEARANCE_ZOOM_OPTIONS.findLast((percentage) => percentage < currentPercentage)
+    ?? currentPercentage
 }

--- a/apps/desktop/src/renderer/src/AppearanceSettings.test.ts
+++ b/apps/desktop/src/renderer/src/AppearanceSettings.test.ts
@@ -39,11 +39,11 @@ it('reports an unreadable preference source without claiming defaults were saved
   expect(markup).not.toContain('>已保存<')
 })
 
-it('keeps a shortcut zoom value outside the common choices representable', () => {
+it('keeps an existing nonpreset zoom value representable', () => {
   const markup = renderToStaticMarkup(createElement(AppearanceSettings, {
-    appearance: { ...DEFAULT_APPEARANCE, zoomPercentage: 250, resolvedTheme: 'day' },
+    appearance: { ...DEFAULT_APPEARANCE, zoomPercentage: 121, resolvedTheme: 'day' },
     disabled: false,
     onChange: async (preferences) => ({ ...preferences, resolvedTheme: 'day' })
   }))
-  expect(markup).toContain('<option value="250" selected="">250%</option>')
+  expect(markup).toContain('<option value="121" selected="">121%</option>')
 })

--- a/apps/desktop/src/shared/appearance.ts
+++ b/apps/desktop/src/shared/appearance.ts
@@ -12,7 +12,12 @@ export const DEFAULT_APPEARANCE: Readonly<AppearancePreferences> = Object.freeze
 
 export const MIN_READING_FONT_SIZE = 12
 export const MAX_READING_FONT_SIZE = 24
-export const APPEARANCE_ZOOM_OPTIONS = [80, 90, 100, 110, 125, 150, 175, 200]
+// Chromium desktop presets, including the exact factors behind the rounded 33% and 67% labels.
+// https://chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/blink/common/page/page_zoom.cc
+export const APPEARANCE_ZOOM_FACTORS = [
+  0.25, 1 / 3, 0.5, 2 / 3, 0.75, 0.8, 0.9, 1, 1.1, 1.25, 1.5, 1.75, 2, 2.5, 3, 4, 5
+]
+export const APPEARANCE_ZOOM_OPTIONS = APPEARANCE_ZOOM_FACTORS.map((factor) => Math.round(factor * 100))
 
 export function appearancePreferencesEqual(a: AppearancePreferences, b: AppearancePreferences): boolean {
   return (Object.keys(DEFAULT_APPEARANCE) as Array<keyof AppearancePreferences>)

--- a/docs/ui/components/app-shell-navigation.md
+++ b/docs/ui/components/app-shell-navigation.md
@@ -2,7 +2,7 @@
 document_type: ui-component-contract
 authority: renderer-app-shell-navigation
 status: accepted
-last_updated: 2026-09-10
+last_updated: 2026-09-12
 ---
 
 # App Shell 与统一侧栏
@@ -163,7 +163,9 @@ Project/Camp 行、菜单、临时提醒和设置返回均可键盘操作，Icon
 Snapshot 刷新、设置/记忆页和应用失焦均不得提前清除。
 
 页面缩放继续使用标准 `CommandOrControl + / - / 0` 快捷键；App 拦截 Electron 的默认倍率阶梯，
-将键盘放大和缩小固定为每次增减 10 个百分点，`CommandOrControl 0` 重置为 100%。键盘调整后，
+与设置页统一采用 [Chrome 桌面缩放档位](../themes/README.md#外观与阅读偏好)，按方向切换相邻档位，
+到达 25% 或 500% 后停止。已有非预设比例按调整方向进入相邻档位；低于 25% 的历史保存值继续
+显示和恢复，放大时进入 25%，缩小时保持当前值。`CommandOrControl 0` 重置为 100%。键盘调整后，
 App Shell 在不抢夺焦点的全局浮层中短暂显示实际缩放比例，并通过 polite live region 播报同一文字。
 浮层使用双主题语义 Token，在首次训练和所有一级页面上保持同一位置与行为。
 

--- a/docs/ui/themes/README.md
+++ b/docs/ui/themes/README.md
@@ -2,7 +2,7 @@
 document_type: ui-theme-index
 authority: renderer-theme-routing
 status: accepted
-last_updated: 2026-09-03
+last_updated: 2026-09-12
 ---
 
 # Renderer 主题
@@ -50,8 +50,11 @@ Theme Token → Shared Component → Surface Composition
 - 文档字号默认 15px，作用于 Markdown 文件正文，标题、表格与代码块等比例调整。
 - 代码字号默认 14px，作用于源码、纯文本和文件差异正文／行号。长行在阅读器内横向滚动。
 - 三种字号只接受 12–24px 的整数；标准／宽松调整正文行距与段落间距，不改变代码行距比例。
-- 原生 Electron 缩放默认 100%，设置页提供 80–200% 常用值；已有快捷键的 10–500% 范围保留，
-  变化同步到设置页并持久化，重新建窗恢复保存比例。
+- 原生 Electron 缩放默认 100%，设置页与快捷键共用 Chrome 桌面档位：25、33、50、67、75、80、90、
+  100、110、125、150、175、200、250、300、400、500%。每次按方向进入相邻档位，到达首尾后停止；
+  33% 和 67% 分别以精确的 1/3、2/3 倍率渲染，来源为 [Chromium 缩放常量](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/blink/common/page/page_zoom.cc)。
+  已有 10–500% 非预设保存值继续显示和恢复，不重置其他外观偏好；下一次快捷键选择该方向最近的
+  档位，没有候选时保持当前值。变化同步到设置页并持久化，重新建窗恢复相同实际倍率。
 - 减少动态效果默认跟随系统；始终减少同时覆盖 CSS 动效、程序化平滑滚动和地图运动。
   设置不隐藏状态、进度或动作结果，也不改变 Runtime 执行。
 

--- a/scripts/fixtures/settings-workspace/main.cjs
+++ b/scripts/fixtures/settings-workspace/main.cjs
@@ -115,10 +115,10 @@ app.whenReady().then(async () => {
     assert.equal(await run("document.querySelector('.general-save-row button').disabled"), true)
 
     await navigate('appearance')
-    assert.deepEqual(await run("[...document.querySelector('#appearance-zoom').options].map(o=>Number(o.value))"), [80,90,100,110,125,150,175,200])
+    assert.deepEqual(await run("[...document.querySelector('#appearance-zoom').options].map(o=>Number(o.value))"), [25,33,50,67,75,80,90,100,110,125,150,175,200,250,300,400,500])
     assert.equal(await run("document.querySelectorAll('.motion-example').length"), 0)
-    await run('window.settingsTest.resetZoom(250)'); await settle()
-    assert.equal(await run("document.querySelector('#appearance-zoom').value"), '250')
+    await run('window.settingsTest.resetZoom(121)'); await settle()
+    assert.equal(await run("document.querySelector('#appearance-zoom').value"), '121')
     await navigate('notifications')
     assert.equal(await run("document.querySelectorAll('input[role=switch]').length"), 5)
 


### PR DESCRIPTION
快捷键此前固定增减 10 个百分点，与设置页的缩放档位不一致。例如从 200% 放大得到 210%，现在设置页和快捷键共用 Chrome 桌面的 17 个预设档位（25%–500%），这一步会进入 250%。

33% 和 67% 分别使用精确的 1/3、2/3 倍率，保存、重新建窗和失败恢复共用同一转换。保留历史非预设保存值及其他外观偏好；下一次快捷键进入对应方向的相邻档位，`CommandOrControl 0` 恢复 100%。同步更新既有测试、设置页验收夹具和 UI 规范。

验证：

- `pnpm typecheck`
- `pnpm test`：Vitest 1,798 项通过；其余脚本测试无失败。
- `pnpm build:desktop`
- `DOCS_BASE_REF=24c12a035f1ca38893b5efac56623fd778864842 pnpm docs:check:ci`
- 隔离 Electron 实测：17 档双向按键、实际倍率、设置同步、保存与重新建窗，以及历史非预设比例恢复。
- PR 分支的生产设置页夹具：完整档位列表、自定义值、键盘控制、双主题及缩放布局通过；使用临时 userData，不启动 Core 或 Runtime。
- `pnpm test:rust:staged`：无 Rust/Cargo 改动，按仓库路由跳过。
