### PR TITLE
fix: unwrap PowerShell paths in execution command previews

### DIFF
--- a/apps/desktop/src/shared/execution-presentation/index.ts
+++ b/apps/desktop/src/shared/execution-presentation/index.ts
@@ -1380,6 +1380,7 @@ function shouldDeferUnresolvedShellActivity(
 }
 
 const SHELL_WRAPPER_EXECUTABLES = new Set(['bash', 'dash', 'fish', 'ksh', 'sh', 'zsh'])
+const POWERSHELL_WRAPPER_EXECUTABLES = new Set(['powershell', 'powershell.exe', 'pwsh', 'pwsh.exe'])
 type ShellPreviewToken = {
   raw: string
   value: string
@@ -1419,9 +1420,16 @@ function unwrapShellCommand(command: string): string {
     const tokens = tokenizeShellPreview(current)
     if (tokens.some((token) => token.operator) || tokens.length < 3) break
     const executable = shellExecutable(tokens[0].value)
-    if (!executable || !SHELL_WRAPPER_EXECUTABLES.has(executable)) break
+    // The POSIX tokenizer consumes single Windows backslashes; retain the raw path
+    // when recognizing a quoted PowerShell executable.
+    const rawExecutable = shellExecutable(tokens[0].raw.replace(/^(['"])(.*)\1$/u, '$2'))
+    const powershell = POWERSHELL_WRAPPER_EXECUTABLES.has(executable ?? '')
+      || POWERSHELL_WRAPPER_EXECUTABLES.has(rawExecutable ?? '')
+    if (!powershell && (!executable || !SHELL_WRAPPER_EXECUTABLES.has(executable))) break
     const commandIndex = tokens.findIndex((token, index) =>
-      index > 0 && (token.value === '-c' || token.value === '-lc')
+      index > 0 && (powershell
+        ? ['-c', '-command'].includes(token.value.toLowerCase())
+        : token.value === '-c' || token.value === '-lc')
     )
     if (commandIndex < 0 || commandIndex + 2 !== tokens.length) break
     current = tokens[commandIndex + 1].value.trim()

--- a/apps/desktop/src/shared/execution-presentation/shell-command-preview.test.ts
+++ b/apps/desktop/src/shared/execution-presentation/shell-command-preview.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import type { CanonicalRuntimeActivityView } from '@contracts'
+import { executionActivityTitle, executionEvidenceResultText } from './index'
+
+const shell: CanonicalRuntimeActivityView = {
+  operationId: 'powershell-command', classifierVersion: 'test', activityDomain: 'shell',
+  semanticKind: 'shell.execute', toolName: 'exec_command', presentationHint: '执行 Shell 命令',
+  phase: 'terminal', outcome: 'succeeded', credibility: 'provider_reported',
+  coverageLevel: 'fine_grained', sourceAuthority: 'runtime', sourceEvidenceIds: [],
+  firstEvidenceSequence: 1, lastEvidenceSequence: 2, revision: 1
+}
+
+const command = 'cargo fmt --all -- --check; cargo check -p rovai-core'
+const displayed = 'cargo fmt --all -- --check ; cargo check -p rovai-core'
+const runtimePath = String.raw`C:\Users\test\.cache\codex-runtimes\codex-primary-runtime\dependencies\native\powershell\pwsh.exe`
+
+describe('PowerShell command presentation', () => {
+  it.each([
+    `"${runtimePath}" -Command '${command}'`,
+    `"${runtimePath.replaceAll('\\', '\\\\')}" -Command '${command}'`,
+    `"C:\\Program Files\\PowerShell\\7\\pwsh.exe" -NoLogo -NoProfile -Command '${command}'`,
+    `powershell.exe -COMMAND '${command}'`,
+    `powershell -c '${command}'`,
+    `pwsh -command '${command}'`,
+    `pwsh.exe -C '${command}'`
+  ])('shows the command without the PowerShell wrapper: %s', (wrapped) => {
+    const payload = { item: {
+      type: 'commandExecution', command: wrapped,
+      commandActions: [{ type: 'unknown' }], aggregatedOutput: 'checks passed'
+    } }
+    expect(executionActivityTitle(shell, payload)).toBe(displayed)
+    expect(executionEvidenceResultText('activity.completed', payload)).toBe(`$ ${displayed}\nchecks passed`)
+    expect(executionActivityTitle(shell, { input: { command: wrapped } })).toBe(displayed)
+  })
+
+  it.each([
+    `pwsh -File script.ps1`,
+    `pwsh -EncodedCommand Z2l0IHN0YXR1cw==`,
+    `custom.exe -Command 'git status'`,
+    `pwsh -Command 'git status' && git diff`,
+    `pwsh -Command 'git status' extra`
+  ])('preserves commands outside the bounded wrapper shape: %s', (wrapped) => {
+    expect(executionActivityTitle(shell, { item: { command: wrapped } })).toBe(wrapped)
+  })
+})


### PR DESCRIPTION
PowerShell commands reported as `"C:\…\powershell\pwsh.exe" -Command 'cargo …'` retain the entire runtime path in execution titles and command details because the wrapper parser recognizes only POSIX shells.

Add `powershell`, `powershell.exe`, `pwsh`, and `pwsh.exe` to bounded wrapper recognition, handle `-Command`/`-c` case-insensitively, and use the raw executable token when POSIX tokenization consumes Windows path separators. Existing POSIX handling, unsupported invocation forms, and outer compound commands remain unchanged.

Validation:

- 12 presentation regression cases pass; 7 relevant cases failed before the fix.
- Replayed 260 PowerShell evidence rows from the reported Camp: no runtime wrapper remains in titles/details.
- TypeScript, desktop production build, Windows x64 release Core/CLI build, and packaged-wrapper checks pass.
- GitHub `CI / gate` passes, including TypeScript, full Vitest, and diff-aware documentation governance.
- NSIS package verification passes: PE architecture/resources, updater metadata, installer hashes, CLI contract, and Core health using an isolated data root.

Local Windows baseline limitations: full Vitest has 1,776 passed, 14 failed, and 16 skipped. All 14 failures reproduce with the production change removed on base `7c313a2b` (symlink permissions, external-path expectations, and evaluation-host fixtures). Separate Node-script checks also encounter platform-specific failures. The full Rust attempt encountered Windows private-ACL errors and prolonged database fixtures and was stopped; Clippy reports existing unused-mut/dead-code errors in unchanged Rust files. No unrelated test or policy changes are included.