### PR TITLE
fix(onboarding): restore Pi to the shared runtime order

### DIFF
--- a/apps/desktop/src/renderer/src/OnboardingFlow.test.ts
+++ b/apps/desktop/src/renderer/src/OnboardingFlow.test.ts
@@ -103,10 +103,12 @@ describe('first-run onboarding flow', () => {
     )
     const markup = renderOnboarding(snapshot('runtime'), 'ready', health, [codexInstallation()])
     const [visible, collapsed] = markup.split('<details class="onboarding-other-runtimes">')
+    expect(visible).toContain('GitHub Copilot')
     expect(visible).toContain('Qwen Code')
     expect(visible).toContain('Kimi Code')
-    expect(collapsed).toContain('GitHub Copilot')
+    expect(collapsed).toContain('Pi Coding Agent')
     expect(collapsed).toContain('Antigravity')
+    expect(collapsed.indexOf('Pi Coding Agent')).toBeGreaterThan(collapsed.indexOf('Antigravity'))
     expect(collapsed.split('</details>')[0]).not.toContain('aria-disabled="false"')
   })
 

--- a/apps/desktop/src/renderer/src/OnboardingFlow.tsx
+++ b/apps/desktop/src/renderer/src/OnboardingFlow.tsx
@@ -20,6 +20,7 @@ import {
 } from './MemberRuntimeParameters'
 import { MemberPortrait } from './MemberPortrait'
 import { BUILTIN_MEMBER_PRESETS, type BuiltinMemberPreset } from './member-presets'
+import { VISIBLE_PRODUCT_RUNTIMES } from './runtime-products'
 import {
   runtimeAvailabilityPresentation,
   runtimePlatformAdmissionAllowsUse,
@@ -51,22 +52,7 @@ export type OnboardingRuntimePhase =
   | 'ready'
   | 'error'
 
-export const ONBOARDING_PRODUCT_RUNTIMES: readonly AdapterKind[] = [
-  'claude-code-cli',
-  'pi',
-  'codex-cli',
-  'copilot-cli',
-  'opencode-cli',
-  'kiro-cli',
-  'qoder-cli',
-  'codebuddy-cli',
-  'qwen-code',
-  'trae-cn-cli',
-  'kimi-code-cli',
-  'grok-build',
-  'zcode-app',
-  'antigravity-app'
-]
+export const ONBOARDING_PRODUCT_RUNTIMES: readonly AdapterKind[] = VISIBLE_PRODUCT_RUNTIMES
 
 const RUNTIME_LOGOS: Record<AdapterKind, string> = {
   'claude-code-cli': claudeCodeLogo,


### PR DESCRIPTION
新手引导维护的独立运行时列表把 Pi 排在 Codex 前面，并挤掉默认直接展示的 GitHub Copilot。现在复用 `VISIBLE_PRODUCT_RUNTIMES`，让 Pi 回到目录末尾（Antigravity 之后），默认前三项恢复为 Claude Code、Codex CLI、GitHub Copilot。可用、已选和实验性运行时仍按现有规则直接展示；安装引导同步使用统一顺序。

更新现有折叠列表测试，验证 Copilot 直接可见、未可用的 Pi 位于 Antigravity 之后。

验证：
- `pnpm typecheck` 通过。
- OnboardingFlow、onboarding-provisioning、MemberRuntimeParameters：41/41 通过。
- `pnpm build:desktop` 通过。
- 本机全量 Vitest 的其他模块有 14 项 Windows 失败，涉及 symlink 权限、临时路径展示及子进程目录占用；本次未修改这些模块。以 PR 的 Ubuntu CI gate 验证全量测试。
- 未启动真实 Runtime 或安装日常 App。